### PR TITLE
[MRG] `get_document_topic` Tests and Documentation changes.

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -883,7 +883,7 @@ class LdaModel(interfaces.TransformationABC):
         top_topics = sorted(coherence_scores, key=lambda t: t[1], reverse=True)
         return top_topics
 
-    def get_document_topics(self, bow, minimum_probability=None, minimum_phi_probability=None, per_word_topics=False):
+    def get_document_topics(self, bow, minimum_probability=None, minimum_phi_value=None, per_word_topics=False):
         """
         Return topic distribution for the given document `bow`, as a list of
         (topic_id, topic_probability) 2-tuples.
@@ -898,9 +898,9 @@ class LdaModel(interfaces.TransformationABC):
             minimum_probability = self.minimum_probability
         minimum_probability = max(minimum_probability, 1e-8)  # never allow zero values in sparse output
 
-        if minimum_phi_probability is None:
-            minimum_phi_probability = self.minimum_probability
-        minimum_phi_probability = max(minimum_phi_probability, 1e-8)  # never allow zero values in sparse output
+        if minimum_phi_value is None:
+            minimum_phi_value = self.minimum_probability
+        minimum_phi_value = max(minimum_phi_value, 1e-8)  # never allow zero values in sparse output
 
         # if the input vector is a corpus, return a transformed corpus
         is_corpus, corpus = utils.is_corpus(bow)
@@ -922,7 +922,7 @@ class LdaModel(interfaces.TransformationABC):
                 phi_values = [] # contains (phi_value, topic) pairing to later be sorted
                 phi_topic = [] # contains topic and corresponding phi value to be returned 'raw' to user
                 for topic_id in range(0, self.num_topics):
-                    if phis[topic_id][word_type] >= minimum_phi_probability:
+                    if phis[topic_id][word_type] >= minimum_phi_value:
                         # appends phi values for each topic for that word
                         # these phi values are scaled by feature length 
                         phi_values.append((phis[topic_id][word_type], topic_id))

--- a/gensim/test/test_ldamodel.py
+++ b/gensim/test/test_ldamodel.py
@@ -279,14 +279,9 @@ class TestLdaModel(unittest.TestCase):
 
         # word_topics looks like this: ({word_id => [topic_id_most_probable, topic_id_second_most_probable, ...]).
         # we check one case in word_topics, i.e of the first word in the doc, and it's likely topics.
-        # also check one case of phi_values
         expected_word = 0
-        expected_topiclist = [1, 0]
-        expected_phi_values = (0, 0.6)
-        # FIXME: Fails on osx and win
-        # self.assertEqual(word_topics[0][0], expected_word)
-        # self.assertEqual(word_topics[0][1], expected_topiclist)
-        # self.assertAlmostEqual(phi_values[0][1], expected_phi_values[1], places = 1)
+        self.assertEqual(word_topics[0][0], expected_word)
+        self.assertTrue(0 in word_topics[0][1])
 
     def testTermTopics(self):
 


### PR DESCRIPTION
@tmylk , I've changed the tests such that it's less strict, it just looks for the presence of topic_0 in the list of most probable topics. 
@graychan changed `minimum_phi_probabilities` to `minimum_phi_values`. 

Edit: python 2.7 fails because of a time-out.