### PR TITLE
Added save/load functionality to AnnoyIndexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changes
 =======
 
+* Added Save/Load interface to AnnoyIndexer for ondex persistence (@fortiema, [#845](https://github.com/RaRe-Technologies/gensim/pull/845))
+
 0.13.2, 2016-08-19
 
 * wordtopics has changed to word_topics in ldamallet, and fixed issue #764. (@bhargavvader, [#771](https://github.com/RaRe-Technologies/gensim/pull/771)) 

--- a/docs/notebooks/annoytutorial.ipynb
+++ b/docs/notebooks/annoytutorial.ipynb
@@ -279,6 +279,56 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Persisting Indexes\n",
+    "You can save and load your indexes from/to disk to prevent having to construct them each time. This will create two files on disk, _fname_ and _fname.d_. Both files are needed to correctly restore all attributes. Before loading an index, you will have to create an empty AnnoyIndexer object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "fname = 'index'\n",
+    "\n",
+    "# Persist index to disk\n",
+    "annoy_index.save(fname)\n",
+    "\n",
+    "# Load index back\n",
+    "if os.path.exists(fname):\n",
+    "    annoy_index2 = AnnoyIndexer()\n",
+    "    annoy_index2.load(fname)\n",
+    "    annoy_index2.model = model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Results should be identical to above\n",
+    "vector = model[\"army\"]\n",
+    "approximate_neighbors = model.most_similar([vector], topn=5, indexer=annoy_index2)\n",
+    "for neighbor in approximate_neighbors:\n",
+    "    print neighbor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Be sure to use the same model at load that was used originally, otherwise you will get unexpected behaviors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Relationship between num_trees and initialization time"
    ]
   },
@@ -378,21 +428,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11+"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/gensim/similarities/index.py
+++ b/gensim/similarities/index.py
@@ -45,8 +45,8 @@ class AnnoyIndexer(object):
     def load(self, fname):
         fname_dict = fname+'.d'
         if not (os.path.exists(fname) and os.path.exists(fname_dict)):
-            raise IOError("Can't find index files '{}' and '{}' - Unable to restore AnnoyIndexer state."
-                          .format(fname, fname_dict))
+            raise IOError(
+                "Can't find index files '%s' and '%s' - Unable to restore AnnoyIndexer state." % (fname, fname_dict))
         else:
             with smart_open(fname_dict) as f:
                 d = _pickle.loads(f.read())

--- a/gensim/similarities/index.py
+++ b/gensim/similarities/index.py
@@ -20,6 +20,8 @@ except ImportError:
 class AnnoyIndexer(object):
 
     def __init__(self, model=None, num_trees=None):
+        self.index = None
+        self.labels = None
         self.model = model
         self.num_trees = num_trees
 
@@ -37,7 +39,7 @@ class AnnoyIndexer(object):
         pickle.dump(d, open(fname+'.d', 'wb'), 2)
 
     def load(self, fname):
-        if os.path.exists(fname):
+        if os.path.exists(fname) and os.path.exists(fname+'.d'):
             d = pickle.load(open(fname+'.d', 'rb'))
             self.num_trees = d['num_trees']
             self.index = AnnoyIndex(d['f'])

--- a/gensim/similarities/index.py
+++ b/gensim/similarities/index.py
@@ -19,7 +19,7 @@ except ImportError:
 
 class AnnoyIndexer(object):
 
-    def __init__(self, model, num_trees):
+    def __init__(self, model=None, num_trees=None):
         self.model = model
         self.num_trees = num_trees
 
@@ -33,12 +33,13 @@ class AnnoyIndexer(object):
 
     def save(self, fname):
         self.index.save(fname)
-        d = {'f': self.model.vector_size, 'labels': self.labels}
+        d = {'f': self.model.vector_size, 'num_trees': self.num_trees, 'labels': self.labels}
         pickle.dump(d, open(fname+'.d', 'wb'), 2)
 
     def load(self, fname):
         if os.path.exists(fname):
             d = pickle.load(open(fname+'.d', 'rb'))
+            self.num_trees = d['num_trees']
             self.index = AnnoyIndex(d['f'])
             self.index.load(fname)
             self.labels = d['labels']

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -473,7 +473,7 @@ class TestWord2VecAnnoyIndexer(unittest.TestCase):
         from gensim.similarities.index import AnnoyIndexer
         self.test_index = AnnoyIndexer()
 
-        self.assertRaises(IOError, self.test_index.load, 'test-index')
+        self.assertRaises(IOError, self.test_index.load, fname='test-index')
 
     def testSaveLoad(self):
         from gensim.similarities.index import AnnoyIndexer
@@ -530,7 +530,7 @@ class TestDoc2VecAnnoyIndexer(unittest.TestCase):
         from gensim.similarities.index import AnnoyIndexer
         self.test_index = AnnoyIndexer()
 
-        self.assertRaises(IOError, self.test_index.load, 'test-index')
+        self.assertRaises(IOError, self.test_index.load, fname='test-index')
 
     def testSaveLoad(self):
         from gensim.similarities.index import AnnoyIndexer

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -464,6 +464,23 @@ class TestWord2VecAnnoyIndexer(unittest.TestCase):
 
         self.assertEqual(approx_words, exact_words)
 
