### PR TITLE
CoherenceModel documentation addition

### DIFF
--- a/gensim/models/coherencemodel.py
+++ b/gensim/models/coherencemodel.py
@@ -92,6 +92,8 @@ class CoherenceModel(interfaces.TransformationABC):
         Args:
         ----
         model : Pre-trained topic model. Should be provided if topics is not provided.
+                Currently supports LdaModel, LdaMallet wrapper and LdaVowpalWabbit wrapper. Use 'topics'
+                parameter to plug in an as yet unsupported model.
         topics : List of tokenized topics. If this is preferred over model, dictionary should be provided.
                  eg. topics = [['human', 'machine', 'computer', 'interface'],
                                ['graph', 'trees', 'binary', 'widths']]


### PR DESCRIPTION
`CoherenceModel` documentation should mention which topic models can currently be plugged in as they are without using the `topics` parameter.