### PR TITLE
fix the module import when linking to the git root instead of module

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
 # script by dedan: helps him to symlink gensim
 import os
-modules_path = os.path.join('site-packages', 'gensim', 'gensim')
-__path__.append(os.path.join(os.path.dirname(os.__file__), modules_path))
+dirname = __path__[0]		# Package's main folder
+__path__.insert(0, os.path.join(dirname, "gensim"))


### PR DESCRIPTION
for some application I need to link to the gensim folder which is also the root of the repository. This script helps python to find the actual sourcecode of the module and had to be changed because radim moved the source within the repo
