### PR TITLE
Match the Annoy index similarity API to the Word2Vec API

### DIFF
--- a/docs/notebooks/annoytutorial.ipynb
+++ b/docs/notebooks/annoytutorial.ipynb
@@ -101,7 +101,7 @@
    ],
    "source": [
     "%%time\n",
-    "neighbors = annoy_index.most_similar(vector, 5)\n",
+    "neighbors = annoy_index.similar_by_vector(vector, 5)\n",
     "for neighbor in neighbors:\n",
     "    print neighbor"
    ]
@@ -234,7 +234,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we are ready to make a query, lets find the top 5 most similar words to \"army\" in the lee corpus. To make a similarity query we call `most_similar` which takes two parameters, a vector, and `num_neighbors`"
+    "Now that we are ready to make a query, lets find the top 5 most similar words to \"army\" in the lee corpus. To make a similarity query we call `similar_by_vector` which takes two parameters, a vector, and `topn`:"
    ]
   },
   {
@@ -259,8 +259,8 @@
    "source": [
     "# Derive the vector for the word \"army\" in our model\n",
     "vector = model[\"army\"]\n",
-    "# Call most_similar() to find the 5 approximate nearest neighbors for the vector representing \"army\"\n",
-    "approximate_neighbors = annoy_index.most_similar(vector, 5)\n",
+    "# Call similar_by_vector() to find the 5 approximate nearest neighbors for the vector representing \"army\"\n",
+    "approximate_neighbors = annoy_index.similar_by_vector(vector, 5)\n",
     "# Neatly print the approximate_neighbors and their corresponding cosine similarity values\n",
     "for neighbor in approximate_neighbors:\n",
     "    print neighbor"
@@ -362,7 +362,7 @@
     "y_axis = []\n",
     "for x in range(1,30):\n",
     "    annoy_index = SimilarityIndex.build_from_word2vec(model, x)\n",
-    "    approximate_results = [result[0] for result in annoy_index.most_similar(model.syn0norm[0], 100)]\n",
+    "    approximate_results = [result[0] for result in annoy_index.similar_by_vector(model.syn0norm[0], 100)]\n",
     "    x_axis.append(x)\n",
     "    y_axis.append(len(set(approximate_results).intersection(exact_results)))\n",
     "    \n",

--- a/gensim/similarities/index.py
+++ b/gensim/similarities/index.py
@@ -43,11 +43,11 @@ class SimilarityIndex(object):
         self.index = index
         self.labels = labels
 
-    def most_similar(self, vector, num_neighbors):
+    def similar_by_vector(self, vector, topn=10):
         """Find the top-N most similar items"""
 
         ids, distances = self.index.get_nns_by_vector(
-            vector, num_neighbors, include_distances=True)
+            vector, topn, include_distances=True)
 
         result = []
         for i in range(len(ids)):

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -442,7 +442,7 @@ class TestWord2VecSimilarityIndex(unittest.TestCase):
     def testVectorIsSimilarToItself(self):
         label = self.model.index2word[0]
         vector = self.model.syn0norm[0]
-        approx_neighbors = self.index.most_similar(vector, 1)
+        approx_neighbors = self.index.similar_by_vector(vector, 1)
         word, similarity = approx_neighbors[0]
 
         self.assertEqual(word, label)
@@ -450,8 +450,8 @@ class TestWord2VecSimilarityIndex(unittest.TestCase):
 
     def testApproxNeighborsMatchExact(self):
         vector = self.model.syn0norm[0]
-        approx_neighbors = self.index.most_similar(vector, 5)
-        exact_neighbors = self.model.most_similar(positive=[vector], topn=5)
+        approx_neighbors = self.index.similar_by_vector(vector, 5)
+        exact_neighbors = self.model.similar_by_vector(vector, topn=5)
 
         approx_words = [neighbor[0] for neighbor in approx_neighbors]
         exact_words = [neighbor[0] for neighbor in exact_neighbors]
@@ -476,7 +476,7 @@ class TestDoc2VecSimilarityIndex(unittest.TestCase):
     def testDocumentIsSimilarToItself(self):
         vector = self.model.docvecs.doctag_syn0norm[0]
 
-        approx_neighbors = self.index.most_similar(vector, 1)
+        approx_neighbors = self.index.similar_by_vector(vector, 1)
         doc, similarity = approx_neighbors[0]
 
         self.assertEqual(doc, 0)
@@ -484,7 +484,7 @@ class TestDoc2VecSimilarityIndex(unittest.TestCase):
 
     def testApproxNeighborsMatchExact(self):
         vector = self.model.docvecs.doctag_syn0norm[0]
-        approx_neighbors = self.index.most_similar(vector, 5)
+        approx_neighbors = self.index.similar_by_vector(vector, 5)
         exact_neighbors = self.model.docvecs.most_similar(
             positive=[vector], topn=5)
 


### PR DESCRIPTION
The implemented similarity lookup method is most like `similar_by_vector`,
rather than `most_similar`.