### PR TITLE
Remove reference to GPL as Hoffman's code is no longer there

### DIFF
--- a/gensim/models/hdpmodel.py
+++ b/gensim/models/hdpmodel.py
@@ -8,9 +8,6 @@
 # Chong Wang (chongw at cs.princeton.edu).
 # http://www.cs.princeton.edu/~chongw/software/onlinehdp.tar.gz
 #
-# Some show/print topics code is adapted from Dr. Hoffman's online lda sample code,
-# (C) 2010  Matthew D. Hoffman, GNU GPL 3.0
-# http://www.cs.princeton.edu/~mdhoffma/code/onlineldavb.tar
 
 
 """

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -4,8 +4,6 @@
 # Copyright (C) 2011 Radim Rehurek <radimrehurek@seznam.cz>
 # Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
 #
-# Parts of the LDA inference code come from Dr. Hoffman's `onlineldavb.py` script,
-# (C) 2010  Matthew D. Hoffman, GNU GPL 3.0
 
 
 """


### PR DESCRIPTION
Affects HDP and LDA models.

BTW Hoffman's code was released under BSD for scikitlearn.