### PR TITLE
Move log_normalize from hdpmodel to matutils, add support for feature normalization

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -326,6 +326,29 @@ def ret_normalized_vec(vec, length):
     else:
         return list(vec)
 
+def ret_log_normalize_vec(vec, axis = 1):
+    log_max = 100.0
+    if len(vec.shape) == 1:
+        max_val = numpy.max(vec)
+        log_shift = log_max - numpy.log(len(vec) + 1.0) - max_val
+        tot = numpy.sum(numpy.exp(vec + log_shift))
+        log_norm = numpy.log(tot) - log_shift
+        vec = vec - log_norm
+    else:
+        if axis == 1:#independently normalize each sample
+            max_val = numpy.max(vec, 1)
+            log_shift = log_max - numpy.log(vec.shape[1] + 1.0) - max_val
+            tot = numpy.sum(numpy.exp(vec + log_shift[:, numpy.newaxis]), 1)
+            log_norm = numpy.log(tot) - log_shift
+            vec = vec - log_norm[:, numpy.newaxis]
+        elif axis == 0:#normalize each feature
+            k = ret_log_normalize_vec(vec.T)
+            return (k[0].T, k[1])
+        else:
+            raise ValueError("'%d' is not a supported axis" % axis)
+    return (vec, log_norm)
+
+
 blas_nrm2 = blas('nrm2', numpy.array([], dtype=float))
 blas_scal = blas('scal', numpy.array([], dtype=float))
 

--- a/gensim/models/hdpmodel.py
+++ b/gensim/models/hdpmodel.py
@@ -46,25 +46,6 @@ meanchangethresh = 0.00001
 rhot_bound = 0.0
 
 
-def log_normalize(v):
-    log_max = 100.0
-    if len(v.shape) == 1:
-        max_val = np.max(v)
-        log_shift = log_max - np.log(len(v) + 1.0) - max_val
-        tot = np.sum(np.exp(v + log_shift))
-        log_norm = np.log(tot) - log_shift
-        v = v - log_norm
-    else:
-        max_val = np.max(v, 1)
-        log_shift = log_max - np.log(v.shape[1] + 1.0) - max_val
-        tot = np.sum(np.exp(v + log_shift[:, np.newaxis]), 1)
-
-        log_norm = np.log(tot) - log_shift
-        v = v - log_norm[:, np.newaxis]
-
-    return (v, log_norm)
-
-
 def dirichlet_expectation(alpha):
     """
     For a vector theta ~ Dir(alpha), compute E[log(theta)] given alpha.
@@ -339,21 +320,21 @@ class HdpModel(interfaces.TransformationABC):
             # var_phi
             if iter < 3:
                 var_phi = np.dot(phi.T,  (Elogbeta_doc * doc_word_counts).T)
-                (log_var_phi, log_norm) = log_normalize(var_phi)
+                (log_var_phi, log_norm) = matutils.ret_log_normalize_vec(var_phi)
                 var_phi = np.exp(log_var_phi)
             else:
                 var_phi = np.dot(phi.T,  (Elogbeta_doc * doc_word_counts).T) + Elogsticks_1st
-                (log_var_phi, log_norm) = log_normalize(var_phi)
+                (log_var_phi, log_norm) = matutils.ret_log_normalize_vec(var_phi)
                 var_phi = np.exp(log_var_phi)
 
             # phi
             if iter < 3:
                 phi = np.dot(var_phi, Elogbeta_doc).T
-                (log_phi, log_norm) = log_normalize(phi)
+                (log_phi, log_norm) = matutils.ret_log_normalize_vec(phi)
                 phi = np.exp(log_phi)
             else:
                 phi = np.dot(var_phi, Elogbeta_doc).T + Elogsticks_2nd
-                (log_phi, log_norm) = log_normalize(phi)
+                (log_phi, log_norm) = matutils.ret_log_normalize_vec(phi)
                 phi = np.exp(log_phi)
 
             # v


### PR DESCRIPTION
- Log normalizing may be used for other models too, hence it's better to shift it to matutils
- log normalize : Currently for an input 2D array , independently normalizing each sample is done.An optional axis parameter is introduced to give support for normalizing along feature.

See axis parameter in : 
http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.normalize.html