### PR TITLE
Proper XML parser for Wikipedia dumps

### DIFF
--- a/gensim/corpora/wikicorpus.py
+++ b/gensim/corpora/wikicorpus.py
@@ -7,46 +7,28 @@
 
 
 """
-USAGE: %(program)s WIKI_XML_DUMP OUTPUT_PREFIX [VOCABULARY_SIZE]
+Construct a corpus from a Wikipedia (or other MediaWiki-based) database dump.
 
-    Convert articles from a Wikipedia dump to (sparse) vectors. The input is a bz2-compressed \
-dump of Wikipedia articles, in XML format.
+If you have the `pattern` package installed, this module will use a fancy
+lemmatization to get a lemma of each token (instead of plain alphabetic
+tokenizer). The package is available at https://github.com/clips/pattern .
 
-This actually creates three files:
-
-* `OUTPUT_PREFIX_wordids.txt`: mapping between words and their integer ids
-* `OUTPUT_PREFIX_bow.mm`: bag-of-words (word counts) representation, in Matrix Matrix format
-* `OUTPUT_PREFIX_tfidf.mm`: TF-IDF representation
-
-The output Matrix Market files can then be compressed (e.g., by bzip2) to save \
-disk space; gensim's corpus iterators can work with compressed input, too.
-
-`VOCABULARY_SIZE` controls how many of the most frequent words to keep (after
-removing tokens that appear in more than 10%% of all documents). Defaults to 50,000.
-
-If you have the `pattern` package installed, this script will use a fancy lemmatization
-to get a lemma of each token (instead of plain alphabetic tokenizer). The package is available at
-https://github.com/clips/pattern .
-
-Example: ./wikicorpus.py ~/gensim/results/enwiki-latest-pages-articles.xml.bz2 ~/gensim/results/wiki_en
+See scripts/make_wikicorpus.py for a canned (example) script based on this
+module.
 """
 
 
-import logging
-import itertools
-import sys
-import os.path
-import re
 import bz2
+import logging
+import re
 # LXML isn't faster, so let's go with the built-in solution.
 from xml.etree.cElementTree import iterparse
 
-from gensim import interfaces, matutils, utils
+from gensim import utils
 
 # cannot import whole gensim.corpora, because that imports wikicorpus...
 from gensim.corpora.dictionary import Dictionary
 from gensim.corpora.textcorpus import TextCorpus
-from gensim.corpora.mmcorpus import MmCorpus
 
 logger = logging.getLogger('gensim.corpora.wikicorpus')
 
