### PR TITLE
Update doc2vec-lee.ipynb to use smart_open

### DIFF
--- a/docs/notebooks/doc2vec-lee.ipynb
+++ b/docs/notebooks/doc2vec-lee.ipynb
@@ -18,6 +18,7 @@
     "import gensim\n",
     "import os\n",
     "import collections\n",
+    "import smart_open\n",
     "import random"
    ]
   },
@@ -99,7 +100,7 @@
    "outputs": [],
    "source": [
     "def read_corpus(fname, tokens_only=False):\n",
-    "    with open(fname, encoding=\"iso-8859-1\") as f:\n",
+    "    with smart_open.smart_open(fname, encoding=\"iso-8859-1\") as f:\n",
     "        for i, line in enumerate(f):\n",
     "            if tokens_only:\n",
     "                yield gensim.utils.simple_preprocess(line)\n",


### PR DESCRIPTION
Changed open() to smart_open() to ensure correct execution of cells while using python 2.6/2.7. Fixes #943.