### PR TITLE
Process cross index queries in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changes
 
 Unreleased:
 
+* Process cross index queries in parallel (@shubhamchaudhary, [#854](https://github.com/RaRe-Technologies/gensim/pull/854)
+
 
 ========
 1.0.1, 2017-03-03

--- a/gensim/similarities/docsim.py
+++ b/gensim/similarities/docsim.py
@@ -394,11 +394,12 @@ class Similarity(interfaces.SimilarityABC):
 
         import multiprocessing
         import functools
-        with multiprocessing.Pool() as pool:
-            worker = functools.partial(_query_chunk_worker, index=self)
-            for result in pool.map(worker, self.iter_chunks()):
-                for sim in result:
-                    yield sim
+        pool = multiprocessing.Pool()
+        worker = functools.partial(_query_chunk_worker, index=self)
+        for result in pool.map(worker, self.iter_chunks()):
+            for sim in result:
+                yield sim
+        pool.terminate()
 
         self.norm = norm  # restore normalization
 


### PR DESCRIPTION
This reduced the processing time from 10hrs to less than 2hrs on a machine with 24 cores (100Gig RAM) and a dataset of size ~635,000. 

<img width="1070" alt="screen shot 2017-03-07 at 1 38 29 am" src="https://cloud.githubusercontent.com/assets/3508878/23627444/d29ee654-02d6-11e7-95e9-2edeb4a14abd.png">

