### PR TITLE
Small error on Doc2vec notebook tutorial 

### DIFF
--- a/docs/notebooks/doc2vec-lee.ipynb
+++ b/docs/notebooks/doc2vec-lee.ipynb
@@ -513,7 +513,7 @@
     "sims = model.docvecs.most_similar([inferred_vector], topn=len(model.docvecs))\n",
     "\n",
     "# Compare and print the most/median/least similar documents from the train corpus\n",
-    "print('Test Document ({}): «{}»\\n'.format(doc_id, ' '.join(train_corpus[doc_id].words)))\n",
+    "print('Test Document ({}): «{}»\\n'.format(doc_id, ' '.join(test_corpus[doc_id])))\n",
     "print(u'SIMILAR/DISSIMILAR DOCS PER MODEL %s:\\n' % model)\n",
     "for label, index in [('MOST', 0), ('MEDIAN', len(sims)//2), ('LEAST', len(sims) - 1)]:\n",
     "    print(u'%s %s: «%s»\\n' % (label, sims[index], ' '.join(train_corpus[sims[index][0]].words)))"


### PR DESCRIPTION
I have just corrected a small error,
In the current version of the notebook, in the last box it prints  document from train corpus instead of test corpus,
Now the document that should appears when printing is the one from the test corpus,
Best regards,