@@ -260,6 +242,8 @@ class WikiCorpus(TextCorpus):
         appear in at least `noBelow` documents are kept).
         """
         self.fname = fname
+        if keep_words is None:
+            keep_words = DEFAULT_DICT_SIZE
         if dictionary is None:
             self.dictionary = Dictionary(self.get_texts())
             self.dictionary.filter_extremes(no_below=no_below, no_above=0.1, keep_n=keep_words)
@@ -321,46 +305,3 @@ class WikiCorpus(TextCorpus):
                      (articles, positions, articles_all))
         self.length = articles # cache corpus length
 #endclass WikiCorpus
-
-
-
-if __name__ == '__main__':
-    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s')
-    logging.root.setLevel(level=logging.INFO)
-    logger.info("running %s" % ' '.join(sys.argv))
-
-    program = os.path.basename(sys.argv[0])
-
-    # check and process input arguments
-    if len(sys.argv) < 3:
-        print globals()['__doc__'] % locals()
-        sys.exit(1)
-    input, output = sys.argv[1:3]
-    if len(sys.argv) > 3:
-        keep_words = int(sys.argv[3])
-    else:
-        keep_words = DEFAULT_DICT_SIZE
-
-    # build dictionary. only keep 100k most frequent words (out of total ~8.2m unique tokens)
-    # takes about 9h on a macbook pro, for 3.5m articles (june 2011 wiki dump)
-    wiki = WikiCorpus(input, keep_words=keep_words)
-    # save dictionary and bag-of-words (term-document frequency matrix)
-    # another ~9h
-    wiki.dictionary.save_as_text(output + '_wordids.txt')
-    MmCorpus.serialize(output + '_bow.mm', wiki, progress_cnt=10000)
-    del wiki
-
-    # initialize corpus reader and word->id mapping
-    id2token = Dictionary.load_from_text(output + '_wordids.txt')
-    mm = MmCorpus(output + '_bow.mm')
-
-    # build tfidf,
-    # ~30min
-    from gensim.models import TfidfModel
-    tfidf = TfidfModel(mm, id2word=id2token, normalize=True)
-
-    # save tfidf vectors in matrix market format
-    # ~2h; result file is 15GB! bzip2'ed down to 4.5GB
-    MmCorpus.serialize(output + '_tfidf.mm', tfidf[mm], progress_cnt=10000)
-
-    logger.info("finished running %s" % program)

--- a/scripts/make_wikicorpus.py
+++ b/scripts/make_wikicorpus.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2010 Radim Rehurek <radimrehurek@seznam.cz>
+# Copyright (C) 2012 Lars Buitinck <larsmans@gmail.com>
+# Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
+
+
+"""
+USAGE: %(program)s WIKI_XML_DUMP OUTPUT_PREFIX [VOCABULARY_SIZE]
+
+Convert articles from a Wikipedia dump to (sparse) vectors. The input is a
+bz2-compressed dump of Wikipedia articles, in XML format.
+
+This actually creates three files:
+
+* `OUTPUT_PREFIX_wordids.txt`: mapping between words and their integer ids
+* `OUTPUT_PREFIX_bow.mm`: bag-of-words (word counts) representation, in
+  Matrix Matrix format
+* `OUTPUT_PREFIX_tfidf.mm`: TF-IDF representation
+
+The output Matrix Market files can then be compressed (e.g., by bzip2) to save
+disk space; gensim's corpus iterators can work with compressed input, too.
+
+`VOCABULARY_SIZE` controls how many of the most frequent words to keep (after
+removing tokens that appear in more than 10%% of all documents). Defaults to
+50,000.
+
+If you have the `pattern` package installed, this script will use a fancy
+lemmatization to get a lemma of each token (instead of plain alphabetic
+tokenizer). The package is available at https://github.com/clips/pattern .
+
+Example: %(program) ~/gensim/results/enwiki-latest-pages-articles.xml.bz3 ~/gensim/results/wiki_en
+"""
+
+
+import logging
+import os.path
+import sys
+
+from gensim.corpora import Dictionary, MmCorpus, WikiCorpus
+from gensim.models import TfidfModel
+
+
+# Wiki is first scanned for all distinct word types (~7M). The types that
+# appear in more than 10% of articles are removed and from the rest, the
+# DEFAULT_DICT_SIZE most frequent types are kept.
+DEFAULT_DICT_SIZE = 50000
+
+
+program = os.path.basename(sys.argv[0])
+logger = logging.getLogger(program)
+
+logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s')
+logging.root.setLevel(level=logging.INFO)
+logger.info("running %s" % ' '.join(sys.argv))
+
+
+# check and process input arguments
+if len(sys.argv) < 3:
+    print __doc__ % locals()
+    print globals()['__doc__'] % locals()
+    sys.exit(1)
+inp, outp = sys.argv[1:3]
+if len(sys.argv) > 3:
+    keep_words = int(sys.argv[3])
+else:
+    keep_words = DEFAULT_DICT_SIZE
+
+# build dictionary. only keep 100k most frequent words (out of total ~8.2m
+# unique tokens) takes about 9h on a macbook pro, for 3.5m articles (june 2011)
+wiki = WikiCorpus(inp, keep_words=keep_words)
+# save dictionary and bag-of-words (term-document frequency matrix)
+# another ~9h
+wiki.dictionary.save_as_text(outp + '_wordids.txt')
+MmCorpus.serialize(outp + '_bow.mm', wiki, progress_cnt=10000)
+del wiki
+
+# initialize corpus reader and word->id mapping
+id2token = Dictionary.load_from_text(outp + '_wordids.txt')
+mm = MmCorpus(outp + '_bow.mm')
+
+# build tfidf,
+# ~30min
+tfidf = TfidfModel(mm, id2word=id2token, normalize=True)
+
+# save tfidf vectors in matrix market format
+# ~2h; result file is 15GB! bzip2'ed down to 4.5GB
+MmCorpus.serialize(outp + '_tfidf.mm', tfidf[mm], progress_cnt=10000)
+
+logger.info("finished running %s" % program)


### PR DESCRIPTION
I've reworked the Wikipedia dump parser in `gensim.corpora.wikicorpus` to use a proper XML parser, instead of the line-oriented parser used now. Experiments on smaller versions of Wikipedia, such as the Norwegian one, show that parsing speed is roughly unchanged.

The main benefit of this approach is that articles can be pruned earlier, e.g. based on the title or the namespace (a user may want to consider only articles from the main namespace, with titles not matching `^List of`, etc.). Also, error handling is improved as the parser checks whether what it gets is XML, and looks like a MediaWiki dump. I think there is also some more room for optimization.

Please let me know what you think.
