### PR TITLE
Fix Issue #743: Added exception handling for n_similarity method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 Changes
 =======
 
-0.13.2, 2016-08-19
+0.13.2, 2016-09-25
 
+* Fixed issue #743, In word2vec's n_similarity method if atleast one empty list is passed ZeroDivideError is raised.
 * wordtopics has changed to word_topics in ldamallet, and fixed issue #764. (@bhargavvader, [#771](https://github.com/RaRe-Technologies/gensim/pull/771)) 
   - assigning wordtopics value of word_topics to keep backward compatibility, for now
 * topics, topn parameters changed to num_topics and num_words in show_topics() and print_topics()(@droudy, [#755](https://github.com/RaRe-Technologies/gensim/pull/755))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changes
 
 0.13.2, 2016-09-25
 
-* Fixed issue #743, In word2vec's n_similarity method if atleast one empty list is passed ZeroDivideError is raised.
+* Fixed issue #743, In word2vec's n_similarity method if atleast one empty list is passed ZeroDivisionError is raised.
 * wordtopics has changed to word_topics in ldamallet, and fixed issue #764. (@bhargavvader, [#771](https://github.com/RaRe-Technologies/gensim/pull/771)) 
   - assigning wordtopics value of word_topics to keep backward compatibility, for now
 * topics, topn parameters changed to num_topics and num_words in show_topics() and print_topics()(@droudy, [#755](https://github.com/RaRe-Technologies/gensim/pull/755))

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1539,9 +1539,15 @@ class Word2Vec(utils.SaveLoad):
           True
 
         """
-        v1 = [self[word] for word in ws1]
-        v2 = [self[word] for word in ws2]
-        return dot(matutils.unitvec(array(v1).mean(axis=0)), matutils.unitvec(array(v2).mean(axis=0)))
+        try:
+            assert(len(ws1)>0 and len(ws2)>0)
+            v1 = [self[word] for word in ws1]
+            v2 = [self[word] for word in ws2]
+            return dot(matutils.unitvec(array(v1).mean(axis=0)), matutils.unitvec(array(v2).mean(axis=0)))
+        except AssertionError:
+            raise ZeroDivisionError("Atleast one of the passed list is empty.")
+            return
+        
 
     def init_sims(self, replace=False):
         """

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1539,13 +1539,13 @@ class Word2Vec(utils.SaveLoad):
           True
 
         """
-        try:
-            assert(len(ws1)>0 and len(ws2)>0)
+        if len(ws1) > 0 and len(ws2) > 0:
             v1 = [self[word] for word in ws1]
             v2 = [self[word] for word in ws2]
-            return dot(matutils.unitvec(array(v1).mean(axis=0)), matutils.unitvec(array(v2).mean(axis=0)))
-        except AssertionError:
-            raise ZeroDivisionError("Atleast one of the passed list is empty.")
+            return dot(matutils.unitvec(array(v1).mean(axis=0)),
+                       matutils.unitvec(array(v2).mean(axis=0)))
+        else:
+            raise ZeroDivisionError('Atleast one of the passed list is empty.')
             return
         
 

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -370,9 +370,12 @@ class TestWord2VecModel(unittest.TestCase):
         model = word2vec.Word2Vec(size=2, min_count=1, sg=0, hs=0, negative=2)
         model.build_vocab(sentences)
         model.train(sentences)
-
+        
         self.assertTrue(model.n_similarity(['graph', 'trees'], ['trees', 'graph']))
         self.assertTrue(model.n_similarity(['graph'], ['trees']) == model.similarity('graph', 'trees'))
+        self.assertRaises(ZeroDivisionError,model.n_similarity(['graph', 'trees'], []))
+        self.assertRaises(ZeroDivisionError,model.n_similarity([], []))
+        self.assertRaises(ZeroDivisionError,model.n_similarity([], ['graph', 'trees']))
 
     def testSimilarBy(self):
         """Test word2vec similar_by_word and similar_by_vector."""


### PR DESCRIPTION
Fix: Word2vec n_similarity returning numpy matrix instead of float with empty list issue #743
in n_similarity() method, if atleast one empty list is passed, it raises ZeroDivisionError.
https://patch-diff.githubusercontent.com/raw/RaRe-Technologies/gensim/pull/882.diff