### PR TITLE
multiplicative objective ('3CosMul') of Levy & Goldberg

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -655,7 +655,7 @@ class Word2Vec(utils.SaveLoad):
         all_words = set()
 
         def word_vec(word):
-            if isinstance(word,ndarray):
+            if isinstance(word, ndarray):
                 return word
             elif word in self.vocab:
                 all_words.add(self.vocab[word].index)
@@ -670,9 +670,9 @@ class Word2Vec(utils.SaveLoad):
 
         # equation (4) of Levy & Goldberg "Linguistic Regularities...",
         # with distances shifted to [0,1] per footnote (7)
-        pos_dists = [((1+dot(self.syn0norm, term))/2) for term in positive]
-        neg_dists = [((1+dot(self.syn0norm, term))/2) for term in negative]
-        dists = prod(pos_dists,axis=0) / (prod(neg_dists,axis=0) + 0.000001)
+        pos_dists = [((1 + dot(self.syn0norm, term)) / 2) for term in positive]
+        neg_dists = [((1 + dot(self.syn0norm, term)) / 2) for term in negative]
+        dists = prod(pos_dists, axis=0) / (prod(neg_dists, axis=0) + 0.000001)
 
         if not topn:
             return dists


### PR DESCRIPTION
`most_similar_cosmul`: ranked words according to the multiplicative objective ('3CosMul') of Levy & Goldberg ("Linguistic Regularities in Sparse and Explicit Word Representations", 2014). May be tested in preference to default `most_similar` by passing as optional `most_similar` argument to `accuracy`, eg:

```
>>> trained_model.accuracy("questions-words.txt",restrict_vocab=300000,most_similar=word2vec.Word2Vec.most_similar_cosmul)
```

With training set similar to that in their paper (recent English Wikipedia full text), the objective gives 3-4 percentage point improvement on question-words.txt analogies task, but at cost of slightly more than 2X slowdown.
