### PR TITLE
Adding norm_only parameter to load_word2vec_format

### DIFF
--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -56,6 +56,17 @@ class TestWord2VecModel(unittest.TestCase):
         model.save(testfile())
         self.models_equal(model, word2vec.Word2Vec.load(testfile()))
 
+    def testPersistenceWord2VecFormat(self):
+        """Test storing/loading the entire model in word2vec format."""
+        model = word2vec.Word2Vec(sentences, min_count=1)
+        model.init_sims()
+        model.save_word2vec_format(testfile(), binary=True)
+        binary_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, norm_only=False)
+        self.assertTrue(numpy.allclose(model['human'], binary_model['human']))
+        norm_only_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, norm_only=True)
+        self.assertFalse(numpy.allclose(model['human'], norm_only_model['human']))
+        self.assertTrue(numpy.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human']))
+
     def testLargeMmap(self):
         """Test storing/loading the entire model."""
         model = word2vec.Word2Vec(sentences, min_count=1)


### PR DESCRIPTION
When set to True, we only keep the normalised
vectors in memory to save space. The normalised
vectors will also be computed in place to save
temporarily allocating large amounts of memory.
