### PR TITLE
Fixing the docstrings in WmdSimilarity and wmdistance

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1244,7 +1244,7 @@ class Word2Vec(utils.SaveLoad):
         result = [(self.index2word[sim], float(dists[sim])) for sim in best if sim not in all_words]
         return result[:topn]
 
-    def wmdistance(self, document1, document2, WCD=False, RWMD=False):
+    def wmdistance(self, document1, document2):
         """
         Compute the Word Mover's Distance between two documents. When using this
         code, please consider citing the following papers:

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1248,9 +1248,10 @@ class Word2Vec(utils.SaveLoad):
         """
         Compute the Word Mover's Distance between two documents. When using this
         code, please consider citing the following papers:
-        * Ofir Pele and Michael Werman, "A linear time histogram metric for improved SIFT matching".
-        * Ofir Pele and Michael Werman, "Fast and robust earth mover's distances".
-        * Matt Kusner et al. "From Word Embeddings To Document Distances".
+
+        .. Ofir Pele and Michael Werman, "A linear time histogram metric for improved SIFT matching".
+        .. Ofir Pele and Michael Werman, "Fast and robust earth mover's distances".
+        .. Matt Kusner et al. "From Word Embeddings To Document Distances".
 
         Note that if one of the documents have no words that exist in the
         Word2Vec vocab, `float('inf')` (i.e. infinity) will be returned.
@@ -1258,21 +1259,21 @@ class Word2Vec(utils.SaveLoad):
         This method only works if `pyemd` is installed (can be installed via pip, but requires a C compiler).
 
         Example:
-        > # Train word2vec model.
-        > model = Word2Vec(sentences)
+            >>> # Train word2vec model.
+            >>> model = Word2Vec(sentences)
 
-        > # Some sentences to test.
-        > sentence_obama = 'Obama speaks to the media in Illinois'.lower().split()
-        > sentence_president = 'The president greets the press in Chicago'.lower().split()
+            >>> # Some sentences to test.
+            >>> sentence_obama = 'Obama speaks to the media in Illinois'.lower().split()
+            >>> sentence_president = 'The president greets the press in Chicago'.lower().split()
 
-        > # Remove their stopwords.
-        > from nltk.corpus import stopwords
-        > stopwords = nltk.corpus.stopwords.words('english')
-        > sentence_obama = [w for w in sentence_obama if w not in stopwords]
-        > sentence_president = [w for w in sentence_president if w not in stopwords]
+            >>> # Remove their stopwords.
+            >>> from nltk.corpus import stopwords
+            >>> stopwords = nltk.corpus.stopwords.words('english')
+            >>> sentence_obama = [w for w in sentence_obama if w not in stopwords]
+            >>> sentence_president = [w for w in sentence_president if w not in stopwords]
 
-        > # Compute WMD.
-        > distance = model.wmdistance(sentence_obama, sentence_president)
+            >>> # Compute WMD.
+            >>> distance = model.wmdistance(sentence_obama, sentence_president)
         """
 
         if not PYEMD_EXT:

--- a/gensim/similarities/docsim.py
+++ b/gensim/similarities/docsim.py
@@ -562,17 +562,18 @@ class WmdSimilarity(interfaces.SimilarityABC):
     retrieved.
 
     When using this code, please consider citing the following papers:
-    * Ofir Pele and Michael Werman, "A linear time histogram metric for improved SIFT matching".
-    * Ofir Pele and Michael Werman, "Fast and robust earth mover's distances".
-    * Matt Kusner et al. "From Word Embeddings To Document Distances".
+
+    .. Ofir Pele and Michael Werman, "A linear time histogram metric for improved SIFT matching".
+    .. Ofir Pele and Michael Werman, "Fast and robust earth mover's distances".
+    .. Matt Kusner et al. "From Word Embeddings To Document Distances".
 
     Example:
-        # Given a document collection "corpus", train word2vec model.
-        model = word2vec(corpus)
-        instance = WmdSimilarity(corpus, model, num_best=10)
+        >>> # Given a document collection "corpus", train word2vec model.
+        >>> model = word2vec(corpus)
+        >>> instance = WmdSimilarity(corpus, model, num_best=10)
 
-        # Make query.
-        sims = instance[query]
+        >>> # Make query.
+        >>> sims = instance[query]
     """
     def __init__(self, corpus, w2v_model, num_best=None, normalize_w2v_and_replace=True, chunksize=256):
         """

--- a/gensim/similarities/docsim.py
+++ b/gensim/similarities/docsim.py
@@ -579,8 +579,7 @@ class WmdSimilarity(interfaces.SimilarityABC):
         """
         corpus:                         List of lists of strings, as in gensim.models.word2vec.
         w2v_model:                      A trained word2vec model.
-        num_best:                       Number of results to retrieve. If provided, a fast algorithm
-                                        called "prefetch and prune" is used.
+        num_best:                       Number of results to retrieve.
         normalize_w2v_and_replace:      Whether or not to normalize the word2vec vectors to
                                         length 1.
         """


### PR DESCRIPTION
@tmylk @piskvorky 

I noticed that I had formatted the docstrings of `WmdSimilarity` and `wmdistance` incorrectly so that their decriptions on the API reference looked hideous (see [here](https://radimrehurek.com/gensim/models/word2vec.html#gensim.models.word2vec.Word2Vec.wmdistance) and [here](https://radimrehurek.com/gensim/similarities/docsim.html#gensim.similarities.docsim.WmdSimilarity)).

So I took the liberty of fixing these (I can't test that they actually will look correct on the Gensim website though). Do the docstrings look correct?

I also noticed two small errors while fixing this (two unused parameters in wmdistance and an error in one of the docstrings), so I fixed that too.