### PR TITLE
Quick Start improvement: print dictionary before print bow to explain what indices are in bag of words

### DIFF
--- a/docs/notebooks/gensim Quick Start.ipynb
+++ b/docs/notebooks/gensim Quick Start.ipynb
@@ -115,7 +115,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dictionary(12 unique tokens: ['minors', 'interface', 'response', 'time', 'eps']...)\n"
+      "Dictionary(12 unique tokens: [u'minors', u'graph', u'system', u'trees', u'eps']...)\n"
      ]
     }
    ],
@@ -152,12 +152,31 @@
    },
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{u'minors': 11, u'graph': 10, u'system': 6, u'trees': 9, u'eps': 8, u'computer': 1, u'survey': 5, u'user': 7, u'human': 2, u'time': 4, u'interface': 0, u'response': 3}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dictionary.token2id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
      "data": {
       "text/plain": [
-       "[(0, 1), (2, 1)]"
+       "[(1, 1), (2, 1)]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -173,25 +192,6 @@
    "metadata": {},
    "source": [
     "The first entry in each tuple corresponds to the ID of the token in the dictionary, the second corresponds to the count of this token. We can see what these IDs correspond to:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'minors': 11, 'interface': 1, 'response': 4, 'time': 7, 'eps': 8, 'computer': 2, 'survey': 3, 'human': 0, 'graph': 10, 'system': 5, 'user': 6, 'trees': 9}\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(dictionary.token2id)"
    ]
   },
   {
@@ -214,14 +214,14 @@
      "data": {
       "text/plain": [
        "[[(0, 1), (1, 1), (2, 1)],\n",
-       " [(2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1)],\n",
-       " [(1, 1), (5, 1), (6, 1), (8, 1)],\n",
-       " [(0, 1), (5, 2), (8, 1)],\n",
-       " [(4, 1), (6, 1), (7, 1)],\n",
+       " [(1, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1)],\n",
+       " [(0, 1), (6, 1), (7, 1), (8, 1)],\n",
+       " [(2, 1), (6, 2), (8, 1)],\n",
+       " [(3, 1), (4, 1), (7, 1)],\n",
        " [(9, 1)],\n",
        " [(9, 1), (10, 1)],\n",
        " [(9, 1), (10, 1), (11, 1)],\n",
-       " [(3, 1), (10, 1), (11, 1)]]"
+       " [(5, 1), (10, 1), (11, 1)]]"
       ]
      },
      "execution_count": 6,
@@ -259,7 +259,7 @@
     {
      "data": {
       "text/plain": [
-       "[(5, 0.5898341626740045), (11, 0.8075244024440723)]"
+       "[(6, 0.5898341626740045), (11, 0.8075244024440723)]"
       ]
      },
      "execution_count": 7,
@@ -287,21 +287,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/gensim Quick Start.ipynb
+++ b/docs/notebooks/gensim Quick Start.ipynb
@@ -141,7 +141,7 @@
     "\n",
     "To infer the latent structure in our corpus we need a way to represent documents that we can manipulate mathematically. One approach is to represent each document as a vector. There are various approachs for creating a vector representation of a document but a simple example is the *bag-of-words model*. Under the bag-of-words model each document is represented by a vector containing the frequency counts of each word in the dictionary. For example, given a dictionary containing the words `['coffee', 'milk', 'sugar', 'spoon']` a document consisting of the string `\"coffee milk coffee\"` could be represented by the vector `[2, 1, 0, 0]` where the entries of the vector are (in order) the occurrences of \"coffee\", \"milk\", \"sugar\" and \"spoon\" in the document. The length of the vector is the number of entries in the dictionary. One of the main properties of the bag-of-words model is that it completely ignores the order of the tokens in the document that is encoded, which is where the name bag-of-words comes from.\n",
     "\n",
-    "Our processed corpus has 12 unique words in it, which means that each document will be represented by a 12-dimensional vector under the bag-of-words model. We can use the dictionary to turn tokenized documents into these 12-dimensional vectors. For example, suppose we wanted to vectorize the phrase \"Human computer interaction\" (note that this phrase was not in our original corpus). We can create the bag-of-word representation for a document using the `doc2bow` method of the dictionary, which returns a sparse representation of the word counts:"
+    "Our processed corpus has 12 unique words in it, which means that each document will be represented by a 12-dimensional vector under the bag-of-words model. We can use the dictionary to turn tokenized documents into these 12-dimensional vectors. We can see what these IDs correspond to:"
    ]
   },
   {
@@ -161,6 +161,13 @@
    ],
    "source": [
     "print(dictionary.token2id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, suppose we wanted to vectorize the phrase \"Human computer interaction\" (note that this phrase was not in our original corpus). We can create the bag-of-word representation for a document using the `doc2bow` method of the dictionary, which returns a sparse representation of the word counts:"
    ]
   },
   {
@@ -191,7 +198,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The first entry in each tuple corresponds to the ID of the token in the dictionary, the second corresponds to the count of this token. We can see what these IDs correspond to:"
+    "The first entry in each tuple corresponds to the ID of the token in the dictionary, the second corresponds to the count of this token."
    ]
   },
   {


### PR DESCRIPTION
The arrangement of In[4] and In[5] was wrong. Rearranged them to desired positions.