### PR TITLE
Update rpmodel.py --> "scipy.linalg.blas.fblas" has been replaced by "scipy.linalg.blas"

### DIFF
--- a/gensim/models/rpmodel.py
+++ b/gensim/models/rpmodel.py
@@ -83,7 +83,7 @@ class RpModel(interfaces.TransformationABC):
 
         vec = matutils.sparse2full(bow, self.num_terms).reshape(self.num_terms, 1) / numpy.sqrt(self.num_topics)
         vec = numpy.asfortranarray(vec, dtype=numpy.float32)
-        topic_dist = scipy.linalg.fblas.sgemv(1.0, self.projection, vec)  # (k, d) * (d, 1) = (k, 1)
+        topic_dist = scipy.linalg.blas.sgemv(1.0, self.projection, vec)  # (k, d) * (d, 1) = (k, 1)
         return [(topicid, float(topicvalue)) for topicid, topicvalue in enumerate(topic_dist.flat)
                 if numpy.isfinite(topicvalue) and not numpy.allclose(topicvalue, 0.0)]
 


### PR DESCRIPTION
"scipy.linalg.blas.fblas" has been replaced by "scipy.linalg.blas"

Fixes the following error when running the rpmodel.py:
ERROR: AttributeError: 'module' object has no attribute 'fblas'

Others have experience this error: https://github.com/Theano/Theano/issues/1144

Changing as shown in the above in the .py and recompiling the .pyc worked for me!

Thanks for a great package!

Andrew
