### PR TITLE
removed the utf8 conversion in the wikicorpus parsing

### DIFF
--- a/src/gensim/corpora/wikicorpus.py
+++ b/src/gensim/corpora/wikicorpus.py
@@ -72,8 +72,7 @@ def filterWiki(raw):
     """
     # parsing of the wiki markup is not perfect, but sufficient for our purposes
     # contributions to improving this code are welcome :)
-    text = utils.decode_htmlentities(unicode(raw, 'utf8', 'ignore'))
-    text = utils.decode_htmlentities(text) # '&amp;nbsp;' --> '\xa0'
+    text = utils.decode_htmlentities(raw) # '&amp;nbsp;' --> '\xa0'
     text = re.sub(RE_P2, "", text) # remove the last list (=languages)
     # the wiki markup is recursive (markup inside markup etc)
     # instead of writing a recursive grammar, here we deal with that by removing


### PR DESCRIPTION
I had problems when I already had utf8 strings and I think this 
should be done outside of the corpus
