### PR TITLE
[Word2Vec] Support for reading calculated skip ngrams

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -228,6 +228,7 @@ class Word2Vec(utils.SaveLoad):
         sentence_no, vocab = -1, {}
         total_words = 0
         for sentence_no, sentence in enumerate(sentences):
+            count = 1
             if skip_n_gram:
                 sentence, distance, count = sentence
             if sentence_no % 10000 == 0:
@@ -236,7 +237,7 @@ class Word2Vec(utils.SaveLoad):
             for word in sentence:
                 total_words += 1
                 if word in vocab:
-                    vocab[word].count += 1
+                    vocab[word].count += count
                 else:
                     vocab[word] = Vocab(count=1)
         logger.info("collected %i word types from a corpus of %i words and %i sentences" %
@@ -297,7 +298,7 @@ class Word2Vec(utils.SaveLoad):
                             next_report[0] = elapsed + 1.0  # don't flood the log, wait at least a second between progress reports
             return worker_train
 
-        if self.skip_n_gram:
+        if skip_n_gram:
             workers = [threading.Thread(target=worker_train_factory(train_sentence)) for _ in xrange(self.workers)]
         else:
             workers = [threading.Thread(target=worker_train_factory(train_skip_n_gram)) for _ in xrange(self.workers)]

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -299,9 +299,9 @@ class Word2Vec(utils.SaveLoad):
             return worker_train
 
         if skip_n_gram:
-            workers = [threading.Thread(target=worker_train_factory(train_sentence)) for _ in xrange(self.workers)]
-        else:
             workers = [threading.Thread(target=worker_train_factory(train_skip_n_gram)) for _ in xrange(self.workers)]
+        else:
+            workers = [threading.Thread(target=worker_train_factory(train_sentence)) for _ in xrange(self.workers)]
         for thread in workers:
             thread.daemon = True  # make interrupting the process with ctrl+c easier
             thread.start()

--- a/gensim/models/word2vec_inner.pyx
+++ b/gensim/models/word2vec_inner.pyx
@@ -176,7 +176,7 @@ def train_sentence(model, sentence, alpha, _work):
 
     return result
 
-def train_skip_n_gram(model, sentence, alpha, _work):
+def train_skip_ngram(model, sentence, alpha, _work):
 
     sentence, _distance, _count = sentence
 

--- a/gensim/models/word2vec_inner.pyx
+++ b/gensim/models/word2vec_inner.pyx
@@ -122,6 +122,8 @@ cdef void fast_sentence2(
 
 DEF MAX_SENTENCE_LEN = 1000
 
+
+
 def train_sentence(model, sentence, alpha, _work):
     cdef REAL_t *syn0 = <REAL_t *>(np.PyArray_DATA(model.syn0))
     cdef REAL_t *syn1 = <REAL_t *>(np.PyArray_DATA(model.syn1))
@@ -171,6 +173,50 @@ def train_sentence(model, sentence, alpha, _work):
                 if j == i or codelens[j] == 0:
                     continue
                 fast_sentence(points[i], codes[i], codelens[i], syn0, syn1, size, indexes[j], _alpha, work)
+
+    return result
+
+def train_skip_n_gram(model, sentence, alpha, _work):
+
+    sentence, _distance, _count = sentence
+
+    cdef int distance = _distance
+    cdef int count = _count
+    cdef int reduced_count = int( (model.window - distance + 1.0)*count / model.window )
+
+    cdef REAL_t *syn0 = <REAL_t *>(np.PyArray_DATA(model.syn0))
+    cdef REAL_t *syn1 = <REAL_t *>(np.PyArray_DATA(model.syn1))
+    cdef REAL_t *work
+    cdef REAL_t _alpha = alpha
+    cdef int size = model.layer1_size
+
+    cdef np.uint32_t *points[MAX_SENTENCE_LEN]
+    cdef np.uint8_t *codes[MAX_SENTENCE_LEN]
+    cdef int codelens[MAX_SENTENCE_LEN]
+    cdef np.uint32_t indexes[MAX_SENTENCE_LEN]
+    cdef int sentence_len
+
+    cdef int i, j, k
+    cdef long result = 0
+
+    # convert Python structures to primitive types, so we can release the GIL
+    work = <REAL_t *>np.PyArray_DATA(_work)
+    sentence_len = <int>min(MAX_SENTENCE_LEN, len(sentence))
+    for i in range(sentence_len):
+        word = sentence[i]
+        if word is None:
+            codelens[i] = 0
+        else:
+            indexes[i] = word.index
+            codelens[i] = <int>len(word.code)
+            codes[i] = <np.uint8_t *>np.PyArray_DATA(word.code)
+            points[i] = <np.uint32_t *>np.PyArray_DATA(word.point)
+            result += 1
+
+    # release GIL & train on the sentence
+    with nogil:
+        for i in range(reduced_count):
+            fast_sentence(points[0], codes[0], codelens[0], syn0, syn1, size, indexes[1], _alpha, work)
 
     return result
 


### PR DESCRIPTION
This adds support for training from precompiled skip ngrams, instead of raw text. Each ``sentence" from the corpus reader now consists of the following format ([str:word1, str:word2], int:distance, int:count). This is useful if you are trying to train a word2vec model from a ngram model, for example the Google Web1T dataset. Both the Python and Cython implementations were updated.

New functionalities are controlled by the skip_ngram parameter, with the default value the behavior of existing functionalities should remain the same.

I wasn't sure how to change the matrix manipulation part, so each skip ngrams with counts will update the matrix multiple times. This is likely to be very inefficient, and should be improved in the future.