### PR TITLE
Inherit LDAMallet wrapper from BaseModel to standardise print_topics

### DIFF
--- a/gensim/test/basetests.py
+++ b/gensim/test/basetests.py
@@ -9,6 +9,7 @@ Automated tests for checking transformation algorithms (the models package).
 """
 
 import six
+import numpy as np
 
 class TestBaseTopicModel(object):
     def testPrintTopic(self):
@@ -29,7 +30,7 @@ class TestBaseTopicModel(object):
 
         for k, v in topic:
             self.assertTrue(isinstance(k, six.string_types))
-            self.assertTrue(isinstance(v, float))
+            self.assertTrue(isinstance(v, (np.floating, float)))
 
     def testShowTopics(self):
         topics = self.model.show_topics(formatted=False)
@@ -39,4 +40,4 @@ class TestBaseTopicModel(object):
             self.assertTrue(isinstance(topic, list))
             for k, v in topic:
                 self.assertTrue(isinstance(k, six.string_types))
-                self.assertTrue(isinstance(v, float))
+                self.assertTrue(isinstance(v, (np.floating, float)))

--- a/gensim/test/test_ldamallet_wrapper.py
+++ b/gensim/test/test_ldamallet_wrapper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#
+#h
 # Copyright (C) 2010 Radim Rehurek <radimrehurek@seznam.cz>
 # Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
 
@@ -10,7 +10,7 @@ Automated tests for checking transformation algorithms (the models package).
 
 
 import logging
-import unittest
+import unittest2 as unittest
 import os
 import os.path
 import tempfile

--- a/gensim/test/test_ldamallet_wrapper.py
+++ b/gensim/test/test_ldamallet_wrapper.py
@@ -24,7 +24,7 @@ from gensim.corpora import mmcorpus, Dictionary
 from gensim.models.wrappers import ldamallet
 from gensim import matutils
 from gensim.models import ldamodel
-
+from gensim.test import basetests
 
 module_path = os.path.dirname(__file__) # needed because sample data files are located in the same folder
 datapath = lambda fname: os.path.join(module_path, 'test_data', fname)
@@ -49,11 +49,16 @@ def testfile():
     # temporary data will be stored to this file
     return os.path.join(tempfile.gettempdir(), 'gensim_models.tst')
 
-class TestLdaMallet(unittest.TestCase):
+class TestLdaMallet(unittest.TestCase, basetests.TestBaseTopicModel):
     def setUp(self):
-        self.corpus = mmcorpus.MmCorpus(datapath('testcorpus.mm'))
         mallet_home = os.environ.get('MALLET_HOME', None)
         self.mallet_path = os.path.join(mallet_home, 'bin', 'mallet') if mallet_home else None
+        if not self.mallet_path:
+            raise unittest.SkipTest("MALLET_HOME not specified. Skipping Mallet tests.")
+        self.corpus = mmcorpus.MmCorpus(datapath('testcorpus.mm'))
+
+        # self.model is used in TestBaseTopicModel
+        self.model = ldamallet.LdaMallet(self.mallet_path, corpus, id2word=dictionary, num_topics=2, iterations=1)
 
 
     def testTransform(self):

--- a/setup.py
+++ b/setup.py
@@ -182,6 +182,7 @@ setup(
     ],
     tests_require=[
     	'testfixtures',
+        'unittest2'
     ],
     extras_require={
         'distributed': ['Pyro4 >= 4.27'],


### PR DESCRIPTION
Continuing from #946 