### PR TITLE
Update gensim/corpora/dictionary.py

### DIFF
--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -242,6 +242,7 @@ class Dictionary(utils.SaveLoad, UserDict.DictMixin):
                 wordid = int(wordid)
                 result.token2id[word] = wordid
                 result.dfs[wordid] = int(docfreq)
+        result.num_docs = len(result.dfs)
         return result
 
 


### PR DESCRIPTION
Line245: Quick fix added to refresh the num_docs attribute which is used in filter_extremes. Not setting this causes all docs to be filtered out.
