### PR TITLE
Added option for tf-length-normalization to models.TfidfModel

### DIFF
--- a/gensim/models/tfidfmodel.py
+++ b/gensim/models/tfidfmodel.py
@@ -122,7 +122,7 @@ class TfidfModel(interfaces.TransformationABC):
             return self._apply(bow)
 
         if self.normalize_tf:
-            doc_length = sum([tf for _, tf in bow])
+            doc_length = sum(tf for _, tf in bow)
             bow = [(termid, float(tf)/doc_length) for termid, tf in bow]
 
         # unknown (new) terms will be given zero weight (NOT infinity/huge weight,


### PR DESCRIPTION
See the discussion in the mailing list: http://groups.google.com/group/gensim/browse_thread/thread/11e19beedd70470c

This implementation calculates the document length (not geometric length!) for each vector and applies the following division to each of the vector's components: `tf / document_length`.

This is done before tf is multiplied with idf.
