### PR TITLE
Return topics in the right order

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -674,7 +674,7 @@ class LdaModel(interfaces.TransformationABC):
             sorted_topics = list(numpy.argsort(sort_alpha))
             chosen_topics = sorted_topics[ : topics/2] + sorted_topics[-topics/2 : ]
         shown = []
-        for i in chosen_topics[::-1]:
+        for i in chosen_topics:
             if formatted:
                 topic = self.print_topic(i, topn=topn)
             else:


### PR DESCRIPTION
Passing -1 or n, where n >= num_of_topics to show_topics() should return the topics in the right order. It currently returns the topics in the reverse order which is difficult to reason about.

**Summary**
`lda.show_topics(-1)[0]` should return the same string as `lda.show_topic(0)`

I did not realise this bug until after going crazy for a week! :frowning:  There's probably a better way to solve this problem and I'm happy to update the PR if required.
