### PR TITLE
Raise a KeyError if tokens are non-unique in a dictionary when loaded fr...

### DIFF
--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -243,7 +243,7 @@ class Dictionary(utils.SaveLoad, UserDict.DictMixin):
                                      % (fname, line.strip()))
                 wordid = int(wordid)
                 if word in result.token2id:
-                    raise KeyError('token %s is defined as ID %d and as ID %d' % (word,wordid,result.token2id[word]))
+                    raise KeyError('token %s is defined as ID %d and as ID %d' % (word, wordid, result.token2id[word]))
                 result.token2id[word] = wordid
                 result.dfs[wordid] = int(docfreq)
         return result


### PR DESCRIPTION
From a discussion on Google Groups.  Raise a KeyError if non-unique tokens are encountered when loading a Dictionary from a text file.