+    def testSave(self):
+        self.index.save('index')
+        self.assertTrue(os.path.exists('index'))
+
+    def testSaveLoad(self):
+        from gensim.similarities.index import AnnoyIndexer
+
+        self.index.save('index')
+
+        self.index2 = AnnoyIndexer()
+        self.index2.load('index')
+        self.index2.model = self.model
+
+        self.assertEqual(self.index.index.f, self.index2.index.f)
+        self.assertEqual(self.index.labels, self.index2.labels)
+        self.assertEqual(self.index.num_trees, self.index2.num_trees)
+
 
 class TestDoc2VecAnnoyIndexer(unittest.TestCase):
 
@@ -496,6 +513,23 @@ class TestDoc2VecAnnoyIndexer(unittest.TestCase):
         exact_words = [neighbor[0] for neighbor in exact_neighbors]
 
         self.assertEqual(approx_words, exact_words)
+
+    def testSave(self):
+        self.index.save('index')
+        self.assertTrue(os.path.exists('index'))
+
+    def testSaveLoad(self):
+        from gensim.similarities.index import AnnoyIndexer
+
+        self.index.save('index')
+
+        self.index2 = AnnoyIndexer()
+        self.index2.load('index')
+        self.index2.model = self.model
+
+        self.assertEqual(self.index.index.f, self.index2.index.f)
+        self.assertEqual(self.index.labels, self.index2.labels)
+        self.assertEqual(self.index.num_trees, self.index2.num_trees)
 
 
 if __name__ == '__main__':

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -473,8 +473,7 @@ class TestWord2VecAnnoyIndexer(unittest.TestCase):
         from gensim.similarities.index import AnnoyIndexer
         self.test_index = AnnoyIndexer()
 
-        with self.assertRaises(IOError):
-            self.test_index.load('test-index')
+        self.assertRaises(IOError, self.test_index.load, 'test-index')
 
     def testSaveLoad(self):
         from gensim.similarities.index import AnnoyIndexer
@@ -531,8 +530,7 @@ class TestDoc2VecAnnoyIndexer(unittest.TestCase):
         from gensim.similarities.index import AnnoyIndexer
         self.test_index = AnnoyIndexer()
 
-        with self.assertRaises(IOError):
-            self.test_index.load('test-index')
+        self.assertRaises(IOError, self.test_index.load, 'test-index')
 
     def testSaveLoad(self):
         from gensim.similarities.index import AnnoyIndexer

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -472,10 +472,9 @@ class TestWord2VecAnnoyIndexer(unittest.TestCase):
     def testLoadNotExist(self):
         from gensim.similarities.index import AnnoyIndexer
         self.test_index = AnnoyIndexer()
-        self.test_index.load('test-index')
 
-        self.assertEqual(self.test_index.index, None)
-        self.assertEqual(self.test_index.labels, None)
+        with self.assertRaises(IOError):
+            self.test_index.load('test-index')
 
     def testSaveLoad(self):
         from gensim.similarities.index import AnnoyIndexer
@@ -531,10 +530,9 @@ class TestDoc2VecAnnoyIndexer(unittest.TestCase):
     def testLoadNotExist(self):
         from gensim.similarities.index import AnnoyIndexer
         self.test_index = AnnoyIndexer()
-        self.test_index.load('test-index')
 
-        self.assertEqual(self.test_index.index, None)
-        self.assertEqual(self.test_index.labels, None)
+        with self.assertRaises(IOError):
+            self.test_index.load('test-index')
 
     def testSaveLoad(self):
         from gensim.similarities.index import AnnoyIndexer

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -467,6 +467,15 @@ class TestWord2VecAnnoyIndexer(unittest.TestCase):
     def testSave(self):
         self.index.save('index')
         self.assertTrue(os.path.exists('index'))
+        self.assertTrue(os.path.exists('index.d'))
+
+    def testLoadNotExist(self):
+        from gensim.similarities.index import AnnoyIndexer
+        self.test_index = AnnoyIndexer()
+        self.test_index.load('test-index')
+
+        self.assertEqual(self.test_index.index, None)
+        self.assertEqual(self.test_index.labels, None)
 
     def testSaveLoad(self):
         from gensim.similarities.index import AnnoyIndexer
@@ -517,6 +526,15 @@ class TestDoc2VecAnnoyIndexer(unittest.TestCase):
     def testSave(self):
         self.index.save('index')
         self.assertTrue(os.path.exists('index'))
+        self.assertTrue(os.path.exists('index.d'))
+
+    def testLoadNotExist(self):
+        from gensim.similarities.index import AnnoyIndexer
+        self.test_index = AnnoyIndexer()
+        self.test_index.load('test-index')
+
+        self.assertEqual(self.test_index.index, None)
+        self.assertEqual(self.test_index.labels, None)
 
     def testSaveLoad(self):
         from gensim.similarities.index import AnnoyIndexer


### PR DESCRIPTION
Having Annoy integrated directly into gensim is really great, but one feature that I was personally missing is the ability to save/load indexes. I am working with indexes in the 10s of GB and having to recreate them every time I run my code is a waste of time.

So I added a simple save/load interface that is similar to Annoy.

For example this code:
```python
fname = 'index'
if os.path.exists(fname):
    self.index_en = AnnoyIndexer()
    self.index_en.load(fname)
    self.index_en.model = model
else:
    self.index_en = AnnoyIndexer(model, 1)
    self.index_en.save(fname)
```

Will create 2 files, _index_ and _index.d_. Both files must be present when using the `load` function, otherwise nothing happens.

For this to work, I also added a if case in the constructor to allow for object creation without passing _model_ and _num_trees_.

try/except on import and using pickle protocol v2 to stay 2-3 compatible.

All comments and suggestions are welcome.