### PR TITLE
fix to using eval_every=None and separate update

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -501,7 +501,10 @@ class LdaModel(interfaces.TransformationABC):
         if update_every > 0:
             updatetype = "online"
             updateafter = min(lencorpus, update_every * self.numworkers * chunksize)
-            evalafter = min(lencorpus, eval_every * self.numworkers * chunksize)
+            if eval_every is not None:
+                evalafter = min(lencorpus, eval_every * self.numworkers * chunksize)
+            else:
+                evalafter = lencorpus
         else:
             updatetype = "batch"
             updateafter = lencorpus


### PR DESCRIPTION
This is a fix to a tiny bug - with the corpus specified in "update" and no perplexity calculation, the  eval_every \* self.numworkers \* chunksize is multiplying an integer with 'None' and crashing.
