### PR TITLE
[WIP] Added method to restrict vocab of Word2Vec most similar search

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1130,68 +1130,6 @@ class Word2Vec(utils.SaveLoad):
 
         If topn is False, most_similar returns the vector of similarity scores.
 
-        `restrict_vocab` is an optional integer which limits the range of vectors which
-        are searched for most-similar values. For example, restrict_vocab=10000 would
-        only check the first 10000 word vectors in the vocabulary order. (This may be
-        meaningful if you've sorted the vocabulary by descending frequency.)
-
-        Example::
-
-          >>> trained_model.most_similar(positive=['woman', 'king'], negative=['man'])
-          [('queen', 0.50882536), ...]
-
-        """
-        self.init_sims()
-
-        if isinstance(positive, string_types) and not negative:
-            # allow calls like most_similar('dog'), as a shorthand for most_similar(['dog'])
-            positive = [positive]
-
-        # add weights for each word, if not already present; default to 1.0 for positive and -1.0 for negative words
-        positive = [
-            (word, 1.0) if isinstance(word, string_types + (ndarray,)) else word
-            for word in positive
-        ]
-        negative = [
-            (word, -1.0) if isinstance(word, string_types + (ndarray,)) else word
-            for word in negative
-        ]
-
-        # compute the weighted average of all words
-        all_words, mean = set(), []
-        for word, weight in positive + negative:
-            if isinstance(word, ndarray):
-                mean.append(weight * word)
-            elif word in self.vocab:
-                mean.append(weight * self.syn0norm[self.vocab[word].index])
-                all_words.add(self.vocab[word].index)
-            else:
-                raise KeyError("word '%s' not in vocabulary" % word)
-        if not mean:
-            raise ValueError("cannot compute similarity with no input")
-        mean = matutils.unitvec(array(mean).mean(axis=0)).astype(REAL)
-
-        limited = self.syn0norm if restrict_vocab is None else self.syn0norm[:restrict_vocab]
-        dists = dot(limited, mean)
-        if not topn:
-            return dists
-        best = matutils.argsort(dists, topn=topn + len(all_words), reverse=True)
-        # ignore (don't return) words from the input
-        result = [(self.index2word[sim], float(dists[sim])) for sim in best if sim not in all_words]
-        return result[:topn]
-    
-    def most_similar_in_list(self, positive=[], negative=[], topn=10, restrict_vocab=None):
-        """
-        Find the top-N most similar words. Positive words contribute positively towards the
-        similarity, negative words negatively.
-
-        This method computes cosine similarity between a simple mean of the projection
-        weight vectors of the given words and the vectors for each word in the model.
-        The method corresponds to the `word-analogy` and `distance` scripts in the original
-        word2vec implementation.
-
-        If topn is False, most_similar returns the vector of similarity scores.
-
         `restrict_vocab` is optional. An integer values limits the range of vectors which
         are searched for most-similar values. For example, restrict_vocab=10000 would
         only check the first 10000 word vectors in the vocabulary order. (This may be

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1205,7 +1205,7 @@ class Word2Vec(utils.SaveLoad):
                     raise KeyError("word '%s' not in vocabulary" % word)
             restrict_vocab_idx = [self.vocab[word].index for word in restrict_vocab]
             limited = self.syn0norm[restrict_vocab_idx]
-        
+
         dists = dot(limited, mean)
         if not topn:
             return dists


### PR DESCRIPTION
I've added a method to `gensim.models.word2vec.py`:

``` python
def most_similar_in_list(self, positive=[], negative=[], topn=10, restrict_vocab=None):
```

which allows `restrict_vocab` to be a list containing words to restrict the search over. 

For example, these are the top 10 most similar results using the original `most_similar` method:

``` python
from gensim.models import Word2Vec
from nltk.corpus import brown

model = Word2Vec(brown.sents())
model.most_similar('vector')
```

```
[(u'V', 0.9310650825500488),
 (u'Q', 0.9126538634300232),
 (u'**zg', 0.9065112471580505),
 (u'null', 0.9064960479736328),
 (u'subspace', 0.9033916592597961),
 (u'intersection', 0.8994101881980896),
 (u'T', 0.8956964015960693),
 (u'staining', 0.8929149508476257),
 (u'secant', 0.8926326036453247),
 (u'concentration', 0.883994460105896)]
```

And we can restrict the search to a list of words with the new `most_similar_in_list` method:

``` python
model.most_similar_in_list('vector', restrict_vocab=['subspace', 'intersection', 'secant'])
```

```
[(u'subspace', 0.9033915996551514),
 (u'intersection', 0.8994101881980896),
 (u'secant', 0.8926326036453247)]
```

Passing an integer for `restrict_vocab` has the same behavior as the original,

``` python
model.most_similar('vector', restrict_vocab=3) == model.most_similar_in_list('vector', restrict_vocab=3)
```

```
True
```

For large vocabularies, there is some benefit to reducing the number of rows in `limited` when you're only interested in a subset of words:

``` python
dists = dot(limited, mean) 
```

The number of rows is `len(restrict_vocab)` rather than the total number of words in the vocab.
