### PR TITLE
eat newline when present in binary dfformat

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -348,6 +348,8 @@ class Word2Vec(utils.SaveLoad):
                     word = []
                     while True:
                         ch = fin.read(1)
+                        if ch == '\n':
+                            continue
                         if ch == ' ':
                             word = ''.join(word)
                             break


### PR DESCRIPTION
fixes issue with binary models. Some models have a newline after the word vectors, some do not. 

From the hexdump analysis on an older trained file (from a few weeks ago)

1b bd 0a 73 65 76 65 6e  20 81 29 06 be 69 52 60  |...seven .)..iR`

notice that before the new word there is indeed a newline (bold), yet in the freebase model 

00001f70  00 00 cc 3c 2f 65 6e 2f  62 61 72 61 63 6b 5f 6f  |...</en/barack_o|

there is no newline, the 2f is / - the first character of the new word. I looked at distance.c and the line

```
fscanf(f, "%s%c", &vocab[b * max_w], &ch);
```

fscanf (used in the word2vec c code) ignores leading and training whitespace, emulating this behavior in python fixes this issue.
