### PR TITLE
closes #167: added __package__ name to run word2vec.py as script

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -72,6 +72,9 @@ from numpy import exp, dot, zeros, outer, random, dtype, get_include, float32 as
 
 logger = logging.getLogger("gensim.models.word2vec")
 
+if __name__ == "__main__" and __package__ is None:
+    import gensim
+    __package__ = "gensim.models" # allows using relative imports when run as a script
 
 from .. import utils, matutils  # utility fnc for pickling, common scipy operations etc
 from .._six import iteritems, itervalues, string_types


### PR DESCRIPTION
Ahoj Radim,

this patch allows to run ``word2vec.py'' as a script while using relative imports.

Čau,
Arne
