### PR TITLE
Filter wikipedia articles by their namespace

### DIFF
--- a/gensim/corpora/wikicorpus.py
+++ b/gensim/corpora/wikicorpus.py
@@ -250,7 +250,7 @@ class WikiCorpus(TextCorpus):
     >>> wiki.saveAsText('wiki_en_vocab200k') # another 8h, creates a file in MatrixMarket format plus file with id->word
 
     """
-    def __init__(self, fname, processes=None, lemmatize=utils.HAS_PATTERN, dictionary=None, filter_namespaces=(0,)):
+    def __init__(self, fname, processes=None, lemmatize=utils.HAS_PATTERN, dictionary=None, filter_namespaces=('0',)):
         """
         Initialize the corpus. Unless a dictionary is provided, this scans the
         corpus once, to determine its vocabulary.


### PR DESCRIPTION
Adds the ability to skip article with certain namespace in Wikipedia. These are Wikipedia entries that are images file, audio files, templates, user profiles, ..., etc. The full list can be found here: http://en.wikipedia.org/wiki/Wikipedia:Namespace .

This commit does not change the currently behavior of the WikiCorpus class, unless the additional filter_namespaces argument is passed to the initializer.

For example,

WikiCorpus( inp, lemmatize=lemmatize, filter_namespaces=('0','2') )

will only include main articles and user profile pages into the corpus, while 

WikiCorpus( inp, lemmatize=lemmatize )

will be the same as the current behavior, using all entries in the Wikipedia dump.
