### PR TITLE
Fix for issue #979

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1399,6 +1399,10 @@ class Word2Vec(utils.SaveLoad):
         dictionary = Dictionary(documents=[document1, document2])
         vocab_len = len(dictionary)
 
+        if vocab_len == 1:
+            # Both documents are composed by a single unique token
+            return 0.0
+
         # Sets for faster look-up.
         docset1 = set(document1)
         docset2 = set(document2)


### PR DESCRIPTION
Issue: WMD Earth mover Distance for sentences that contain a single word return inf
Fix: Return float 0.0 when the dictionary size is 1 (both sentences are composed with the same token)
