### PR TITLE
Fix easy_install instructions for Pyro to Pyro4

### DIFF
--- a/docs/_sources/install.txt
+++ b/docs/_sources/install.txt
@@ -56,7 +56,7 @@ If you don't know what distributed computing means, you can ignore it:
 `gensim` will work fine for you anyway.
 This optional extension can also be installed separately later with::
 
-    sudo easy_install Pyro
+    sudo easy_install Pyro4
 
 -----
 


### PR DESCRIPTION
Small typo in the docs. I think you want to point people to install Pyro4, judging by your setup.py.
