### PR TITLE
Fix RP model loading for large Fortran-order arrays

### DIFF
--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -256,7 +256,6 @@ class SaveLoad(object):
         opportunity to recursively included SaveLoad instances.
 
         """
-
         mmap_error = lambda x, y: IOError(
             'Cannot mmap compressed object %s in file %s. ' % (x, y) +
             'Use `load(fname, mmap=None)` or uncompress files manually.')


### PR DESCRIPTION
...seems like a left-over bug from when `SaveLoad` started storing large arrays separately.

RpModel overloads `__setstate__`, which expected all arrays to be loaded at once. The reason for this overload was to work around a bug in NumPy, which was causing segfaults on using loaded Fortran-order arrays. The fact that we're now loading some object attributes later broke this `__setstate__` functionality, causing an exception [reported by users on the mailing list](https://groups.google.com/forum/#!topic/gensim/BE3qDSNJs54).

The fix in this PR delays applying the bug workaround for when the loaded array is first *used* (as opposed to *loaded*).

Might also be worth checking if the NumPy bug (segfault) is still there in the first place, so we could remove the workaround altogether. In fact, NumPy has seen a lot of changes since 2010, so maybe we don't need to keep arrays in Fortran-order at all. Or maybe we still do -- check!