### PR TITLE
[WIP] Add support for using Annoy as an external similarity index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
   - conda create --yes -n gensim-test python=$TRAVIS_PYTHON_VERSION pip atlas numpy scipy
   - source activate gensim-test
   - pip install pyemd
+  - pip install annoy
   - pip install testfixtures
   - python setup.py install
 script: python setup.py test

--- a/gensim/similarities/index.py
+++ b/gensim/similarities/index.py
@@ -17,6 +17,15 @@ class SimilarityIndex(object):
         return cls._build_from_model(model.syn0norm, model.index2word, model.vector_size, num_trees)
 
     @classmethod
+    def build_from_doc2vec(cls, model, num_trees):
+        """Build an Annoy index using document vectors from a Doc2Vec model"""
+
+        docvecs = model.docvecs
+        docvecs.init_sims()
+        labels = [docvecs.index_to_doctag(i) for i in range(0, docvecs.count)]
+        return cls._build_from_model(docvecs.doctag_syn0norm, labels, model.vector_size, num_trees)
+
+    @classmethod
     def _build_from_model(cls, vectors, labels, num_features, num_trees):
         index = AnnoyIndex(num_features)
 

--- a/gensim/similarities/index.py
+++ b/gensim/similarities/index.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2013 Radim Rehurek <me@radimrehurek.com>
+# Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
+
+from annoy import AnnoyIndex
+
+
+class SimilarityIndex(object):
+
+    @classmethod
+    def build_from_word2vec(cls, model, num_trees):
+        """Build an Annoy index using word vectors from a Word2Vec model"""
+
+        model.init_sims()
+        return cls._build_from_model(model.syn0norm, model.index2word, model.vector_size, num_trees)
+
+    @classmethod
+    def _build_from_model(cls, vectors, labels, num_features, num_trees):
+        index = AnnoyIndex(num_features)
+
+        for i in range(len(vectors)):
+            vector = vectors[i]
+            index.add_item(i, vector)
+
+        index.build(num_trees)
+        return SimilarityIndex(index, labels)
+
+    def __init__(self, index, labels):
+        self.index = index
+        self.labels = labels
+
+    def most_similar(self, vector, num_neighbors):
+        """Find the top-N most similar items"""
+
+        ids, distances = self.index.get_nns_by_vector(
+            vector, num_neighbors, include_distances=True)
+
+        result = []
+        for i in range(len(ids)):
+            label = self.labels[ids[i]]
+            similarity = 1 - distances[i] / 2
+            result += [(label, similarity)]
+
+        return result


### PR DESCRIPTION
(Related to #617, #527, and #51.)

This is a partial implementation of an external similarity index based on Annoy for approximate nearest neighbor search. It's based on #617 and the related comments, using a test-first approach. I'm running out of time to pursue it during the PyCon sprints, but wanted to share the pieces that may be useful for pushing #617 forward (e.g. class method index construction, conditional Annoy dependency in the tests).