### PR TITLE
remove newline read

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -357,7 +357,7 @@ class Word2Vec(utils.SaveLoad):
                     result.vocab[word] = Vocab(index=line_no, count=vocab_size - line_no)
                     result.index2word.append(word)
                     result.syn0[line_no] = fromstring(fin.read(binary_len), dtype=REAL)
-                    fin.read(1)  # newline
+                    #fin.read(1)  # newline
             else:
                 for line_no, line in enumerate(fin):
                     parts = line.split()


### PR DESCRIPTION
fin.read is nolonger required and prevents the first character of a new style model from being read 
