### PR TITLE
fix Dictionary for Python 3

### DIFF
--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -17,12 +17,12 @@ with other dictionary (:func:`Dictionary.merge_with`) etc.
 
 from __future__ import with_statement
 
+from collections import Mapping
 import logging
 import itertools
-import UserDict
 
 from gensim import utils
-from gensim._six import iteritems, iterkeys, itervalues, string_types
+from gensim._six import PY3, iteritems, iterkeys, itervalues, string_types
 from gensim._six.moves import xrange
 from gensim._six.moves import zip as izip
 
@@ -30,7 +30,7 @@ from gensim._six.moves import zip as izip
 logger = logging.getLogger('gensim.corpora.dictionary')
 
 
-class Dictionary(utils.SaveLoad, UserDict.DictMixin):
+class Dictionary(utils.SaveLoad, Mapping):
     """
     Dictionary encapsulates the mapping between normalized words and their integer ids.
 
@@ -56,6 +56,21 @@ class Dictionary(utils.SaveLoad, UserDict.DictMixin):
             # recompute id->word accordingly
             self.id2token = dict((v, k) for k, v in iteritems(self.token2id))
         return self.id2token[tokenid] # will throw for non-existent ids
+
+
+    def __iter__(self):
+        return iter(self.keys())
+
+
+    if PY3:
+        # restore Py2-style dict API
+        iterkeys = __iter__
+
+        def iteritems(self):
+            return self.items()
+
+        def itervalues(self):
+            return self.values()
 
 
     def keys(self):

--- a/gensim/test/test_corpora_dictionary.py
+++ b/gensim/test/test_corpora_dictionary.py
@@ -8,6 +8,7 @@ Unit tests for the `corpora.Dictionary` class.
 """
 
 
+from collections import Mapping
 import logging
 import tempfile
 import unittest
@@ -15,6 +16,8 @@ import os
 import os.path
 
 from gensim.corpora import Dictionary
+from gensim._six import PY3
+from gensim._six.moves import zip
 
 
 # sample data files are located in the same folder
@@ -160,6 +163,26 @@ class TestDictionary(unittest.TestCase):
         self.assertEqual(dictionary.num_docs, dictionary_from_corpus.num_docs)
         self.assertEqual(dictionary.num_pos, dictionary_from_corpus.num_pos)
         self.assertEqual(dictionary.num_nnz, dictionary_from_corpus.num_nnz)
+
+    def test_dict_interface(self):
+        """Test Python 2 dict-like interface in both Python 2 and 3."""
+        d = Dictionary(self.texts)
+
+        self.assertTrue(isinstance(d, Mapping))
+
+        self.assertEqual(list(zip(d.keys(), d.values())), list(d.items()))
+
+        # Even in Py3, we want the iter* members.
+        self.assertEqual(list(d.items()), list(d.iteritems()))
+        self.assertEqual(list(d.keys()), list(d.iterkeys()))
+        self.assertEqual(list(d.values()), list(d.itervalues()))
+
+        # XXX Do we want list results from the dict members in Py3 too?
+        if not PY3:
+            self.assertTrue(isinstance(d.items(), list))
+            self.assertTrue(isinstance(d.keys(), list))
+            self.assertTrue(isinstance(d.values(), list))
+
 #endclass TestDictionary
 
 


### PR DESCRIPTION
@piskvorky, I hope this fixes the Dictionary issue. It uses the Mapping mixin rather than inheritance from dict. Open question is whether Dictionary should behave like a Py2 dict even in Py3; currently it doesn't and I think it would break the Py3 Mapping contract to do so.

The new test passes in Py2 and 3.
