### PR TITLE
Str to byte fix for DTM wrapper.

### DIFF
--- a/gensim/models/wrappers/dtmmodel.py
+++ b/gensim/models/wrappers/dtmmodel.py
@@ -171,6 +171,7 @@ class DtmModel(utils.SaveLoad):
         logger.info("serializing temporary corpus to %s" % self.fcorpustxt())
         # write out the corpus in a file format that DTM understands:
         corpora.BleiCorpus.save_corpus(self.fcorpustxt(), corpus)
+
         with utils.smart_open(self.ftimeslices(), 'wb') as fout:
             fout.write(six.u(utils.to_utf8(str(len(self.time_slices)) + "\n")))
             for sl in time_slices:

--- a/gensim/models/wrappers/dtmmodel.py
+++ b/gensim/models/wrappers/dtmmodel.py
@@ -173,9 +173,9 @@ class DtmModel(utils.SaveLoad):
         corpora.BleiCorpus.save_corpus(self.fcorpustxt(), corpus)
 
         with utils.smart_open(self.ftimeslices(), 'wb') as fout:
-            fout.write(six.u(str(len(self.time_slices)) + "\n"))
+            fout.write(six.u(str(len(self.time_slices)) + "\n").encode('utf-8'))
             for sl in time_slices:
-                fout.write(six.u(str(sl) + "\n"))
+                fout.write(six.u(str(sl) + "\n").encode('utf-8'))
 
     def train(self, corpus, time_slices, mode, model):
         """

--- a/gensim/models/wrappers/dtmmodel.py
+++ b/gensim/models/wrappers/dtmmodel.py
@@ -171,11 +171,10 @@ class DtmModel(utils.SaveLoad):
         logger.info("serializing temporary corpus to %s" % self.fcorpustxt())
         # write out the corpus in a file format that DTM understands:
         corpora.BleiCorpus.save_corpus(self.fcorpustxt(), corpus)
-
         with utils.smart_open(self.ftimeslices(), 'wb') as fout:
-            fout.write(six.u(str(len(self.time_slices)) + "\n").encode('utf-8'))
+            fout.write(six.u(utils.to_utf8(str(len(self.time_slices)) + "\n")))
             for sl in time_slices:
-                fout.write(six.u(str(sl) + "\n").encode('utf-8'))
+                fout.write(six.u(utils.to_utf8(str(sl) + "\n")))
 
     def train(self, corpus, time_slices, mode, model):
         """


### PR DESCRIPTION
@piskvorky , this is with respect to #698.

You were right, all that had to be done was use `utils.to_utf8` before writing to file. 
Works fine with both python2 and 3.