### PR TITLE
Fix for ZeroDivisionError: float division by zero in pagerank_weighted.py #851

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes
     - bigram construction can now support multiple bigrams within one sentence
 * Fixed issue #838, RuntimeWarning: overflow encountered in exp  (@markroxor, [#895](https://github.com/RaRe-Technologies/gensim/pull/895))
 *  Changed some log messages to warnings as suggested in issue #828. (@rhnvrm, [#884](https://github.com/RaRe-Technologies/gensim/pull/884))
+*  Fixed issue #851, In summarizer.py, check for single sentence as an input added to avoid ZeroDivionError, added test cases in test/test_summarization.py(@metalaman, #887)
 
 
 0.13.2, 2016-08-19

--- a/gensim/summarization/summarizer.py
+++ b/gensim/summarization/summarizer.py
@@ -193,7 +193,7 @@ def summarize(text, ratio=0.2, word_count=None, split=False):
         logger.warning("Input text is empty.")
         return
 
-    # If only one sentence is present, the function return the input text. 
+    # If only one sentence is present, the function return the input text (Avoids ZeroDivisionError). 
     if len(sentences) == 1:
         logger.warning("Summarization not performed since the document has only one sentence.")
         return text

--- a/gensim/summarization/summarizer.py
+++ b/gensim/summarization/summarizer.py
@@ -193,6 +193,11 @@ def summarize(text, ratio=0.2, word_count=None, split=False):
         logger.warning("Input text is empty.")
         return
 
+    # If only one sentence is present, the function return the input text. 
+    if len(sentences) == 1:
+        logger.warning("Summarization not performed since the document has only one sentence.")
+        return text
+    
     # Warns if the text is too short.
     if len(sentences) < INPUT_MIN_LENGTH:
         logger.warning("Input text is expected to have at least " + str(INPUT_MIN_LENGTH) + " sentences.")

--- a/gensim/test/test_summarization.py
+++ b/gensim/test/test_summarization.py
@@ -88,6 +88,17 @@ class TestSummarizationTest(unittest.TestCase):
 
         self.assertTrue(summarize(text) is not None)
 
+    def test_text_summarization_returns_input_on_single_input_sentence(self):
+        pre_path = os.path.join(os.path.dirname(__file__), 'test_data')
+
+        with utils.smart_open(os.path.join(pre_path, "testsummarization_unrelated.txt"), mode="r") as f:
+            text = f.read()
+
+        # Keeps the first sentence only.
+        text = "\n".join(text.split('\n')[:1])
+
+        self.assertTrue(summarize(text) is not None)
+
     def test_corpus_summarization_raises_exception_on_short_input_text(self):
         pre_path = os.path.join(os.path.dirname(__file__), 'test_data')
 

--- a/gensim/test/test_summarization.py
+++ b/gensim/test/test_summarization.py
@@ -95,7 +95,7 @@ class TestSummarizationTest(unittest.TestCase):
             text = f.read()
 
         # Keeps the first sentence only.
-        text = "\n".join(text.split('\n')[:1])
+        text = text.split('\n')[:1]
 
         self.assertTrue(summarize(text) is not None)
 

--- a/gensim/test/test_summarization.py
+++ b/gensim/test/test_summarization.py
@@ -97,7 +97,7 @@ class TestSummarizationTest(unittest.TestCase):
         # Keeps the first sentence only.
         text = text.split('\n')[0]
 
-        self.assertTrue(summarize(text) is not None)
+        self.assertEqual(summarize(text),text)
 
     def test_corpus_summarization_raises_exception_on_short_input_text(self):
         pre_path = os.path.join(os.path.dirname(__file__), 'test_data')

--- a/gensim/test/test_summarization.py
+++ b/gensim/test/test_summarization.py
@@ -95,7 +95,7 @@ class TestSummarizationTest(unittest.TestCase):
             text = f.read()
 
         # Keeps the first sentence only.
-        text = text.split('\n')[:1]
+        text = text.split('\n')[0]
 
         self.assertTrue(summarize(text) is not None)
 

--- a/gensim/test/test_wikicorpus.py
+++ b/gensim/test/test_wikicorpus.py
@@ -12,10 +12,12 @@ Automated tests for checking the WikiCorpus
 import os
 import sys
 import types
+import logging
 import unittest
 
 from gensim.corpora.wikicorpus import WikiCorpus
 
+logger = logging.getLogger(__name__)
 
 module_path = os.path.dirname(__file__) # needed because sample data files are located in the same folder
 datapath = lambda fname: os.path.join(module_path, 'test_data', fname)
@@ -29,6 +31,7 @@ class TestWikiCorpus(unittest.TestCase):
 
 
     def test_get_texts_returns_generator_of_lists(self):
+        logger.debug("Python version " + str(sys.version_info))
         if sys.version_info < (2, 7, 0):
             return
         wc = WikiCorpus(datapath(FILENAME))

--- a/gensim/test/test_wikicorpus.py
+++ b/gensim/test/test_wikicorpus.py
@@ -12,12 +12,12 @@ Automated tests for checking the WikiCorpus
 import os
 import sys
 import types
-import logging
+
 import unittest
 
 from gensim.corpora.wikicorpus import WikiCorpus
 
-logger = logging.getLogger(__name__)
+
 
 module_path = os.path.dirname(__file__) # needed because sample data files are located in the same folder
 datapath = lambda fname: os.path.join(module_path, 'test_data', fname)
@@ -31,7 +31,7 @@ class TestWikiCorpus(unittest.TestCase):
 
 
     def test_get_texts_returns_generator_of_lists(self):
-        logger.debug("Python version " + str(sys.version_info))
+        
         if sys.version_info < (2, 7, 0):
             return
         wc = WikiCorpus(datapath(FILENAME))


### PR DESCRIPTION
Returns the original text as soon as it finds only one sentence present in the document.
