### PR TITLE
bugfix: len(SimilarityABC) should not break when corpus is merely an iterable

### DIFF
--- a/src/gensim/interfaces.py
+++ b/src/gensim/interfaces.py
@@ -251,6 +251,6 @@ class SimilarityABC(utils.SaveLoad):
 
 
     def __len__(self):
-        return self.corpus.shape[0]
+        return len(self.corpus)
 #endclass SimilarityABC
 


### PR DESCRIPTION
bugfix: len(SimilarityABC) should not break when corpus is merely an iterable

The only requirements of a corpus is that is iterable.  Hence the
attribute shape may not exist.
