### PR TITLE
Docker instructions in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,8 @@ If this feature list left you scratching your head, you can first read more abou
 Space Model <http://en.wikipedia.org/wiki/Vector_space_model>`_ and `unsupervised
 document analysis <http://en.wikipedia.org/wiki/Latent_semantic_indexing>`_ on Wikipedia.
 
-Fast Installation
------------------
+Fast Installation with Docker
+-----------------------------
 
 If your system supports Docker and you are root, the easiest way to get the library working is to start the `gensim image <https://hub.docker.com/r/zmarty/python3-gensim-doc2vec/>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -52,9 +52,7 @@ Then map a folder inside the Docker container, and run the container::
 
     docker run -it --rm -v /usr/local/gensim-app/:/usr/local/gensim-app/ zmarty/python3-gensim:based-on-ubuntu-15.10
 
-Then write your script and use the python3 command to run it.
-
-**Keep all your code in that folder (in our example /usr/local/gensim-app/), as all other folders in the container will get wiped out when exiting the container.**
+Then write your script in **/usr/local/gensim** and use the python3 command to run it. **Keep all your code in that folder**, as all other folders in the container will get wiped out when exiting the container.
 
 Manual Installation
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,7 @@ document analysis <http://en.wikipedia.org/wiki/Latent_semantic_indexing>`_ on W
 Fast Installation with Docker
 -----------------------------
 
-If your system supports Docker and you are root, the easiest way to get the library working is to start the `gensim image <https://hub.docker.com/r/zmarty/python3-gensim-doc2vec/>`_.
-
-The instructions below are for an Ubuntu system, but they can be easily modified for any other Docker system. First install docker::
+If your system supports Docker and you are root, the easiest way to get the library working is to start the `gensim image <https://hub.docker.com/r/zmarty/python3-gensim-doc2vec/>`_. The instructions below are for an Ubuntu system, but they can be easily modified for any other Docker system. First install docker::
 
     apt-get install docker-engine
 

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Then map a folder inside the Docker container, and run the container::
 
     docker run -it --rm -v /usr/local/gensim-app/:/usr/local/gensim-app/ zmarty/python3-gensim
 
-Then write your script in **/usr/local/gensim** and use the python3 command to run it. **Keep all your code in that folder**, as all other folders in the container will get wiped out when exiting the container.
+Then write your script in **/usr/local/gensim-app** and use the python3 command to run it. **Keep all your code in that folder**, as all other folders in the container will get wiped out when exiting the container.
 
 Manual Installation
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -44,13 +44,11 @@ Fast Installation
 
 If your system supports Docker and you are root, the easiest way to get the library working is to start the `gensim image <https://hub.docker.com/r/zmarty/python3-gensim-doc2vec/>`_.
 
-The instructions below are for an Ubuntu system, but they can be easily modified for any other Docker system::
-
-Install docker::
+The instructions below are for an Ubuntu system, but they can be easily modified for any other Docker system. First install docker::
 
     apt-get install docker-engine
 
-Map a folder inside the Docker container, and run the container::
+Then map a folder inside the Docker container, and run the container::
 
     docker run -it --rm -v /usr/local/gensim-app/:/usr/local/gensim-app/ zmarty/python3-gensim:based-on-ubuntu-15.10
 

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,27 @@ If this feature list left you scratching your head, you can first read more abou
 Space Model <http://en.wikipedia.org/wiki/Vector_space_model>`_ and `unsupervised
 document analysis <http://en.wikipedia.org/wiki/Latent_semantic_indexing>`_ on Wikipedia.
 
-Installation
-------------
+Fast Installation
+-----------------
+
+If you system supports Docker and you are root, the easiest way to get the library working is to start the `gensim image <https://hub.docker.com/r/zmarty/python3-gensim-doc2vec/>`_.
+
+The instructions below are for an Ubuntu system, but they can be easily modified for any other Docker system::
+
+Install docker::
+
+    apt-get install docker-engine
+
+Map a folder inside the Docker container, and run the container::
+
+    docker run -it --rm -v /usr/local/gensim-app/:/usr/local/gensim-app/ zmarty/python3-gensim:based-on-ubuntu-15.10
+
+Then write your script and use the python3 command to run it.
+
+**Keep all your code in that folder (in our example /usr/local/gensim-app/), as all other folders in the container will get wiped out when exiting the container.**
+
+Manual Installation
+-------------------
 
 This software depends on `NumPy and Scipy <http://www.scipy.org/Download>`_, two Python packages for scientific computing.
 You must have them installed prior to installing `gensim`.

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ document analysis <http://en.wikipedia.org/wiki/Latent_semantic_indexing>`_ on W
 Fast Installation
 -----------------
 
-If you system supports Docker and you are root, the easiest way to get the library working is to start the `gensim image <https://hub.docker.com/r/zmarty/python3-gensim-doc2vec/>`_.
+If your system supports Docker and you are root, the easiest way to get the library working is to start the `gensim image <https://hub.docker.com/r/zmarty/python3-gensim-doc2vec/>`_.
 
 The instructions below are for an Ubuntu system, but they can be easily modified for any other Docker system::
 

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ document analysis <http://en.wikipedia.org/wiki/Latent_semantic_indexing>`_ on W
 Fast Installation with Docker
 -----------------------------
 
-If your system supports Docker and you are root, the easiest way to get the library working is to start the `gensim image <https://hub.docker.com/r/zmarty/python3-gensim-doc2vec/>`_. The instructions below are for an Ubuntu system, but they can be easily modified for any other Docker system. First install docker::
+If your system supports `Docker <https://www.docker.com/what-docker>`_ and you are root, the easiest way to get the library working is to start the `gensim image <https://hub.docker.com/r/zmarty/python3-gensim-doc2vec/>`_. The instructions below are for an Ubuntu system, but they can be easily modified for any other Docker system. First install docker::
 
     apt-get install docker-engine
 

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ If your system supports Docker and you are root, the easiest way to get the libr
 
 Then map a folder inside the Docker container, and run the container::
 
-    docker run -it --rm -v /usr/local/gensim-app/:/usr/local/gensim-app/ zmarty/python3-gensim:based-on-ubuntu-15.10
+    docker run -it --rm -v /usr/local/gensim-app/:/usr/local/gensim-app/ zmarty/python3-gensim
 
 Then write your script in **/usr/local/gensim** and use the python3 command to run it. **Keep all your code in that folder**, as all other folders in the container will get wiped out when exiting the container.
 


### PR DESCRIPTION
Add instructions to quickly start a Docker image that has gensim and all its dependencies already installed.
