### PR TITLE
Case insensitive option for word2vec accuracy 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changes
 * Implemented LsiModel.docs_processed attribute
 * Added LdaMallet support. Added LdaVowpalWabbit, LdaMallet example to notebook. Added test suite for coherencemodel and aggregation.
   Added `topics` parameter to coherencemodel. Can now provide tokenized topics to calculate coherence value (@dsquareindia, #750)
+* Changed `use_lowercase` option in word2vec accuracy to `case_insensitive` to account for case variations in training vocabulary (@jayantj, #714)
 
 0.13.1, 2016-06-22
 

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1576,8 +1576,8 @@ class Word2Vec(utils.SaveLoad):
         Use `restrict_vocab` to ignore all questions containing a word whose frequency
         is not in the top-N most frequent words (default top 30,000).
 
-        Use `use_lowercase` to convert all words in questions to thier lowercase form before evaluating
-        the accuracy. It's useful when assuming the text preprocessing also uses lowercase.  (default True).
+        Use `case_insensitive` to convert all words in questions and vocab to their lowercase form before evaluating
+        the accuracy. Useful in case of case-mismatch between training tokens and question words.  (default True).
 
         This method corresponds to the `compute-accuracy` script of the original C word2vec.
 

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1573,8 +1573,10 @@ class Word2Vec(utils.SaveLoad):
         The accuracy is reported (=printed to log and returned as a list) for each
         section separately, plus there's one aggregate summary at the end.
 
-        Use `restrict_vocab` to ignore all questions containing a word whose frequency
-        is not in the top-N most frequent words (default top 30,000).
+        `restrict_vocab` is an optional integer which limits the vocab to be used
+        for answering questions. For example, restrict_vocab=10000 would only check
+        the first 10000 word vectors in the vocabulary order. (This may be meaningful
+        if you've sorted the vocabulary by descending frequency.)
 
         Use `case_insensitive` to convert all words in questions and vocab to their lowercase form before evaluating
         the accuracy. Useful in case of case-mismatch between training tokens and question words.  (default True).
@@ -1582,11 +1584,9 @@ class Word2Vec(utils.SaveLoad):
         This method corresponds to the `compute-accuracy` script of the original C word2vec.
 
         """
-        ok_vocab = dict(sorted(iteritems(self.vocab),
-                               key=lambda item: -item[1].count)[:restrict_vocab])
+        ok_vocab = [(w, self.vocab[w]) for w in self.index2word[:restrict_vocab]]
+        ok_vocab = dict((w.lower(), v) for w, v in reversed(ok_vocab)) if case_insensitive else dict(ok_vocab)
         ok_index = set(v.index for v in itervalues(ok_vocab))
-        if case_insensitive:
-            ok_vocab = dict((w.lower(), v) for w, v in iteritems(ok_vocab))
 
         sections, section = [], None
         for line_no, line in enumerate(utils.smart_open(questions)):

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1573,13 +1573,15 @@ class Word2Vec(utils.SaveLoad):
         The accuracy is reported (=printed to log and returned as a list) for each
         section separately, plus there's one aggregate summary at the end.
 
-        `restrict_vocab` is an optional integer which limits the vocab to be used
-        for answering questions. For example, restrict_vocab=10000 would only check
-        the first 10000 word vectors in the vocabulary order. (This may be meaningful
-        if you've sorted the vocabulary by descending frequency.)
+        Use `restrict_vocab` to ignore all questions containing a word not in the first `restrict_vocab`
+        words (default 30,000). This may be meaningful if you've sorted the vocabulary by descending frequency.
+        In case `case_insensitive` is True, the first `restrict_vocab` words are taken first, and then
+        case normalization is performed.
 
-        Use `case_insensitive` to convert all words in questions and vocab to their uppercase form before evaluating
-        the accuracy. Useful in case of case-mismatch between training tokens and question words.  (default True).
+        Use `case_insensitive` to convert all words in questions and vocab to their uppercase form before 
+        evaluating the accuracy (default True). Useful in case of case-mismatch between training tokens 
+        and question words. In case of multiple case variants of a single word, the vector for the first
+        occurrence (also the most frequent if vocabulary is sorted) is taken.
 
         This method corresponds to the `compute-accuracy` script of the original C word2vec.
 

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1608,6 +1608,7 @@ class Word2Vec(utils.SaveLoad):
                         a, b, c, expected = [word for word in line.split()]
                 except:
                     logger.info("skipping invalid line #%i in %s" % (line_no, questions))
+                    continue
                 if a not in ok_vocab or b not in ok_vocab or c not in ok_vocab or expected not in ok_vocab:
                     logger.debug("skipping line #%i with OOV words: %s" % (line_no, line.strip()))
                     continue

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1578,14 +1578,14 @@ class Word2Vec(utils.SaveLoad):
         the first 10000 word vectors in the vocabulary order. (This may be meaningful
         if you've sorted the vocabulary by descending frequency.)
 
-        Use `case_insensitive` to convert all words in questions and vocab to their lowercase form before evaluating
+        Use `case_insensitive` to convert all words in questions and vocab to their uppercase form before evaluating
         the accuracy. Useful in case of case-mismatch between training tokens and question words.  (default True).
 
         This method corresponds to the `compute-accuracy` script of the original C word2vec.
 
         """
         ok_vocab = [(w, self.vocab[w]) for w in self.index2word[:restrict_vocab]]
-        ok_vocab = dict((w.lower(), v) for w, v in reversed(ok_vocab)) if case_insensitive else dict(ok_vocab)
+        ok_vocab = dict((w.upper(), v) for w, v in reversed(ok_vocab)) if case_insensitive else dict(ok_vocab)
 
         sections, section = [], None
         for line_no, line in enumerate(utils.smart_open(questions)):
@@ -1602,7 +1602,7 @@ class Word2Vec(utils.SaveLoad):
                     raise ValueError("missing section header before line #%i in %s" % (line_no, questions))
                 try:
                     if case_insensitive:
-                        a, b, c, expected = [word.lower() for word in line.split()]  # assumes vocabulary preprocessing uses lowercase, too...
+                        a, b, c, expected = [word.upper() for word in line.split()]
                     else:
                         a, b, c, expected = [word for word in line.split()]
                 except:
@@ -1620,7 +1620,7 @@ class Word2Vec(utils.SaveLoad):
                 sims = most_similar(self, positive=[b, c], negative=[a], topn=False, restrict_vocab=restrict_vocab)
                 self.vocab = original_vocab
                 for index in matutils.argsort(sims, reverse=True):
-                    predicted = self.index2word[index].lower() if case_insensitive else self.index2word[index]
+                    predicted = self.index2word[index].upper() if case_insensitive else self.index2word[index]
                     if predicted in ok_vocab and predicted not in ignore:
                         if predicted != expected:
                             logger.debug("%s: expected %s, predicted %s", line.strip(), expected, predicted)

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1586,7 +1586,6 @@ class Word2Vec(utils.SaveLoad):
         """
         ok_vocab = [(w, self.vocab[w]) for w in self.index2word[:restrict_vocab]]
         ok_vocab = dict((w.lower(), v) for w, v in reversed(ok_vocab)) if case_insensitive else dict(ok_vocab)
-        ok_index = set(v.index for v in itervalues(ok_vocab))
 
         sections, section = [], None
         for line_no, line in enumerate(utils.smart_open(questions)):
@@ -1615,14 +1614,14 @@ class Word2Vec(utils.SaveLoad):
 
                 original_vocab = self.vocab
                 self.vocab = ok_vocab
-                ignore = set(self.vocab[v].index for v in [a, b, c])  # indexes of words to ignore
+                ignore = set([a, b, c])  # input words to be ignored
                 predicted = None
                 # find the most likely prediction, ignoring OOV words and input words
                 sims = most_similar(self, positive=[b, c], negative=[a], topn=False, restrict_vocab=restrict_vocab)
                 self.vocab = original_vocab
                 for index in matutils.argsort(sims, reverse=True):
-                    if index in ok_index and index not in ignore:
-                        predicted = self.index2word[index].lower() if case_insensitive else self.index2word[index]
+                    predicted = self.index2word[index].lower() if case_insensitive else self.index2word[index]
+                    if predicted in ok_vocab and predicted not in ignore:
                         if predicted != expected:
                             logger.debug("%s: expected %s, predicted %s", line.strip(), expected, predicted)
                         break

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1586,7 +1586,7 @@ class Word2Vec(utils.SaveLoad):
                                key=lambda item: -item[1].count)[:restrict_vocab])
         ok_index = set(v.index for v in itervalues(ok_vocab))
         if case_insensitive:
-            ok_vocab = {w.lower(): v for w, v in iteritems(ok_vocab)}
+            ok_vocab = dict((w.lower(), v) for w, v in iteritems(ok_vocab))
 
         sections, section = [], None
         for line_no, line in enumerate(utils.smart_open(questions)):


### PR DESCRIPTION
Related to #714 

Quick PR to get some feedback. Also, should we have tests for this? There aren't any currently, which seems fine to me since `accuracy` is an informal evaluation metric rather than basic functionality

A couple of concerns mentioned as comments 

