### PR TITLE
Fix len() on [Sparse]MatrixSimilarity objects initialized without corpus

### DIFF
--- a/gensim/similarities/docsim.py
+++ b/gensim/similarities/docsim.py
@@ -349,8 +349,10 @@ class MatrixSimilarity(interfaces.SimilarityABC):
 
 
     def __len__(self):
-        return self.index.shape[0]
-
+        try:
+            return self.index.shape[0]
+        except AttributeError:
+            return 0
 
     def get_similarities(self, query):
         """
@@ -457,7 +459,10 @@ class SparseMatrixSimilarity(interfaces.SimilarityABC):
 
 
     def __len__(self):
-        return self.index.shape[0]
+        try:
+            return self.index.shape[0]
+        except AttributeError:
+            return 0
 
 
     def get_similarities(self, query):


### PR DESCRIPTION
The constructor of [Sparse]MatrixSimilarity allows creating objects without specifying a corpus.
however, calling len() on these objects will abort with an AttributeError, this patch fixes that
