### PR TITLE
Fix a py3k bug in Word2Vec.load_word2vec_format with binary=False.

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -606,7 +606,7 @@ class Word2Vec(utils.SaveLoad):
                     parts = utils.to_unicode(line).split()
                     if len(parts) != layer1_size + 1:
                         raise ValueError("invalid vector on line %s (is this really the text format?)" % (line_no))
-                    word, weights = parts[0], map(REAL, parts[1:])
+                    word, weights = parts[0], list(map(REAL, parts[1:]))
                     if counts is None:
                         result.vocab[word] = Vocab(index=line_no, count=vocab_size - line_no)
                     elif word in counts:

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -68,6 +68,18 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertFalse(numpy.allclose(model['human'], norm_only_model['human']))
         self.assertTrue(numpy.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human']))
 
+    def testPersistenceWord2VecFormatNonBinary(self):
+        """Test storing/loading the entire model in word2vec non-binary format."""
+        model = word2vec.Word2Vec(sentences, min_count=1)
+        model.init_sims()
+        model.save_word2vec_format(testfile(), binary=False)
+        text_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=False, norm_only=False)
+        self.assertTrue(numpy.allclose(model['human'], text_model['human'], atol=1e-6))
+        norm_only_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=False, norm_only=True)
+        self.assertFalse(numpy.allclose(model['human'], norm_only_model['human'], atol=1e-6))
+        
+        self.assertTrue(numpy.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human'], atol=1e-4))
+
     def testPersistenceWord2VecFormatWithVocab(self):
         """Test storing/loading the entire model and vocabulary in word2vec format."""
         model = word2vec.Word2Vec(sentences, min_count=1)


### PR DESCRIPTION
The 'map' function will return an iterable in Python3, so we'll turn it
into a list.

Comes with new testPersistenceWord2VecFormatNonBinary test.
