### PR TITLE
Fix failing testRandomState()

### DIFF
--- a/gensim/test/test_ldamodel.py
+++ b/gensim/test/test_ldamodel.py
@@ -52,7 +52,6 @@ def testRandomState():
     testcases = [numpy.random.seed(0), None, numpy.random.RandomState(0), 0]
     for testcase in testcases:
         assert(isinstance(ldamodel.get_random_state(testcase), numpy.random.RandomState))
-        assertEqual(ldamodel.get_random_state(testcase), numpy.random.RandomState(0))
 
 class TestLdaModel(unittest.TestCase):
     def setUp(self):

--- a/gensim/test/test_ldamodel.py
+++ b/gensim/test/test_ldamodel.py
@@ -48,6 +48,12 @@ def testfile():
     return os.path.join(tempfile.gettempdir(), 'gensim_models.tst')
 
 
+def testRandomState():
+    testcases = [numpy.random.seed(0), None, numpy.random.RandomState(0), 0]
+    for testcase in testcases:
+        assert(isinstance(ldamodel.get_random_state(testcase), numpy.random.RandomState))
+        assertEqual(ldamodel.get_random_state(testcase), numpy.random.RandomState(0))
+
 class TestLdaModel(unittest.TestCase):
     def setUp(self):
         self.corpus = mmcorpus.MmCorpus(datapath('testcorpus.mm'))
@@ -423,12 +429,6 @@ class TestLdaModel(unittest.TestCase):
 
         # test loading the large model arrays with mmap
         self.assertRaises(IOError, self.class_.load, fname, mmap='r')
-
-    def testRandomState(self):
-        testcases = [numpy.random.seed(0), None, numpy.random.RandomState(0), 0]
-        for testcase in testcases:
-            assert (isinstance(ldamodel.get_random_state(testcase), numpy.random.RandomState))
-            self.assertEqual(ldamodel.get_random_state(testcase), numpy.random.RandomState(0))
 
 #endclass TestLdaModel
 

--- a/gensim/test/test_ldamodel.py
+++ b/gensim/test/test_ldamodel.py
@@ -48,12 +48,6 @@ def testfile():
     return os.path.join(tempfile.gettempdir(), 'gensim_models.tst')
 
 
-def testRandomState():
-    testcases = [numpy.random.seed(0), None, numpy.random.RandomState(0), 0]
-    for testcase in testcases:
-        assert(isinstance(ldamodel.get_random_state(testcase), numpy.random.RandomState))
-        assertEqual(ldamodel.get_random_state(testcase), numpy.random.RandomState(0))
-
 class TestLdaModel(unittest.TestCase):
     def setUp(self):
         self.corpus = mmcorpus.MmCorpus(datapath('testcorpus.mm'))
@@ -429,6 +423,12 @@ class TestLdaModel(unittest.TestCase):
 
         # test loading the large model arrays with mmap
         self.assertRaises(IOError, self.class_.load, fname, mmap='r')
+
+    def testRandomState(self):
+        testcases = [numpy.random.seed(0), None, numpy.random.RandomState(0), 0]
+        for testcase in testcases:
+            assert (isinstance(ldamodel.get_random_state(testcase), numpy.random.RandomState))
+            self.assertEqual(ldamodel.get_random_state(testcase), numpy.random.RandomState(0))
 
 #endclass TestLdaModel
 


### PR DESCRIPTION
`numpy.random.RandomState(0) ==  numpy.random.RandomState(0)` returns `False` so the test was failing. 