### PR TITLE
Improved Citations in LdaModel

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -341,6 +341,9 @@ class LdaModel(interfaces.TransformationABC):
         to update the model's topic-word distributions, and return a 2-tuple
         `(gamma, sstats)`. Otherwise, return `(gamma, None)`. `gamma` is of shape
         `len(chunk) x self.num_topics`.
+        
+        Avoids computing the `phi` variational parameter directly using the
+        optimization presented in **Lee, Seung: Algorithms for non-negative matrix factorization, NIPS 2001**.
 
         """
         try:
@@ -429,7 +432,7 @@ class LdaModel(interfaces.TransformationABC):
         Update parameters for the Dirichlet prior on the per-document
         topic weights `alpha` given the last `gammat`.
 
-        Uses Newton's method: http://www.stanford.edu/~jhuang11/research/dirichlet/dirichlet.pdf
+        Uses Newton's method, described in **Huang: Maximum Likelihood Estimation of Dirichlet Distribution Parameters.** (http://www.stanford.edu/~jhuang11/research/dirichlet/dirichlet.pdf)
 
         """
         N = float(len(gammat))


### PR DESCRIPTION
Added more detailed information about the papers referenced in the comments of LdaModel, including titles and author names.  

This change effectively:
- Clarifies the reference to the "Lee & Seung trick" in the implementation of `LdaModel.inference`
- Protects the reference to a paper about Dirichlet parameter estimation against a dead link in the future.  No author name or title was previously provided.

Updated references now appear in the docstrings of relevant functions.  It may be useful to add them to the module docstring as well.
