### PR TITLE
Fix textcorpus metadata

### DIFF
--- a/gensim/corpora/textcorpus.py
+++ b/gensim/corpora/textcorpus.py
@@ -93,12 +93,14 @@ class TextCorpus(interfaces.CorpusABC):
         # Instead of raising NotImplementedError, let's provide a sample implementation:
         # assume documents are lines in a single file (one document per line).
         # Yield each document as a list of lowercase tokens, via `utils.tokenize`.
-        length = 0
+        self.length = 0
         with self.getstream() as lines:
             for lineno, line in enumerate(lines):
-                length += 1
-                yield utils.tokenize(line, lowercase=True)
-        self.length = length
+                if self.metadata:
+                    yield utils.tokenize(line, lowercase=True), (lineno,)
+                else:
+                    yield utils.tokenize(line, lowercase=True)
+            self.length = lineno + 1
 
 
     def __len__(self):

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -13,7 +13,8 @@ import os.path
 import unittest
 import tempfile
 
-from gensim.corpora import bleicorpus, mmcorpus, lowcorpus, svmlightcorpus, ucicorpus, malletcorpus
+from gensim.corpora import (bleicorpus, mmcorpus, lowcorpus, svmlightcorpus,
+                            ucicorpus, malletcorpus, textcorpus)
 
 
 module_path = os.path.dirname(__file__) # needed because sample data files are located in the same folder
@@ -155,6 +156,31 @@ class TestMalletCorpus(unittest.TestCase, CorpusTesterABC):
             self.assertEqual(metadata[0], str(i + 1))
             self.assertEqual(metadata[1], 'en')
 #endclass TestMalletCorpus
+
+
+class TestTextCorpus(unittest.TestCase):
+
+    def setUp(self):
+        self.corpus_class = textcorpus.TextCorpus
+        self.file_extension = '.txt'
+
+    def test_load_with_metadata(self):
+        fname = datapath('testcorpus.' + self.file_extension.lstrip('.'))
+        corpus = self.corpus_class(fname)
+        corpus.metadata = True
+        docs = list(corpus)
+        self.assertEqual(len(docs), 9) # the deerwester corpus always has nine documents, no matter what format
+        for i, docmeta in enumerate(docs):
+            doc, metadata = docmeta
+
+            self.assertEqual(metadata[0], i)
+
+    def test_load(self):
+        fname = datapath('testcorpus.' + self.file_extension.lstrip('.'))
+        corpus = self.corpus_class(fname)
+        docs = list(corpus)
+        self.assertEqual(len(docs), 9) # the deerwester corpus always has nine documents, no matter what format
+#endclass TestTextCorpus
 
 
 if __name__ == '__main__':

--- a/gensim/test/test_data/testcorpus.txt
+++ b/gensim/test/test_data/testcorpus.txt
@@ -1,0 +1,9 @@
+computer human interface
+computer response survey system time user
+interface system user eps
+human system system eps
+response time user
+trees
+trees graph
+trees graph minors
+survey graph minors


### PR DESCRIPTION
Fixes TextCorpus not having proper metadata info. I've defaulted to returning the line number that a document appears on.
