### PR TITLE
Add two methods to Word2Vec for word-word similarity

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -38,7 +38,7 @@ from numpy import zeros_like, empty, exp, dot, outer, random, dtype, get_include
     float32 as REAL, uint32, seterr, array, uint8, vstack, argsort, fromstring
 
 from numpy.linalg import norm
-	
+    
 logger = logging.getLogger("gensim.models.word2vec")
 
 
@@ -360,43 +360,43 @@ class Word2Vec(utils.SaveLoad):
         dists = dot(vectors, mean)
         return sorted(zip(dists, words))[0][1]
 
-	def get_vector_representation(self, word):
-		"""
-		Find the word representations in vector space.
+    def get_vector_representation(self, word):
+        """
+        Find the word representations in vector space.
 
-		This method return a numpy word vector representation.
+        This method return a numpy word vector representation.
 
-		Example::
+        Example::
 
-		  >>> trained_model.get_vector_representation('woman')
-		  array([ -1.40128313e-02, ...] 
+          >>> trained_model.get_vector_representation('woman')
+          array([ -1.40128313e-02, ...] 
 
-		"""
-		return self.syn0[self.vocab[word].index]
+        """
+        return self.syn0[self.vocab[word].index]
 
-	def cosine_similarity(self, w1, w2):
-		"""
-		Compute the a similarity measure between two words.
+    def cosine_similarity(self, w1, w2):
+        """
+        Compute the a similarity measure between two words.
 
-		This method computes cosine similarity between two given words.
+        This method computes cosine similarity between two given words.
 
-		Example::
+        Example::
 
-		  >>> trained_model.cosine_similarity('woman', 'man')
-		  0.73723527
-		  
-		  >>> trained_model.cosine_similarity('woman', 'woman')
-		  1.0
+          >>> trained_model.cosine_similarity('woman', 'man')
+          0.73723527
+          
+          >>> trained_model.cosine_similarity('woman', 'woman')
+          1.0
 
-		"""
-		v1 = self.get_vector_representation(w1)
-		v2 = self.get_vector_representation(w2)
-		n = norm(v1) * norm(v2)
-		
-		if (n == 0.0):
-			return 0.0
-		
-		return dot(v1, v2) / n	
+        """
+        v1 = self.get_vector_representation(w1)
+        v2 = self.get_vector_representation(w2)
+        n = norm(v1) * norm(v2)
+        
+        if (n == 0.0):
+            return 0.0
+        
+        return dot(v1, v2) / n    
 
     def init_sims(self):
         if getattr(self, 'syn0norm', None) is None:


### PR DESCRIPTION
The first method returns the vector space representation of a word. It's a common task and not totally obvious unless you dig into the code source. The second method performs word-word similarity by computing the cosine distance between the representations of the given words.
