### PR TITLE
Raise warning if calling load() on an instance rather than the class

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1873,9 +1873,11 @@ if __name__ == "__main__":
 def methodize(func, instance):
     return MethodType(func, instance, instance.__class__)
 
-def load(self):
-    logger.warn("Load was called on instanc. Calling on class instead")
-    Word2Vec.load()
-def load_word2vec_format(self):
-	logger.warn("Load was called on instanc. Calling on class instead")
-	Word2Vec.load_word2vec_format()
+def load(self, *args, **kwargs):
+    logger.warn("Load was called on instance. Calling on class instead")
+    Word2Vec.load(*args, **kwargs)
+def load_word2vec_format(self, fname, fvocab=None, binary=False, encoding='utf8', unicode_errors='strict',
+                             limit=None, datatype=REAL):
+	logger.warn("Load was called on instance. Calling on class instead")
+	Word2Vec.load_word2vec_format(fname, fvocab=None, binary=False, encoding='utf8', unicode_errors='strict',
+                             limit=None, datatype=REAL)

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1876,6 +1876,7 @@ def methodize(func, instance):
 def load(self, *args, **kwargs):
     logger.warn("Load was called on instance. Calling on class instead")
     Word2Vec.load(*args, **kwargs)
+	
 def load_word2vec_format(self, fname, fvocab=None, binary=False, encoding='utf8', unicode_errors='strict',
                              limit=None, datatype=REAL):
 	logger.warn("Load was called on instance. Calling on class instead")

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1882,3 +1882,4 @@ def load_word2vec_format(self, fname, fvocab=None, binary=False, encoding='utf8'
 	logger.warn("Load was called on instance. Calling on class instead")
 	Word2Vec.load_word2vec_format(fname, fvocab=None, binary=False, encoding='utf8', unicode_errors='strict',
                              limit=None, datatype=REAL)
+			

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -94,7 +94,6 @@ from gensim.corpora.dictionary import Dictionary
 from six import iteritems, itervalues, string_types
 from six.moves import xrange
 from types import GeneratorType
-from types import MethodType
 
 logger = logging.getLogger(__name__)
 
@@ -1543,9 +1542,13 @@ class Word2Vec(utils.SaveLoad):
           True
 
         """
+        if not(len(ws1) and len(ws2)):
+            raise ZeroDivisionError('Atleast one of the passed list is empty.')
         v1 = [self[word] for word in ws1]
         v2 = [self[word] for word in ws2]
-        return dot(matutils.unitvec(array(v1).mean(axis=0)), matutils.unitvec(array(v2).mean(axis=0)))
+        return dot(matutils.unitvec(array(v1).mean(axis=0)),
+                   matutils.unitvec(array(v2).mean(axis=0)))
+        
 
     def init_sims(self, replace=False):
         """
@@ -1684,8 +1687,8 @@ class Word2Vec(utils.SaveLoad):
     save.__doc__ = utils.SaveLoad.save.__doc__
 
     @classmethod
-    def load(cls, *args, **kwargs):        
-		model = super(Word2Vec, cls).load(*args, **kwargs)   
+    def load(cls, *args, **kwargs):
+        model = super(Word2Vec, cls).load(*args, **kwargs)
         # update older models
         if hasattr(model, 'table'):
             delattr(model, 'table')  # discard in favor of cum_table
@@ -1869,17 +1872,33 @@ if __name__ == "__main__":
         model.accuracy(args.accuracy)
 
     logger.info("finished running %s", program)
-    
+
 def methodize(func, instance):
     return MethodType(func, instance, instance.__class__)
 
+
 def load(self, *args, **kwargs):
-    logger.warn("Load was called on instance. Calling on class instead")
+    logger.warn('Load was called on instance. Calling on class instead')
     Word2Vec.load(*args, **kwargs)
-	
-def load_word2vec_format(self, fname, fvocab=None, binary=False, encoding='utf8', unicode_errors='strict',
-                             limit=None, datatype=REAL):
-	logger.warn("Load was called on instance. Calling on class instead")
-	Word2Vec.load_word2vec_format(fname, fvocab=None, binary=False, encoding='utf8', unicode_errors='strict',
-                             limit=None, datatype=REAL)
-			
+
+
+def load_word2vec_format(
+    self,
+    fname,
+    fvocab=None,
+    binary=False,
+    encoding='utf8',
+    unicode_errors='strict',
+    limit=None,
+    datatype=REAL,
+    ):
+    logger.warn('Load was called on instance. Calling on class instead')
+    Word2Vec.load_word2vec_format(
+        fname,
+        fvocab=None,
+        binary=False,
+        encoding='utf8',
+        unicode_errors='strict',
+        limit=None,
+        datatype=REAL,
+        )

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -94,6 +94,7 @@ from gensim.corpora.dictionary import Dictionary
 from six import iteritems, itervalues, string_types
 from six.moves import xrange
 from types import GeneratorType
+from types import MethodType
 
 logger = logging.getLogger(__name__)
 
@@ -452,6 +453,9 @@ class Word2Vec(utils.SaveLoad):
         self.total_train_time = 0
         self.sorted_vocab = sorted_vocab
         self.batch_words = batch_words
+        
+        self.load = methodize(load, self)
+        self.load_word2vec_format = methodize(load, self)
 
         if sentences is not None:
             if isinstance(sentences, GeneratorType):
@@ -1680,8 +1684,8 @@ class Word2Vec(utils.SaveLoad):
     save.__doc__ = utils.SaveLoad.save.__doc__
 
     @classmethod
-    def load(cls, *args, **kwargs):
-        model = super(Word2Vec, cls).load(*args, **kwargs)
+    def load(cls, *args, **kwargs):        
+		model = super(Word2Vec, cls).load(*args, **kwargs)   
         # update older models
         if hasattr(model, 'table'):
             delattr(model, 'table')  # discard in favor of cum_table
@@ -1865,3 +1869,13 @@ if __name__ == "__main__":
         model.accuracy(args.accuracy)
 
     logger.info("finished running %s", program)
+    
+def methodize(func, instance):
+    return MethodType(func, instance, instance.__class__)
+
+def load(self):
+    logger.warn("Load was called on instanc. Calling on class instead")
+    Word2Vec.load()
+def load_word2vec_format(self):
+	logger.warn("Load was called on instanc. Calling on class instead")
+	Word2Vec.load_word2vec_format()


### PR DESCRIPTION
Addresses one out of four issues in [#692](https://github.com/RaRe-Technologies/gensim/issues/692)

Makes use of bound functions to differentiate between calls made through `self` and those made through class.