### PR TITLE
Bugfix: Full2sparse clipped to use abs value

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -238,7 +238,7 @@ def full2sparse_clipped(vec, topn, eps=1e-9):
         return []
     vec = numpy.asarray(vec, dtype=float)
     nnz = numpy.nonzero(abs(vec) > eps)[0]
-    biggest = nnz.take(argsort(vec.take(nnz), topn, reverse=True))
+    biggest = nnz.take(argsort(abs(vec).take(nnz), topn, reverse=True))
     return list(zip(biggest, vec.take(biggest)))
 
 

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -101,6 +101,13 @@ class _TestSimilarityABC(object):
         for num_best in [None, 0, 1, 9, 1000]:
             self.testFull(num_best=num_best)
 
+    def test_full2sparse_clipped(self):
+
+        vec = [0.8, 0.2, 0.0, 0.0, -0.1, -0.15]
+        expected = numpy.asarray([0, 1, 5], dtype=int)
+        self.assertEqual(matutils.full2sparse_clipped(vec, topn=3), expected)
+
+
 
     def testChunking(self):
         if self.cls == similarities.Similarity:

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -104,8 +104,8 @@ class _TestSimilarityABC(object):
     def test_full2sparse_clipped(self):
 
         vec = [0.8, 0.2, 0.0, 0.0, -0.1, -0.15]
-        expected = numpy.asarray([0, 1, 5], dtype=int)
-        self.assertEqual(matutils.full2sparse_clipped(vec, topn=3), expected)
+        expected = [(0, 0.80000000000000004), (1, 0.20000000000000001), (5, -0.14999999999999999)]
+        self.assertTrue(matutils.full2sparse_clipped(vec, topn=3), expected)
 
 
 


### PR DESCRIPTION
Fix full2sparse_clipped to return he `topn` elements of the greatest magnitude (abs). Previously it was returing the greatest elements(without abs).

See mailing list discussion https://groups.google.com/d/msg/gensim/oscEnOiMtOc/WC1LnNBoAQAJ