### PR TITLE
fixed incorrect doctags in most_similar #601

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changes
 * Remove ShardedCorpus from init because of Theano dependency (@tmylk, [#919](https://github.com/RaRe-Technologies/gensim/pull/919))
 * Documentation improvements ( @dsquareindia & @tmylk, [#914](https://github.com/RaRe-Technologies/gensim/pull/914), [#906](https://github.com/RaRe-Technologies/gensim/pull/906) )
 * Add Annoy memory-mapping example (@harshul1610, [#899](https://github.com/RaRe-Technologies/gensim/pull/899))
+* Fixed issue [#601](https://github.com/RaRe-Technologies/gensim/issues/601), correct docID in most_similar for clip range (@parulsethi, [#994](https://github.com/RaRe-Technologies/gensim/pull/994))
 
 0.13.2, 2016-08-19
 

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -460,7 +460,7 @@ class DocvecsArray(utils.SaveLoad):
             return dists
         best = matutils.argsort(dists, topn=topn + len(all_docs), reverse=True)
         # ignore (don't return) docs from the input
-        result = [(self.index_to_doctag(sim + clip_start), float(dists[sim])) for sim in best if (sim+clip_start) not in all_docs]
+        result = [(self.index_to_doctag(sim + clip_start), float(dists[sim])) for sim in best if (sim + clip_start) not in all_docs]
         return result[:topn]
 
     def doesnt_match(self, docs):

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -460,7 +460,7 @@ class DocvecsArray(utils.SaveLoad):
             return dists
         best = matutils.argsort(dists, topn=topn + len(all_docs), reverse=True)
         # ignore (don't return) docs from the input
-        result = [(self.index_to_doctag(sim + clip_start), float(dists[sim])) for sim in best if sim not in all_docs]
+        result = [(self.index_to_doctag(sim + clip_start), float(dists[sim])) for sim in best if (sim+clip_start) not in all_docs]
         return result[:topn]
 
     def doesnt_match(self, docs):

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -460,7 +460,7 @@ class DocvecsArray(utils.SaveLoad):
             return dists
         best = matutils.argsort(dists, topn=topn + len(all_docs), reverse=True)
         # ignore (don't return) docs from the input
-        result = [(self.index_to_doctag(sim), float(dists[sim])) for sim in best if sim not in all_docs]
+        result = [(self.index_to_doctag(sim + clip_start), float(dists[sim])) for sim in best if sim not in all_docs]
         return result[:topn]
 
     def doesnt_match(self, docs):

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -8,6 +8,7 @@
 Automated tests for checking transformation algorithms (the models package).
 """
 
+
 from __future__ import with_statement
 
 import logging
@@ -158,6 +159,12 @@ class TestDoc2VecModel(unittest.TestCase):
         sims = sims[:20]
         self.assertEqual(list(zip(*sims))[0], list(zip(*sims2))[0])  # same doc ids
         self.assertTrue(np.allclose(list(zip(*sims))[1], list(zip(*sims2))[1]))  # close-enough dists
+
+        # sim results should be in clip range if given
+        clip_sims = model.docvecs.most_similar(fire1, clip_start=len(model.docvecs)//2, clip_end=len(model.docvecs))
+        sims_doc_id = [docid for docid, sim in clip_sims]
+        for s_id in sims_doc_id:
+            self.assertTrue(len(model.docvecs)//2 <= s_id <= len(model.docvecs))
 
         # tennis doc should be out-of-place among fire news
         self.assertEqual(model.docvecs.doesnt_match([fire1, tennis1, fire2]), tennis1)

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -161,10 +161,10 @@ class TestDoc2VecModel(unittest.TestCase):
         self.assertTrue(np.allclose(list(zip(*sims))[1], list(zip(*sims2))[1]))  # close-enough dists
 
         # sim results should be in clip range if given
-        clip_sims = model.docvecs.most_similar(fire1, clip_start=len(model.docvecs)//2, clip_end=len(model.docvecs))
+        clip_sims = model.docvecs.most_similar(fire1, clip_start=len(model.docvecs) // 2, clip_end=len(model.docvecs) * 2 // 3)
         sims_doc_id = [docid for docid, sim in clip_sims]
         for s_id in sims_doc_id:
-            self.assertTrue(len(model.docvecs)//2 <= s_id <= len(model.docvecs))
+            self.assertTrue(len(model.docvecs) // 2 <= s_id <= len(model.docvecs) * 2 // 3)
 
         # tennis doc should be out-of-place among fire news
         self.assertEqual(model.docvecs.doesnt_match([fire1, tennis1, fire2]), tennis1)


### PR DESCRIPTION
most_similar() in doc2vec.py doesn't consider given clip range for tagID/indexes [#601](https://github.com/RaRe-Technologies/gensim/issues/601)
fix: add clip_start to index_to_doctag's indexes.