### PR TITLE
Fixing example code overflow in documentation

### DIFF
--- a/docs/src/_static/css/style.css
+++ b/docs/src/_static/css/style.css
@@ -732,6 +732,7 @@ pre {
     border: 1px solid #ccc;
     background-color: #f8f8f8;
     line-height: 120%;
+    overflow-x: auto;
 }
 
 tt {


### PR DESCRIPTION
This tiny change should improve the display of [pages like this](http://radimrehurek.com/gensim/dist_lda.html) in the documentation. Right now, the long lines of code overflow their boundaries and this keeps them contained and adds a scroll bar to the offending block.
