### PR TITLE
fix ImportError with six 1.2.0

### DIFF
--- a/gensim/models/ldamulticore.py
+++ b/gensim/models/ldamulticore.py
@@ -51,8 +51,7 @@ import logging
 
 from gensim import utils
 from gensim.models.ldamodel import LdaModel, LdaState
-from six.moves.queue import Full
-from six.moves import xrange
+from six.moves import queue, xrange
 from multiprocessing import Pool, Queue, cpu_count
 
 logger = logging.getLogger(__name__)
@@ -252,7 +251,7 @@ class LdaMulticore(LdaModel):
                         logger.info('PROGRESS: pass %i, dispatched chunk #%i = '
                             'documents up to #%i/%i, outstanding queue size %i',
                             pass_, chunk_no, chunk_no * self.chunksize + len(chunk), lencorpus, queue_size[0])
-                    except Full:
+                    except queue.Full:
                         # in case the input job queue is full, keep clearing the
                         # result queue, to make sure we don't deadlock
                         process_result_queue()

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ setup(
     install_requires=[
         'numpy >= 1.3',
         'scipy >= 0.7.0',
-        'six >= 1.6.0',
+        'six >= 1.2.0',
     ],
 
     extras_require={


### PR DESCRIPTION
This fixes the import of `queue.Full` to work with six 1.2.0 again. All tests pass with this version and with 1.4.1.
