### PR TITLE
Update dtmmodel.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changes
 * Implemented LsiModel.docs_processed attribute
 * Added LdaMallet support. Added LdaVowpalWabbit, LdaMallet example to notebook. Added test suite for coherencemodel and aggregation.
   Added `topics` parameter to coherencemodel. Can now provide tokenized topics to calculate coherence value (@dsquareindia, #750)
-* Added a check for empty (no words) documents before starting to run the DTM wrapper if model = "fixed" is used (DIM model) as this    causes the an error when such documents are reached in training. (@eickho #806)
+* Added a check for empty (no words) documents before starting to run the DTM wrapper if model = "fixed" is used (DIM model) as this    causes the an error when such documents are reached in training. (@eickho, #806)
 
 0.13.1, 2016-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Changes
 * Implemented LsiModel.docs_processed attribute
 * Added LdaMallet support. Added LdaVowpalWabbit, LdaMallet example to notebook. Added test suite for coherencemodel and aggregation.
   Added `topics` parameter to coherencemodel. Can now provide tokenized topics to calculate coherence value (@dsquareindia, #750)
-* Added a check for empty (no words) documents before starting to run the DTM wrapper if model = "fixed" is used (DIM model) as this    causes the an error when such documents are reached in training.
+* Added a check for empty (no words) documents before starting to run the DTM wrapper if model = "fixed" is used (DIM model) as this    causes the an error when such documents are reached in training. (@eickho #806)
+
 0.13.1, 2016-06-22
 
 * Topic coherence C_v and U_mass (@dsquareindia, #710)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changes
 * Implemented LsiModel.docs_processed attribute
 * Added LdaMallet support. Added LdaVowpalWabbit, LdaMallet example to notebook. Added test suite for coherencemodel and aggregation.
   Added `topics` parameter to coherencemodel. Can now provide tokenized topics to calculate coherence value (@dsquareindia, #750)
-
+* Added a check for empty (no words) documents before starting to run the DTM wrapper if model = "fixed" is used (DIM model) as this    causes the an error when such documents are reached in training.
 0.13.1, 2016-06-22
 
 * Topic coherence C_v and U_mass (@dsquareindia, #710)

--- a/gensim/models/wrappers/dtmmodel.py
+++ b/gensim/models/wrappers/dtmmodel.py
@@ -93,7 +93,7 @@ class DtmModel(utils.SaveLoad):
             lencorpus = sum(1 for _ in corpus)
         if lencorpus == 0:
             raise ValueError("cannot compute DTM over an empty corpus")
-        if any([i == 0 for i in [len(text) for text in corpus.get_texts()]]):
+        if any([i == 0 for i in [len(text) for text in corpus.get_texts()]]) and model == "fixed:
             raise ValueError("""There is a text without words in the input corpus.
                     This breaks method='fixed' (The DIM model).""")
         if lencorpus != sum(time_slices):

--- a/gensim/models/wrappers/dtmmodel.py
+++ b/gensim/models/wrappers/dtmmodel.py
@@ -93,7 +93,7 @@ class DtmModel(utils.SaveLoad):
             lencorpus = sum(1 for _ in corpus)
         if lencorpus == 0:
             raise ValueError("cannot compute DTM over an empty corpus")
-        if any([i == 0 for i in [len(text) for text in corpus.get_texts()]]) and model == "fixed:
+        if model == "fixed" and any([i == 0 for i in [len(text) for text in corpus.get_texts()]]):
             raise ValueError("""There is a text without words in the input corpus.
                     This breaks method='fixed' (The DIM model).""")
         if lencorpus != sum(time_slices):

--- a/gensim/models/wrappers/dtmmodel.py
+++ b/gensim/models/wrappers/dtmmodel.py
@@ -93,6 +93,9 @@ class DtmModel(utils.SaveLoad):
             lencorpus = sum(1 for _ in corpus)
         if lencorpus == 0:
             raise ValueError("cannot compute DTM over an empty corpus")
+        if any([i == 0 for i in [len(text) for text in corpus.get_texts()]]):
+            raise ValueError("""There is a text without words in the input corpus.
+                    This breaks method='fixed' (The DIM model).""")
         if lencorpus != sum(time_slices):
             raise ValueError("mismatched timeslices %{slices} for corpus of len {clen}".format(
                 slices=sum(time_slices), clen=lencorpus))


### PR DESCRIPTION
Adds a check if any documents in the supplied corpus are empty, which breaks the DIM model without providing a usable error description to the user. It should be noted that this _only_ seems to cause errors with the DIM model and not the DTM model. However, I don't think there is any upside to having empty documents in the DTM anyway?