### PR TITLE
LdaMallet bug fix.

### DIFF
--- a/gensim/models/wrappers/ldamallet.py
+++ b/gensim/models/wrappers/ldamallet.py
@@ -95,7 +95,6 @@ class LdaMallet(utils.SaveLoad):
         self.workers = workers
         self.optimize_interval = optimize_interval
         self.iterations = iterations
-
         if corpus is not None:
             self.train(corpus)
 
@@ -204,7 +203,6 @@ class LdaMallet(utils.SaveLoad):
                     continue
                 tokenid = word2id[token]
                 word_topics[int(topic), tokenid] += 1.0
-        self.print_topics(15)
         return word_topics
 
     def print_topics(self, num_topics=10, num_words=10):


### PR DESCRIPTION
Fixes #796 . 
Because of `self.print_topics(15)` being called before an assignment to word_topics, an error was being thrown. 
I've fixed this by removing that line - I don't see why it was there in the first place. If there is a particular reason for it being there, we can think of  a different/better way to fix this.

@tmylk , @piskvorky , please review this as soon as possible because the mallet wrapper cannot be used otherwise.