### PR TITLE
switch deprecated _pyroOneway to decorator

### DIFF
--- a/docs/src/distributed.rst
+++ b/docs/src/distributed.rst
@@ -36,7 +36,7 @@ Prerequisites
 -----------------
 
 For communication between nodes, `gensim` uses `Pyro (PYthon Remote Objects)
-<http://pypi.python.org/pypi/Pyro4>`_, version >= 4.8. This is a library for low-level socket communication
+<http://pypi.python.org/pypi/Pyro4>`_, version >= 4.27. This is a library for low-level socket communication
 and remote procedure calls (RPC) in Python. `Pyro` is a pure-Python library, so its
 installation is quite painless and only involves copying its `*.py` files somewhere onto your Python's import path::
 

--- a/gensim/models/lda_worker.py
+++ b/gensim/models/lda_worker.py
@@ -24,6 +24,7 @@ try:
     import Queue
 except ImportError:
     import queue as Queue
+import Pyro4
 from gensim.models import ldamodel
 from gensim import utils
 
@@ -50,6 +51,7 @@ class Worker(object):
         self.model = ldamodel.LdaModel(**model_params)
 
 
+    @Pyro4.oneway
     def requestjob(self):
         """
         Request jobs from the dispatcher, in a perpetual loop until `getstate()` is called.
@@ -104,6 +106,7 @@ class Worker(object):
         self.finished = False
 
 
+    @Pyro4.oneway
     def exit(self):
         logger.info("terminating worker #%i" % self.myid)
         os._exit(0)

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -297,7 +297,6 @@ class LdaModel(interfaces.TransformationABC):
             try:
                 import Pyro4
                 dispatcher = Pyro4.Proxy('PYRONAME:gensim.lda_dispatcher')
-                dispatcher._pyroOneway.add("exit")
                 logger.debug("looking for dispatcher at %s" % str(dispatcher._pyroUri))
                 dispatcher.initialize(id2word=self.id2word, num_topics=num_topics,
                                       chunksize=chunksize, alpha=alpha, eta=eta, distributed=False)

--- a/gensim/models/lsi_dispatcher.py
+++ b/gensim/models/lsi_dispatcher.py
@@ -20,6 +20,7 @@ try:
     from Queue import Queue
 except ImportError:
     from queue import Queue
+import Pyro4
 from gensim import utils
 
 
@@ -69,16 +70,12 @@ class Dispatcher(object):
         # locate all available workers and store their proxies, for subsequent RMI calls
         self.workers = {}
         with utils.getNS() as ns:
-            import Pyro4
             self.callback = Pyro4.Proxy('PYRONAME:gensim.lsi_dispatcher') # = self
-            self.callback._pyroOneway.add("jobdone") # make sure workers transfer control back to dispatcher asynchronously
             for name, uri in ns.list(prefix='gensim.lsi_worker').iteritems():
                 try:
                     worker = Pyro4.Proxy(uri)
                     workerid = len(self.workers)
                     # make time consuming methods work asynchronously
-                    worker._pyroOneway.add("requestjob")
-                    worker._pyroOneway.add("exit")
                     logger.info("registering worker #%i from %s" % (workerid, uri))
                     worker.initialize(workerid, dispatcher=self.callback, **model_params)
                     self.workers[workerid] = worker
@@ -144,7 +141,7 @@ class Dispatcher(object):
         self._jobsdone = 0
         self._jobsreceived = 0
 
-
+    @Pyro4.oneway
     @utils.synchronous('lock_update')
     def jobdone(self, workerid):
         """
@@ -165,6 +162,7 @@ class Dispatcher(object):
         return self._jobsdone
 
 
+    @Pyro4.oneway
     def exit(self):
         """
         Terminate all registered workers and then the dispatcher.

--- a/gensim/models/lsi_worker.py
+++ b/gensim/models/lsi_worker.py
@@ -24,6 +24,7 @@ try:
     import Queue
 except ImportError:
     import queue as Queue
+import Pyro4
 from gensim.models import lsimodel
 from gensim import utils
 
@@ -49,6 +50,7 @@ class Worker(object):
         self.model = lsimodel.LsiModel(**model_params)
 
 
+    @Pyro4.oneway
     def requestjob(self):
         """
         Request jobs from the dispatcher, in a perpetual loop until `getstate()` is called.
@@ -96,6 +98,7 @@ class Worker(object):
         self.finished = False
 
 
+    @Pyro4.oneway
     def exit(self):
         logger.info("terminating worker #%i" % self.myid)
         os._exit(0)

--- a/gensim/models/lsimodel.py
+++ b/gensim/models/lsimodel.py
@@ -314,7 +314,6 @@ class LsiModel(interfaces.TransformationABC):
             try:
                 import Pyro4
                 dispatcher = Pyro4.Proxy('PYRONAME:gensim.lsi_dispatcher')
-                dispatcher._pyroOneway.add("exit")
                 logger.debug("looking for dispatcher at %s" % str(dispatcher._pyroUri))
                 dispatcher.initialize(id2word=self.id2word, num_topics=num_topics,
                                       chunksize=chunksize, decay=decay,

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
     ],
 
     extras_require={
-        'distributed': ['Pyro4 >= 4.8'],
+        'distributed': ['Pyro4 >= 4.27'],
     },
 
     include_package_data=True,


### PR DESCRIPTION
This is regarding #254.

I removed all the places where `Pyro4.Proxy._pyroOneway` was being used to specify nonblocking calls, and added `@Pyro4.oneway` to all of those methods instead.

I also updated `setup.py` to require `Pyro4>=4.27` and the documentation to match.
