### PR TITLE
new options for load/intersect_word2vec_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changes
 =======
-0.13.2
+
+0.13.2, TBD
 
 * wordtopics has changed to word_topics in ldamallet, and fixed issue #764. (@bhargavvader, #771) 
   - assigning wordtopics value of word_topics to keep backward compatibility, for now
@@ -11,6 +12,7 @@ Changes
 * Implemented LsiModel.docs_processed attribute
 * Added LdaMallet support. Added LdaVowpalWabbit, LdaMallet example to notebook. Added test suite for coherencemodel and aggregation.
   Added `topics` parameter to coherencemodel. Can now provide tokenized topics to calculate coherence value (@dsquareindia, #750)
+* New parameters `limit`, `datatype` for load_word2vec_format(); `lockf` for intersect_word2vec_format (@gojomo, #817)
 
 0.13.1, 2016-06-22
 

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1730,7 +1730,8 @@ class Text8Corpus(object):
             while True:
                 text = rest + fin.read(8192)  # avoid loading the entire file (=1 line) into RAM
                 if text == rest:  # EOF
-                    sentence.extend(rest.split())  # return the last chunk of words, too (may be shorter/longer)
+                    words = utils.to_unicode(text).split()
+                    sentence.extend(words)  # return the last chunk of words, too (may be shorter/longer)
                     if sentence:
                         yield sentence
                     break

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1190,7 +1190,7 @@ class Word2Vec(utils.SaveLoad):
                     if word in self.vocab:
                         overlap_count += 1
                         self.syn0[self.vocab[word].index] = weights
-                        self.syn0_lockf[self.vocab[word].index] = lockf  # lock-factor: 0.0 stopss further changes
+                        self.syn0_lockf[self.vocab[word].index] = lockf  # lock-factor: 0.0 stops further changes
             else:
                 for line_no, line in enumerate(fin):
                     parts = utils.to_unicode(line.rstrip(), encoding=encoding, errors=unicode_errors).split(" ")

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1153,7 +1153,7 @@ class Word2Vec(utils.SaveLoad):
         logger.info("loaded %s matrix from %s" % (result.syn0.shape, fname))
         return result
 
-    def intersect_word2vec_format(self, fname, binary=False, encoding='utf8', unicode_errors='strict'):
+    def intersect_word2vec_format(self, fname, lockf=0.0, binary=False, encoding='utf8', unicode_errors='strict'):
         """
         Merge the input-hidden weight matrix from the original C word2vec-tool format
         given, where it intersects with the current vocabulary. (No words are added to the
@@ -1161,6 +1161,10 @@ class Word2Vec(utils.SaveLoad):
         non-intersecting words are left alone.)
 
         `binary` is a boolean indicating whether the data is in binary word2vec format.
+
+        `lockf` is a lock-factor value to be set for any imported word-vectors; the
+        default value of 0.0 prevents further updating of the vector during subsequent
+        training. Use 1.0 to allow further training updates of merged vectors.
         """
         overlap_count = 0
         logger.info("loading projection weights from %s" % (fname))
@@ -1186,7 +1190,7 @@ class Word2Vec(utils.SaveLoad):
                     if word in self.vocab:
                         overlap_count += 1
                         self.syn0[self.vocab[word].index] = weights
-                        self.syn0_lockf[self.vocab[word].index] = 0.0  # lock it
+                        self.syn0_lockf[self.vocab[word].index] = lockf  # lock-factor: 0.0 stopss further changes
             else:
                 for line_no, line in enumerate(fin):
                     parts = utils.to_unicode(line.rstrip(), encoding=encoding, errors=unicode_errors).split(" ")

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1098,7 +1098,7 @@ class Word2Vec(utils.SaveLoad):
             header = utils.to_unicode(fin.readline(), encoding=encoding)
             vocab_size, vector_size = map(int, header.split())  # throws for invalid file format
             if limit:
-                vocab_size = limit
+                vocab_size = min(vocab_size, limit)
             result = cls(size=vector_size)
             result.syn0 = zeros((vocab_size, vector_size), dtype=datatype)
 
@@ -1129,6 +1129,8 @@ class Word2Vec(utils.SaveLoad):
                         ch = fin.read(1)
                         if ch == b' ':
                             break
+                        if ch == b'':
+                            raise EOFError("unexpected end of input; is count incorrect or file otherwise damaged?")
                         if ch != b'\n':  # ignore newlines in front of words (some binary files have)
                             word.append(ch)
                     word = utils.to_unicode(b''.join(word), encoding=encoding, errors=unicode_errors)
@@ -1137,6 +1139,8 @@ class Word2Vec(utils.SaveLoad):
             else:
                 for line_no in xrange(vocab_size):
                     line = fin.readline()
+                    if line == b'':
+                        raise EOFError("unexpected end of input; is count incorrect or file otherwise damaged?")
                     parts = utils.to_unicode(line.rstrip(), encoding=encoding, errors=unicode_errors).split(" ")
                     if len(parts) != vector_size + 1:
                         raise ValueError("invalid vector on line %s (is this really the text format?)" % (line_no))

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -110,10 +110,30 @@ class TestWord2VecModel(unittest.TestCase):
         norm_only_model.init_sims(replace=True)
         self.assertFalse(numpy.allclose(model['human'], norm_only_model['human']))
         self.assertTrue(numpy.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human']))
-        truncated_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, limit=3)
-        self.assertEquals(len(truncated_model.syn0), 3)
+        limited_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, limit=3)
+        self.assertEquals(len(limited_model.syn0), 3)
         half_precision_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, datatype=numpy.float16)
         self.assertEquals(binary_model.syn0.nbytes, half_precision_model.syn0.nbytes * 2)
