### PR TITLE
load_word_topics() returns value

### DIFF
--- a/gensim/models/wrappers/ldamallet.py
+++ b/gensim/models/wrappers/ldamallet.py
@@ -201,8 +201,8 @@ class LdaMallet(utils.SaveLoad):
                 tokenid = word2id[token]
                 wordtopics[int(topic), tokenid] += 1.0
         logger.info("loaded assigned topics for %i tokens", wordtopics.sum())
-        self.wordtopics = wordtopics
         self.print_topics(15)
+        return wordtopics
 
     def print_topics(self, num_topics=10, num_words=10):
         return self.show_topics(num_topics, num_words, log=True)

--- a/gensim/models/wrappers/ldamallet.py
+++ b/gensim/models/wrappers/ldamallet.py
@@ -164,7 +164,7 @@ class LdaMallet(utils.SaveLoad):
         # NOTE "--keep-sequence-bigrams" / "--use-ngrams true" poorer results + runs out of memory
         logger.info("training MALLET LDA with %s", cmd)
         check_output(cmd, shell=True)
-        self.wordtopics = self.load_word_topics()
+        self.word_topics = self.load_word_topics()
 
     def __getitem__(self, bow, iterations=100):
         is_corpus, corpus = utils.is_corpus(bow)
@@ -182,7 +182,7 @@ class LdaMallet(utils.SaveLoad):
 
     def load_word_topics(self):
         logger.info("loading assigned topics from %s", self.fstate())
-        wordtopics = numpy.zeros((self.num_topics, self.num_terms), dtype=numpy.float32)
+        word_topics = numpy.zeros((self.num_topics, self.num_terms), dtype=numpy.float32)
         if hasattr(self.id2word, 'token2id'):
             word2id = self.id2word.token2id
         else:
@@ -199,10 +199,10 @@ class LdaMallet(utils.SaveLoad):
                 if token not in word2id:
                     continue
                 tokenid = word2id[token]
-                wordtopics[int(topic), tokenid] += 1.0
-        logger.info("loaded assigned topics for %i tokens", wordtopics.sum())
+                word_topics[int(topic), tokenid] += 1.0
+        logger.info("loaded assigned topics for %i tokens", word_topics.sum())
         self.print_topics(15)
-        return wordtopics
+        return word_topics
 
     def print_topics(self, num_topics=10, num_words=10):
         return self.show_topics(num_topics, num_words, log=True)
@@ -242,7 +242,7 @@ class LdaMallet(utils.SaveLoad):
         return shown
 
     def show_topic(self, topicid, topn=10):
-        topic = self.wordtopics[topicid]
+        topic = self.word_topics[topicid]
         topic = topic / topic.sum()  # normalize to probability dist
         bestn = matutils.argsort(topic, topn, reverse=True)
         beststr = [(topic[id], self.id2word[id]) for id in bestn]

--- a/gensim/models/wrappers/ldamallet.py
+++ b/gensim/models/wrappers/ldamallet.py
@@ -242,6 +242,8 @@ class LdaMallet(utils.SaveLoad):
         return shown
 
     def show_topic(self, topicid, topn=10):
+        if self.word_topics is None:
+            logger.info("Run train or load_word_topics before showing topics.")
         topic = self.word_topics[topicid]
         topic = topic / topic.sum()  # normalize to probability dist
         bestn = matutils.argsort(topic, topn, reverse=True)

--- a/gensim/models/wrappers/ldamallet.py
+++ b/gensim/models/wrappers/ldamallet.py
@@ -164,7 +164,7 @@ class LdaMallet(utils.SaveLoad):
         # NOTE "--keep-sequence-bigrams" / "--use-ngrams true" poorer results + runs out of memory
         logger.info("training MALLET LDA with %s", cmd)
         check_output(cmd, shell=True)
-        self.word_topics = self.load_word_topics()
+        self.wordtopics = self.load_word_topics()
 
     def __getitem__(self, bow, iterations=100):
         is_corpus, corpus = utils.is_corpus(bow)

--- a/gensim/models/wrappers/ldamallet.py
+++ b/gensim/models/wrappers/ldamallet.py
@@ -243,7 +243,7 @@ class LdaMallet(utils.SaveLoad):
 
     def show_topic(self, topicid, topn=10):
         if self.word_topics is None:
-            logger.info("Run train or load_word_topics before showing topics.")
+            logger.warn("Run train or load_word_topics before showing topics.")
         topic = self.word_topics[topicid]
         topic = topic / topic.sum()  # normalize to probability dist
         bestn = matutils.argsort(topic, topn, reverse=True)

--- a/gensim/test/test_ldamallet_wrapper.py
+++ b/gensim/test/test_ldamallet_wrapper.py
@@ -104,7 +104,7 @@ class TestLdaMallet(unittest.TestCase):
         model.save(fname)
         model2 = ldamallet.LdaMallet.load(fname)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy.allclose(model.wordtopics, model2.wordtopics))
+        self.assertTrue(numpy.allclose(model.word_topics, model2.word_topics))
         tstvec = []
         self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 
@@ -116,7 +116,7 @@ class TestLdaMallet(unittest.TestCase):
         model.save(fname)
         model2 = ldamallet.LdaMallet.load(fname, mmap=None)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy.allclose(model.wordtopics, model2.wordtopics))
+        self.assertTrue(numpy.allclose(model.word_topics, model2.word_topics))
         tstvec = []
         self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 
@@ -132,8 +132,8 @@ class TestLdaMallet(unittest.TestCase):
         # test loading the large model arrays with mmap
         model2 = ldamodel.LdaModel.load(testfile(), mmap='r')
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(isinstance(model2.wordtopics, numpy.memmap))
-        self.assertTrue(numpy.allclose(model.wordtopics, model2.wordtopics))
+        self.assertTrue(isinstance(model2.word_topics, numpy.memmap))
+        self.assertTrue(numpy.allclose(model.word_topics, model2.word_topics))
         tstvec = []
         self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 


### PR DESCRIPTION
@tmylk, @piskvorky , with reference to #764 .

`load_word_topics()` now returns `word topics` which is assigned by `train` to `self.wordtopics`.

Before, there were two variables; `word_topics` and a `wordtopics`, and only the `wordtopics` variable was being used elsewhere; so I removed `word_topics`.

Is that ok?