### PR TITLE
Parameterize the downweighting aka Tau_0 in LDA's rho

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -182,7 +182,7 @@ class LdaModel(interfaces.TransformationABC):
     """
     def __init__(self, corpus=None, num_topics=100, id2word=None,
                  distributed=False, chunksize=2000, passes=1, update_every=1,
-                 alpha='symmetric', eta=None, decay=0.5, downweighting=1.0,
+                 alpha='symmetric', eta=None, decay=0.5, offset=1.0,
                  eval_every=10, iterations=50, gamma_threshold=0.001):
         """
         If given, start training from the iterable `corpus` straight away. If not given,
@@ -218,8 +218,8 @@ class LdaModel(interfaces.TransformationABC):
         `eval_every` model updates (setting this to 1 slows down training ~2x;
         default is 10 for better performance). Set to None to disable perplexity estimation.
 
-        `decay` and `downweighting` parameters are the same as Tau_0 and Kappa
-        in Hoffman et al.
+        `decay` and `offset` parameters are the same as Kappa and Tau_0 in
+        Hoffman et al, respectively.
 
         Example:
 
@@ -252,7 +252,7 @@ class LdaModel(interfaces.TransformationABC):
         self.num_topics = int(num_topics)
         self.chunksize = chunksize
         self.decay = decay
-        self.downweighting = downweighting
+        self.offset = offset
         self.num_updates = 0
 
         self.passes = passes
@@ -472,7 +472,7 @@ class LdaModel(interfaces.TransformationABC):
         return perwordbound
 
 
-    def update(self, corpus, chunksize=None, decay=None, downweighting=None,
+    def update(self, corpus, chunksize=None, decay=None, offset=None,
                passes=None, update_every=None, eval_every=None, iterations=None,
                gamma_threshold=None):
         """
@@ -490,7 +490,7 @@ class LdaModel(interfaces.TransformationABC):
         For stationary input (no topic drift in new documents), on the other hand,
         this equals the online update of Hoffman et al. and is guaranteed to
         converge for any `decay` in (0.5, 1.0>. Additionally, for smaller
-        `corpus` sizes, an increasing `downweighting` may be beneficial (see
+        `corpus` sizes, an increasing `offset` may be beneficial (see
         Table 1 in Hoffman et al.)
 
         """
@@ -499,8 +499,8 @@ class LdaModel(interfaces.TransformationABC):
             chunksize = self.chunksize
         if decay is None:
             decay = self.decay
-        if downweighting is None:
-            downweighting = self.downweighting
+        if offset is None:
+            offset = self.offset
         if passes is None:
             passes = self.passes
         if update_every is None:
@@ -513,7 +513,7 @@ class LdaModel(interfaces.TransformationABC):
             gamma_threshold = self.gamma_threshold
 
         # rho is the "speed" of updating; TODO try other fncs
-        rho = lambda: pow(downweighting + self.num_updates / self.chunksize, -decay)
+        rho = lambda: pow(offset + self.num_updates / self.chunksize, -decay)
 
         try:
             lencorpus = len(corpus)

--- a/gensim/models/ldamulticore.py
+++ b/gensim/models/ldamulticore.py
@@ -77,8 +77,9 @@ class LdaMulticore(LdaModel):
 
     """
     def __init__(self, corpus=None, num_topics=100, id2word=None, workers=None,
-                 chunksize=2000, passes=1, batch=False, alpha='symmetric', eta=None, decay=0.5,
-                 eval_every=10, iterations=50, gamma_threshold=0.001):
+                 chunksize=2000, passes=1, batch=False, alpha='symmetric',
+                 eta=None, decay=0.5, offset=1.0, eval_every=10, iterations=50,
+                 gamma_threshold=0.001):
         """
         If given, start training from the iterable `corpus` straight away. If not given,
         the model is left untrained (presumably because you want to call `update()` manually).
@@ -120,6 +121,9 @@ class LdaMulticore(LdaModel):
         `eval_every` documents. Set to `None` to disable perplexity estimation (faster),
         or to `0` to only evaluate perplexity once, at the end of each corpus pass.
 
+        `decay` and `offset` parameters are the same as Kappa and Tau_0 in
+        Hoffman et al, respectively.
+
         Example:
 
         >>> lda = LdaMulticore(corpus, id2word=id2word, num_topics=100)  # train model
@@ -134,7 +138,7 @@ class LdaMulticore(LdaModel):
             raise NotImplementedError("auto-tuning alpha not implemented in multicore LDA; use plain LdaModel.")
         super(LdaMulticore, self).__init__(corpus=corpus, num_topics=num_topics,
             id2word=id2word, chunksize=chunksize, passes=passes, alpha=alpha, eta=eta,
-            decay=decay, eval_every=eval_every, iterations=iterations,
+            decay=decay, offset=offset, eval_every=eval_every, iterations=iterations,
             gamma_threshold=gamma_threshold)
 
 
@@ -157,7 +161,7 @@ class LdaMulticore(LdaModel):
 
         """
         # rho is the "speed" of updating, decelerating over time
-        rho = lambda: pow(1.0 + self.num_updates / self.chunksize, -self.decay)
+        rho = lambda: pow(self.offset + self.num_updates / self.chunksize, -self.decay)
 
         try:
             lencorpus = len(corpus)


### PR DESCRIPTION
Very simple change, just want to make sure I've got the documentation correct! This change corresponds with Table 1 in Hoffman et al.