+
+    def testTooShortBinaryWord2VecFormat(self):
+        tfile = testfile()
+        model = word2vec.Word2Vec(sentences, min_count=1)
+        model.init_sims()
+        model.save_word2vec_format(tfile, binary=True)
+        f = open(tfile, 'r+b')
+        f.write(b'13')  # write wrong (too-long) vector count
+        f.close()
+        self.assertRaises(EOFError, word2vec.Word2Vec.load_word2vec_format, tfile, binary=True)
+
+    def testTooShortTextWord2VecFormat(self):
+        tfile = testfile()
+        model = word2vec.Word2Vec(sentences, min_count=1)
+        model.init_sims()
+        model.save_word2vec_format(tfile, binary=False)
+        f = open(tfile, 'r+b')
+        f.write(b'13')  # write wrong (too-long) vector count
+        f.close()
+        self.assertRaises(EOFError, word2vec.Word2Vec.load_word2vec_format, tfile, binary=False)
 
     def testPersistenceWord2VecFormatNonBinary(self):
         """Test storing/loading the entire model in word2vec non-binary format."""

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -110,6 +110,10 @@ class TestWord2VecModel(unittest.TestCase):
         norm_only_model.init_sims(replace=True)
         self.assertFalse(numpy.allclose(model['human'], norm_only_model['human']))
         self.assertTrue(numpy.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human']))
+        truncated_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, limit=3)
+        self.assertEquals(len(truncated_model.syn0), 3)
+        half_precision_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, datatype=numpy.float16)
+        self.assertEquals(binary_model.syn0.nbytes, half_precision_model.syn0.nbytes * 2)
 
     def testPersistenceWord2VecFormatNonBinary(self):
         """Test storing/loading the entire model in word2vec non-binary format."""


### PR DESCRIPTION
load_word2vec_format:
* `limit` to only read 1st N vectors from file 
* `datatype` to force smaller datatype (risky/slow but can save memory)

intersect_word2vec_format:
* `lockf` argument to set whether imported vectors are locked-against-changes (0.0) or not (1.0)

also: tiny fix in Text8Corpus, ensuring final chunk fragment gets same unicode-treatment as all other created-lines.