### PR TITLE
adding the --preserve-case flag to the import-file command

### DIFF
--- a/gensim/models/ldamallet.py
+++ b/gensim/models/ldamallet.py
@@ -139,7 +139,7 @@ class LdaMallet(utils.SaveLoad):
                 fout.write(utils.to_utf8("%s 0 %s\n" % (docno, ' '.join(tokens))))
 
         # convert the text file above into MALLET's internal format
-        cmd = self.mallet_path + " import-file --keep-sequence --remove-stopwords --token-regex '\S+' --input %s --output %s"
+        cmd = self.mallet_path + " import-file --preserve-case --keep-sequence --remove-stopwords --token-regex '\S+' --input %s --output %s"
         if infer:
             cmd += ' --use-pipe-from ' + self.fcorpusmallet()
             cmd = cmd % (self.fcorpustxt(), self.fcorpusmallet() + '.infer')


### PR DESCRIPTION
By default MALLET converts all word features to lowercase, this is not always the desired functionality. This causes a key error when looking up top-words in the corpus dictionary that are capitalized in the corpus object but lowercase in the model object. By adding the --preserve-case flag MALLET won't convert words to lowercase (if they exist). Converting to lowercase should happen _before_ writing the MALLET files when generating the corpus/dictionary objects.
