### PR TITLE
numpy as np

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -32,7 +32,7 @@ The algorithm:
 
 
 import logging
-import numpy  # for arrays, array broadcasting etc.
+import numpy as np  # for arrays, array broadcasting etc.
 import numbers
 
 from gensim import interfaces, utils, matutils
@@ -62,9 +62,9 @@ def dirichlet_expectation(alpha):
 
     """
     if (len(alpha.shape) == 1):
-        result = psi(alpha) - psi(numpy.sum(alpha))
+        result = psi(alpha) - psi(np.sum(alpha))
     else:
-        result = psi(alpha) - psi(numpy.sum(alpha, 1))[:, numpy.newaxis]
+        result = psi(alpha) - psi(np.sum(alpha, 1))[:, np.newaxis]
     return result.astype(alpha.dtype)  # keep the same precision as input
 
 
@@ -74,13 +74,13 @@ def update_dir_prior(prior, N, logphat, rho):
     **Huang: Maximum Likelihood Estimation of Dirichlet Distribution Parameters.**
     http://jonathan-huang.org/research/dirichlet/dirichlet.pdf
     """
-    dprior = numpy.copy(prior)
-    gradf = N * (psi(numpy.sum(prior)) - psi(prior) + logphat)
+    dprior = np.copy(prior)
+    gradf = N * (psi(np.sum(prior)) - psi(prior) + logphat)
 
-    c = N * polygamma(1, numpy.sum(prior))
+    c = N * polygamma(1, np.sum(prior))
     q = -N * polygamma(1, prior)
 
-    b = numpy.sum(gradf / q) / (1 / c + numpy.sum(1 / q))
+    b = np.sum(gradf / q) / (1 / c + np.sum(1 / q))
 
     dprior = -(gradf - b) / q
 
@@ -96,13 +96,13 @@ def get_random_state(seed):
 
          Method originally from maciejkula/glove-python, and written by @joshloyal
      """
-     if seed is None or seed is numpy.random:
-         return numpy.random.mtrand._rand
-     if isinstance(seed, (numbers.Integral, numpy.integer)):
-         return numpy.random.RandomState(seed)
-     if isinstance(seed, numpy.random.RandomState):
+     if seed is None or seed is np.random:
+         return np.random.mtrand._rand
+     if isinstance(seed, (numbers.Integral, np.integer)):
+         return np.random.RandomState(seed)
+     if isinstance(seed, np.random.RandomState):
         return seed
-     raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
+     raise ValueError('%r cannot be used to seed a np.random.RandomState'
                       ' instance' % seed)
 
 class LdaState(utils.SaveLoad):
@@ -115,7 +115,7 @@ class LdaState(utils.SaveLoad):
     """
     def __init__(self, eta, shape):
         self.eta = eta
-        self.sstats = numpy.zeros(shape)
+        self.sstats = np.zeros(shape)
         self.numdocs = 0
 
     def reset(self):
@@ -257,7 +257,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         `minimum_probability` controls filtering the topics returned for a document (bow).
 
-        `random_state` can be a numpy.random.RandomState object or the seed for one
+        `random_state` can be a np.random.RandomState object or the seed for one
 
         Example:
 
@@ -340,7 +340,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         # Initialize the variational distribution q(beta|lambda)
         self.state = LdaState(self.eta, (self.num_topics, self.num_terms))
         self.state.sstats = self.random_state.gamma(100., 1. / 100., (self.num_topics, self.num_terms))
-        self.expElogbeta = numpy.exp(dirichlet_expectation(self.state.sstats))
+        self.expElogbeta = np.exp(dirichlet_expectation(self.state.sstats))
 
         # if a training corpus was provided, start estimating the model right away
         if corpus is not None:
@@ -356,25 +356,25 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         if isinstance(prior, six.string_types):
             if prior == 'symmetric':
                 logger.info("using symmetric %s at %s", name, 1.0 / self.num_topics)
-                init_prior = numpy.asarray([1.0 / self.num_topics for i in xrange(self.num_topics)])
+                init_prior = np.asarray([1.0 / self.num_topics for i in xrange(self.num_topics)])
             elif prior == 'asymmetric':
-                init_prior = numpy.asarray([1.0 / (i + numpy.sqrt(self.num_topics)) for i in xrange(self.num_topics)])
+                init_prior = np.asarray([1.0 / (i + np.sqrt(self.num_topics)) for i in xrange(self.num_topics)])
                 init_prior /= init_prior.sum()
                 logger.info("using asymmetric %s %s", name, list(init_prior))
             elif prior == 'auto':
                 is_auto = True
-                init_prior = numpy.asarray([1.0 / self.num_topics for i in xrange(self.num_topics)])
+                init_prior = np.asarray([1.0 / self.num_topics for i in xrange(self.num_topics)])
                 logger.info("using autotuned %s, starting with %s", name, list(init_prior))
             else:
                 raise ValueError("Unable to determine proper %s value given '%s'" % (name, prior))
         elif isinstance(prior, list):
-            init_prior = numpy.asarray(prior)
-        elif isinstance(prior, numpy.ndarray):
+            init_prior = np.asarray(prior)
+        elif isinstance(prior, np.ndarray):
             init_prior = prior
-        elif isinstance(prior, numpy.number) or isinstance(prior, numbers.Real):
-            init_prior = numpy.asarray([prior] * self.num_topics)
+        elif isinstance(prior, np.number) or isinstance(prior, numbers.Real):
+            init_prior = np.asarray([prior] * self.num_topics)
         else:
-            raise ValueError("%s must be either a numpy array of scalars, list of scalars, or scalar" % name)
+            raise ValueError("%s must be either a np array of scalars, list of scalars, or scalar" % name)
 
         if name == 'eta':
             # please note the difference in shapes between alpha and eta:
@@ -391,7 +391,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             (self.num_terms, self.num_topics, self.decay, self.chunksize)
 
     def sync_state(self):
-        self.expElogbeta = numpy.exp(self.state.get_Elogbeta())
+        self.expElogbeta = np.exp(self.state.get_Elogbeta())
 
     def clear(self):
         """Clear model state (free up some memory). Used in the distributed algo."""
@@ -427,9 +427,9 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         # Initialize the variational distribution q(theta|gamma) for the chunk
         gamma = self.random_state.gamma(100., 1. / 100., (len(chunk), self.num_topics))
         Elogtheta = dirichlet_expectation(gamma)
-        expElogtheta = numpy.exp(Elogtheta)
+        expElogtheta = np.exp(Elogtheta)
         if collect_sstats:
-            sstats = numpy.zeros_like(self.expElogbeta)
+            sstats = np.zeros_like(self.expElogbeta)
         else:
             sstats = None
         converged = 0
@@ -440,11 +440,11 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         # to Blei's original LDA-C code, cool!).
         for d, doc in enumerate(chunk):
             if doc and not isinstance(doc[0][0], six.integer_types):
-                # make sure the term IDs are ints, otherwise numpy will get upset
+                # make sure the term IDs are ints, otherwise np will get upset
                 ids = [int(id) for id, _ in doc]
             else:
                 ids = [id for id, _ in doc]
-            cts = numpy.array([cnt for _, cnt in doc])
+            cts = np.array([cnt for _, cnt in doc])
             gammad = gamma[d, :]
             Elogthetad = Elogtheta[d, :]
             expElogthetad = expElogtheta[d, :]
@@ -453,7 +453,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             # The optimal phi_{dwk} is proportional to expElogthetad_k * expElogbetad_w.
             # phinorm is the normalizer.
             # TODO treat zeros explicitly, instead of adding 1e-100?
-            phinorm = numpy.dot(expElogthetad, expElogbetad) + 1e-100
+            phinorm = np.dot(expElogthetad, expElogbetad) + 1e-100
 
             # Iterate between gamma and phi until convergence
             for _ in xrange(self.iterations):
@@ -461,12 +461,12 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
                 # We represent phi implicitly to save memory and time.
                 # Substituting the value of the optimal phi back into
                 # the update for gamma gives this update. Cf. Lee&Seung 2001.
-                gammad = self.alpha + expElogthetad * numpy.dot(cts / phinorm, expElogbetad.T)
+                gammad = self.alpha + expElogthetad * np.dot(cts / phinorm, expElogbetad.T)
                 Elogthetad = dirichlet_expectation(gammad)
-                expElogthetad = numpy.exp(Elogthetad)
-                phinorm = numpy.dot(expElogthetad, expElogbetad) + 1e-100
+                expElogthetad = np.exp(Elogthetad)
+                phinorm = np.dot(expElogthetad, expElogbetad) + 1e-100
                 # If gamma hasn't changed much, we're done.
-                meanchange = numpy.mean(abs(gammad - lastgamma))
+                meanchange = np.mean(abs(gammad - lastgamma))
                 if (meanchange < self.gamma_threshold):
                     converged += 1
                     break
@@ -474,7 +474,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             if collect_sstats:
                 # Contribution of document d to the expected sufficient
                 # statistics for the M step.
-                sstats[:, ids] += numpy.outer(expElogthetad.T, cts / phinorm)
+                sstats[:, ids] += np.outer(expElogthetad.T, cts / phinorm)
 
         if len(chunk) > 1:
             logger.debug("%i/%i documents converged within %i iterations",
@@ -542,7 +542,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         subsample_ratio = 1.0 * total_docs / len(chunk)
         perwordbound = self.bound(chunk, subsample_ratio=subsample_ratio) / (subsample_ratio * corpus_words)
         logger.info("%.3f per-word bound, %.1f perplexity estimate based on a held-out corpus of %i documents with %i words" %
-                    (perwordbound, numpy.exp2(-perwordbound), len(chunk), corpus_words))
+                    (perwordbound, np.exp2(-perwordbound), len(chunk), corpus_words))
         return perwordbound
 
     def update(self, corpus, chunksize=None, decay=None, offset=None,
@@ -569,11 +569,11 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         Args:
             corpus (gensim corpus): The corpus with which the LDA model should be updated.
 
-            chunks_as_numpy (bool): Whether each chunk passed to `.inference` should be a numpy
-                array of not. Numpy can in some settings turn the term IDs
+            chunks_as_numpy (bool): Whether each chunk passed to `.inference` should be a np
+                array of not. np can in some settings turn the term IDs
                 into floats, these will be converted back into integers in
                 inference, which incurs a performance hit. For distributed
-                computing it may be desirable to keep the chunks as numpy
+                computing it may be desirable to keep the chunks as np
                 arrays.
 
         For other parameter settings, see :class:`LdaModel` constructor.
@@ -707,14 +707,14 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         logger.debug("updating topics")
         # update self with the new blend; also keep track of how much did
         # the topics change through this update, to assess convergence
-        diff = numpy.log(self.expElogbeta)
+        diff = np.log(self.expElogbeta)
         self.state.blend(rho, other)
         diff -= self.state.get_Elogbeta()
         self.sync_state()
 
         # print out some debug info at the end of each EM iteration
         self.print_topics(5)
-        logger.info("topic diff=%f, rho=%f", numpy.mean(numpy.abs(diff)), rho)
+        logger.info("topic diff=%f, rho=%f", np.mean(np.abs(diff)), rho)
 
         if self.optimize_eta:
             self.update_eta(self.state.get_lambda(), rho)
@@ -747,26 +747,26 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             Elogthetad = dirichlet_expectation(gammad)
 
             # E[log p(doc | theta, beta)]
-            score += numpy.sum(cnt * logsumexp(Elogthetad + Elogbeta[:, id]) for id, cnt in doc)
+            score += np.sum(cnt * logsumexp(Elogthetad + Elogbeta[:, id]) for id, cnt in doc)
 
             # E[log p(theta | alpha) - log q(theta | gamma)]; assumes alpha is a vector
-            score += numpy.sum((self.alpha - gammad) * Elogthetad)
-            score += numpy.sum(gammaln(gammad) - gammaln(self.alpha))
-            score += gammaln(numpy.sum(self.alpha)) - gammaln(numpy.sum(gammad))
+            score += np.sum((self.alpha - gammad) * Elogthetad)
+            score += np.sum(gammaln(gammad) - gammaln(self.alpha))
+            score += gammaln(np.sum(self.alpha)) - gammaln(np.sum(gammad))
 
         # compensate likelihood for when `corpus` above is only a sample of the whole corpus
         score *= subsample_ratio
 
         # E[log p(beta | eta) - log q (beta | lambda)]; assumes eta is a scalar
-        score += numpy.sum((self.eta - _lambda) * Elogbeta)
-        score += numpy.sum(gammaln(_lambda) - gammaln(self.eta))
+        score += np.sum((self.eta - _lambda) * Elogbeta)
+        score += np.sum(gammaln(_lambda) - gammaln(self.eta))
 
-        if numpy.ndim(self.eta) == 0:
+        if np.ndim(self.eta) == 0:
             sum_eta = self.eta * self.num_terms
         else:
-            sum_eta = numpy.sum(self.eta, 1)
+            sum_eta = np.sum(self.eta, 1)
 
-        score += numpy.sum(gammaln(sum_eta) - gammaln(numpy.sum(_lambda, 1)))
+        score += np.sum(gammaln(sum_eta) - gammaln(np.sum(_lambda, 1)))
         return score
 
     def show_topics(self, num_topics=10, num_words=10, log=False, formatted=True):
@@ -873,7 +873,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             for m in top_words[1:]:
                 # m_docs is v_m^(t)
                 m_docs = doc_word_list[m]
-                m_index = numpy.where(top_words == m)[0]
+                m_index = np.where(top_words == m)[0]
 
                 # Sum of top words l=1..m-1
                 # i.e., all words ranked higher than the current word m
@@ -887,7 +887,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
                         co_doc_frequency = len(m_docs.intersection(l_docs))
 
                         # add to the coherence sum for these two words m, l
-                        coherence += numpy.log((co_doc_frequency + 1.0) / len(l_docs))
+                        coherence += np.log((co_doc_frequency + 1.0) / len(l_docs))
 
             coherence_scores.append((str_topics[t], coherence))
 
@@ -999,7 +999,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         keep in mind:
 
           1. The pickled Python dictionaries will not work across Python versions
-          2. The `save` method does not automatically save all NumPy arrays using NumPy, only
+          2. The `save` method does not automatically save all np arrays using np, only
              those ones that exceed `sep_limit` set in `gensim.utils.SaveLoad.save`. The main
              concern here is the `alpha` array if for instance using `alpha='auto'`.
 

--- a/gensim/models/ldaseqmodel.py
+++ b/gensim/models/ldaseqmodel.py
@@ -25,7 +25,7 @@ The next steps to take this forward would be:
 
 from gensim import utils, matutils
 from gensim.models import ldamodel
-import numpy
+import numpy as np
 from scipy.special import digamma, gammaln
 from scipy import optimize
 import logging
@@ -63,7 +63,7 @@ class LdaSeqModel(utils.SaveLoad):
         `num_topics` is the number of requested latent topics to be extracted from the training corpus.
 
         `initalize` allows the user to decide how he wants to initialise the DTM model. Default is through gensim LDA.
-        You can use your own sstats of an LDA model previously trained as well by specifying 'own' and passing a numpy matrix through sstats.
+        You can use your own sstats of an LDA model previously trained as well by specifying 'own' and passing a numpy as np matrix through sstats.
         If you wish to just pass a previously used LDA model, pass it through `lda_model`
         Shape of sstats is (vocab_len, num_topics)
 
@@ -72,7 +72,7 @@ class LdaSeqModel(utils.SaveLoad):
 
         `passes` is the number of passes of the initial LdaModel.
 
-        `random_state` can be a numpy.random.RandomState object or the seed for one, for the LdaModel.
+        `random_state` can be a numpy as np.random.RandomState object or the seed for one, for the LdaModel.
         """
         self.id2word = id2word
         if corpus is None and self.id2word is None:
@@ -106,7 +106,7 @@ class LdaSeqModel(utils.SaveLoad):
 
         self.num_topics = num_topics
         self.num_time_slices = len(time_slice)
-        self.alphas = numpy.full(num_topics, alphas)
+        self.alphas = numpy as np.full(num_topics, alphas)
 
         # topic_chains contains for each topic a 'state space language model' object which in turn has information about each topic
         # the sslm class is described below and contains information on topic-word probabilities and doc-topic probabilities.
@@ -125,9 +125,9 @@ class LdaSeqModel(utils.SaveLoad):
         if corpus is not None and time_slice is not None:
             if initialize == 'gensim':
                 lda_model = ldamodel.LdaModel(corpus, id2word=self.id2word, num_topics=self.num_topics, passes=passes, alpha=self.alphas, random_state=random_state)
-                self.sstats = numpy.transpose(lda_model.state.sstats)
+                self.sstats = numpy as np.transpose(lda_model.state.sstats)
             if initialize == 'ldamodel':
-                self.sstats = numpy.transpose(lda_model.state.sstats)
+                self.sstats = numpy as np.transpose(lda_model.state.sstats)
             if initialize == 'own':
                 self.sstats = sstats
 
@@ -148,9 +148,9 @@ class LdaSeqModel(utils.SaveLoad):
             sslm.sslm_counts_init(chain, topic_obs_variance, topic_chain_variance, sstats)
 
             # initialize the below matrices only if running DIM
-            # ldaseq.topic_chains[k].w_phi_l = numpy.zeros((ldaseq.vocab_len, ldaseq.num_time_slices))
-            # ldaseq.topic_chains[k].w_phi_sum = numpy.zeros((ldaseq.vocab_len, ldaseq.num_time_slices))
-            # ldaseq.topic_chains[k].w_phi_sq = numpy.zeros((ldaseq.vocab_len, ldaseq.num_time_slices))
+            # ldaseq.topic_chains[k].w_phi_l = numpy as np.zeros((ldaseq.vocab_len, ldaseq.num_time_slices))
+            # ldaseq.topic_chains[k].w_phi_sum = numpy as np.zeros((ldaseq.vocab_len, ldaseq.num_time_slices))
+            # ldaseq.topic_chains[k].w_phi_sq = numpy as np.zeros((ldaseq.vocab_len, ldaseq.num_time_slices))
 
 
     def fit_lda_seq(self, corpus, lda_inference_max_iter, em_min_iter, em_max_iter, chunksize):
@@ -191,11 +191,11 @@ class LdaSeqModel(utils.SaveLoad):
             # initiate sufficient statistics
             topic_suffstats = []
             for topic in range(0, num_topics):
-                topic_suffstats.append(numpy.resize(numpy.zeros(vocab_len * data_len), (vocab_len, data_len)))
+                topic_suffstats.append(numpy as np.resize(numpy as np.zeros(vocab_len * data_len), (vocab_len, data_len)))
 
             # set up variables
-            gammas = numpy.resize(numpy.zeros(corpus_len * num_topics), (corpus_len, num_topics))
-            lhoods = numpy.resize(numpy.zeros(corpus_len * num_topics + 1), (corpus_len, num_topics + 1))
+            gammas = numpy as np.resize(numpy as np.zeros(corpus_len * num_topics), (corpus_len, num_topics))
+            lhoods = numpy as np.resize(numpy as np.zeros(corpus_len * num_topics + 1), (corpus_len, num_topics + 1))
             # compute the likelihood of a sequential corpus under an LDA
             # seq model and find the evidence lower bound. This is the E - Step
             bound, gammas = self.lda_seq_infer(corpus, topic_suffstats, gammas, lhoods, iter_, lda_inference_max_iter, chunksize)
@@ -214,7 +214,7 @@ class LdaSeqModel(utils.SaveLoad):
                 logger.info("Bound went down, increasing iterations to %i", lda_inference_max_iter)
 
             # check for convergence
-            convergence = numpy.fabs((bound - old_bound) / old_bound)
+            convergence = numpy as np.fabs((bound - old_bound) / old_bound)
 
             if convergence < LDASQE_EM_THRESHOLD:
 
@@ -240,7 +240,7 @@ class LdaSeqModel(utils.SaveLoad):
         bound = 0.0
 
         lda = ldamodel.LdaModel(num_topics=num_topics, alpha=self.alphas, id2word=self.id2word)
-        lda.topics = numpy.array(numpy.split(numpy.zeros(vocab_len * num_topics), vocab_len))
+        lda.topics = numpy as np.array(numpy as np.split(numpy as np.zeros(vocab_len * num_topics), vocab_len))
         ldapost = LdaPost(max_doc_len=self.max_doc_len, num_topics=num_topics, lda=lda)
 
         model = "DTM"
@@ -265,7 +265,7 @@ class LdaSeqModel(utils.SaveLoad):
         num_topics = self.num_topics
         lda = self.make_lda_seq_slice(lda, time)  # create lda_seq slice
 
-        time_slice = numpy.cumsum(numpy.array(self.time_slice))
+        time_slice = numpy as np.cumsum(numpy as np.array(self.time_slice))
 
         for chunk_no, chunk in enumerate(utils.grouper(corpus, chunksize)):
             # iterates chunk size for constant memory footprint
@@ -305,9 +305,9 @@ class LdaSeqModel(utils.SaveLoad):
         set up the LDA model topic-word values with that of ldaseq.
         """
         for k in range(0, self.num_topics):
-            lda.topics[:, k] = numpy.copy(self.topic_chains[k].e_log_prob[:, time])
+            lda.topics[:, k] = numpy as np.copy(self.topic_chains[k].e_log_prob[:, time])
 
-        lda.alpha = numpy.copy(self.alphas)
+        lda.alpha = numpy as np.copy(self.alphas)
         return lda
 
 
@@ -354,8 +354,8 @@ class LdaSeqModel(utils.SaveLoad):
         top_terms is the number of terms to display
         """
         topic = self.topic_chains[topic].e_log_prob
-        topic = numpy.transpose(topic)
-        topic = numpy.exp(topic[time])
+        topic = numpy as np.transpose(topic)
+        topic = numpy as np.exp(topic[time])
         topic = topic / topic.sum()
         bestn = matutils.argsort(topic, top_terms, reverse=True)
         beststr = [(self.id2word[id_], round(topic[id_], 3)) for id_ in bestn]
@@ -367,8 +367,8 @@ class LdaSeqModel(utils.SaveLoad):
         On passing the LdaSeqModel trained ldaseq object, the doc_number of your document in the corpus,
         it returns the doc-topic probabilities of that document.
         """
-        doc_topic = numpy.copy(self.gammas)
-        doc_topic /= doc_topic.sum(axis=1)[:, numpy.newaxis]
+        doc_topic = numpy as np.copy(self.gammas)
+        doc_topic /= doc_topic.sum(axis=1)[:, numpy as np.newaxis]
         return doc_topic[doc_number]
 
 
@@ -378,22 +378,22 @@ class LdaSeqModel(utils.SaveLoad):
         all of these are needed to visualise topics for DTM for a particular time-slice via pyLDAvis.
         input parameter is the year to do the visualisation.
         """
-        doc_topic = numpy.copy(self.gammas)
-        doc_topic /= doc_topic.sum(axis=1)[:, numpy.newaxis]
+        doc_topic = numpy as np.copy(self.gammas)
+        doc_topic /= doc_topic.sum(axis=1)[:, numpy as np.newaxis]
 
-        topic_term = [numpy.exp(numpy.transpose(chain.e_log_prob)[time]) / numpy.exp(numpy.transpose(chain.e_log_prob)[time]).sum() for k, chain in enumerate(self.topic_chains)]
+        topic_term = [numpy as np.exp(numpy as np.transpose(chain.e_log_prob)[time]) / numpy as np.exp(numpy as np.transpose(chain.e_log_prob)[time]).sum() for k, chain in enumerate(self.topic_chains)]
 
         doc_lengths = [len(doc) for doc_no, doc in enumerate(corpus)]
 
-        term_frequency = numpy.zeros(self.vocab_len)
+        term_frequency = numpy as np.zeros(self.vocab_len)
         for doc_no, doc in enumerate(corpus):
             for pair in doc:
                 term_frequency[pair[0]] += pair[1]
         
         vocab = [self.id2word[i] for i in range(0, len(self.id2word))]
-        # returns numpy arrays for doc_topic proportions, topic_term proportions, and document_lengths, term_frequency.
+        # returns numpy as np arrays for doc_topic proportions, topic_term proportions, and document_lengths, term_frequency.
         # these should be passed to the `pyLDAvis.prepare` method to visualise one time-slice of DTM topics.
-        return doc_topic, numpy.array(topic_term), doc_lengths, term_frequency, vocab
+        return doc_topic, numpy as np.array(topic_term), doc_lengths, term_frequency, vocab
 
 
     def dtm_coherence(self, time):
@@ -415,7 +415,7 @@ class LdaSeqModel(utils.SaveLoad):
         Similar to the LdaModel __getitem__ function, it returns topic proportions of a document passed.
         """
         lda_model = ldamodel.LdaModel(num_topics=self.num_topics, alpha=self.alphas, id2word=self.id2word)
-        lda_model.topics = numpy.array(numpy.split(numpy.zeros(self.vocab_len * self.num_topics), self.vocab_len))
+        lda_model.topics = numpy as np.array(numpy as np.split(numpy as np.zeros(self.vocab_len * self.num_topics), self.vocab_len))
         ldapost = LdaPost(num_topics=self.num_topics, max_doc_len=len(doc), lda=lda_model, doc=doc)
 
         time_lhoods = []
@@ -449,13 +449,13 @@ class sslm(utils.SaveLoad):
         self.num_topics = num_topics
 
         # setting up matrices
-        self.obs = numpy.array(numpy.split(numpy.zeros(num_time_slices * vocab_len), vocab_len))
-        self.e_log_prob = numpy.array(numpy.split(numpy.zeros(num_time_slices * vocab_len), vocab_len))
-        self.mean = numpy.array(numpy.split(numpy.zeros((num_time_slices + 1) * vocab_len), vocab_len))
-        self.fwd_mean = numpy.array(numpy.split(numpy.zeros((num_time_slices + 1) * vocab_len), vocab_len))
-        self.fwd_variance = numpy.array(numpy.split(numpy.zeros((num_time_slices + 1) * vocab_len), vocab_len))
-        self.variance = numpy.array(numpy.split(numpy.zeros((num_time_slices + 1) * vocab_len), vocab_len))
-        self.zeta = numpy.zeros(num_time_slices)
+        self.obs = numpy as np.array(numpy as np.split(numpy as np.zeros(num_time_slices * vocab_len), vocab_len))
+        self.e_log_prob = numpy as np.array(numpy as np.split(numpy as np.zeros(num_time_slices * vocab_len), vocab_len))
+        self.mean = numpy as np.array(numpy as np.split(numpy as np.zeros((num_time_slices + 1) * vocab_len), vocab_len))
+        self.fwd_mean = numpy as np.array(numpy as np.split(numpy as np.zeros((num_time_slices + 1) * vocab_len), vocab_len))
+        self.fwd_variance = numpy as np.array(numpy as np.split(numpy as np.zeros((num_time_slices + 1) * vocab_len), vocab_len))
+        self.variance = numpy as np.array(numpy as np.split(numpy as np.zeros((num_time_slices + 1) * vocab_len), vocab_len))
+        self.zeta = numpy as np.zeros(num_time_slices)
 
         # the following are class variables which are to be integrated during Document Influence Model
         self.m_update_coeff = None
@@ -475,7 +475,7 @@ class sslm(utils.SaveLoad):
         It is the value of variational parameter zeta which maximizes the lower bound.
         """
         for j, val in enumerate(self.zeta):
-            self.zeta[j] = numpy.sum(numpy.exp(self.mean[:, j + 1] + self.variance[:, j + 1] / 2))
+            self.zeta[j] = numpy as np.sum(numpy as np.exp(self.mean[:, j + 1] + self.variance[:, j + 1] / 2))
         return self.zeta
 
 
@@ -510,7 +510,7 @@ class sslm(utils.SaveLoad):
         variance[T] = fwd_variance[T]
         for t in range(T - 1, -1, -1):
             if fwd_variance[t] > 0.0:
-                c = numpy.power((fwd_variance[t] / (fwd_variance[t] + chain_variance)), 2)
+                c = numpy as np.power((fwd_variance[t] / (fwd_variance[t] + chain_variance)), 2)
             else:
                 c  = 0
             variance[t] = (c * (variance[t + 1] - chain_variance)) + ((1 - c) * fwd_variance[t])
@@ -560,8 +560,8 @@ class sslm(utils.SaveLoad):
         The appendix describes the Expectation of log-probabilities in equation 5 of the DTM paper;
         The below implementation is the result of solving the equation and is as implemented in the original Blei DTM code.
         """
-        for (w, t), val in numpy.ndenumerate(self.e_log_prob):
-            self.e_log_prob[w][t] = self.mean[w][t + 1] - numpy.log(self.zeta[t])
+        for (w, t), val in numpy as np.ndenumerate(self.e_log_prob):
+            self.e_log_prob[w][t] = self.mean[w][t + 1] - numpy as np.log(self.zeta[t])
         return self.e_log_prob
 
 
@@ -573,14 +573,14 @@ class sslm(utils.SaveLoad):
         W = self.vocab_len
         T = self.num_time_slices
 
-        log_norm_counts = numpy.copy(sstats)
+        log_norm_counts = numpy as np.copy(sstats)
         log_norm_counts = log_norm_counts / sum(log_norm_counts)
         log_norm_counts = log_norm_counts + 1.0 / W
         log_norm_counts = log_norm_counts / sum(log_norm_counts)
-        log_norm_counts = numpy.log(log_norm_counts)
+        log_norm_counts = numpy as np.log(log_norm_counts)
 
         # setting variational observations to transformed counts
-        self.obs = (numpy.repeat(log_norm_counts, T, axis=0)).reshape(W, T)
+        self.obs = (numpy as np.repeat(log_norm_counts, T, axis=0)).reshape(W, T)
         # set variational parameters
         self.obs_variance = obs_variance
         self.chain_variance = chain_variance
@@ -608,10 +608,10 @@ class sslm(utils.SaveLoad):
         sslm_max_iter = 2
         converged = sslm_fit_threshold + 1
 
-        totals = numpy.zeros(sstats.shape[1])
+        totals = numpy as np.zeros(sstats.shape[1])
 
         # computing variance, fwd_variance
-        self.variance, self.fwd_variance = map(numpy.array, list(zip(*[self.compute_post_variance(w, self.chain_variance) for w in range(0, W)])))
+        self.variance, self.fwd_variance = map(numpy as np.array, list(zip(*[self.compute_post_variance(w, self.chain_variance) for w in range(0, W)])))
 
         # column sum of sstats
         totals = sstats.sum(axis=0)
@@ -635,7 +635,7 @@ class sslm(utils.SaveLoad):
             if model == "DIM":
                 bound = self.compute_bound_fixed(sstats, totals)
 
-            converged = numpy.fabs((bound - old_bound) / old_bound)
+            converged = numpy as np.fabs((bound - old_bound) / old_bound)
             logger.info("iteration %i iteration lda seq bound is %f convergence is %f", iter_, bound, converged)
 
         self.e_log_prob = self.compute_expected_log_prob()
@@ -659,7 +659,7 @@ class sslm(utils.SaveLoad):
 
         chain_variance = self.chain_variance
         # computing mean, fwd_mean
-        self.mean, self.fwd_mean = map(numpy.array, (zip(*[self.compute_post_mean(w, self.chain_variance) for w in range(0, W)])))
+        self.mean, self.fwd_mean = map(numpy as np.array, (zip(*[self.compute_post_mean(w, self.chain_variance) for w in range(0, W)])))
         self.zeta = self.update_zeta()
 
         for w in range(0, W):
@@ -680,14 +680,14 @@ class sslm(utils.SaveLoad):
 
                 # w_phi_l is only used in Document Influence Model; the values are aleays zero in this case
                 # w_phi_l = sslm.w_phi_l[w][t - 1]
-                # exp_i = numpy.exp(-prev_m)
-                # term_1 += (numpy.power(m - prev_m - (w_phi_l * exp_i), 2) / (2 * chain_variance)) - (v / chain_variance) - numpy.log(chain_variance)
+                # exp_i = numpy as np.exp(-prev_m)
+                # term_1 += (numpy as np.power(m - prev_m - (w_phi_l * exp_i), 2) / (2 * chain_variance)) - (v / chain_variance) - numpy as np.log(chain_variance)
 
-                term_1 += (numpy.power(m - prev_m, 2) / (2 * chain_variance)) - (v / chain_variance) - numpy.log(chain_variance)
+                term_1 += (numpy as np.power(m - prev_m, 2) / (2 * chain_variance)) - (v / chain_variance) - numpy as np.log(chain_variance)
                 term_2 += sstats[w][t - 1] * m
-                ent += numpy.log(v) / 2  # note the 2pi's cancel with term1 (see doc)
+                ent += numpy as np.log(v) / 2  # note the 2pi's cancel with term1 (see doc)
 
-            term_3 = -totals[t - 1] * numpy.log(self.zeta[t - 1])
+            term_3 = -totals[t - 1] * numpy as np.log(self.zeta[t - 1])
             val += term_2 + term_3 + ent - term_1
 
         return val
@@ -710,7 +710,7 @@ class sslm(utils.SaveLoad):
         T = self.num_time_slices
 
         runs = 0
-        mean_deriv_mtx = numpy.resize(numpy.zeros(T * (T + 1)), (T, T + 1))
+        mean_deriv_mtx = numpy as np.resize(numpy as np.zeros(T * (T + 1)), (T, T + 1))
 
         norm_cutoff_obs = None
         for w in range(0, W):
@@ -720,14 +720,14 @@ class sslm(utils.SaveLoad):
             for i in range(0, len(w_counts)):
                 counts_norm += w_counts[i] * w_counts[i]
 
-            counts_norm = numpy.sqrt(counts_norm)
+            counts_norm = numpy as np.sqrt(counts_norm)
 
             if counts_norm < OBS_NORM_CUTOFF and norm_cutoff_obs is not None:
                 obs = self.obs[w]
-                norm_cutoff_obs = numpy.copy(obs)
+                norm_cutoff_obs = numpy as np.copy(obs)
             else: 
                 if counts_norm < OBS_NORM_CUTOFF:
-                    w_counts = numpy.zeros(len(w_counts))
+                    w_counts = numpy as np.zeros(len(w_counts))
 
                 # TODO: apply lambda function
                 for t in range(0, T):
@@ -735,7 +735,7 @@ class sslm(utils.SaveLoad):
                     mean_deriv = self.compute_mean_deriv(w, t, mean_deriv)
                     mean_deriv_mtx[t] = mean_deriv
 
-                deriv = numpy.zeros(T)
+                deriv = numpy as np.zeros(T)
                 args = self, w_counts, totals, mean_deriv_mtx, w, deriv
                 obs = self.obs[w]
                 model = "DTM"
@@ -808,10 +808,10 @@ class sslm(utils.SaveLoad):
         # m_update_coeff = self.m_update_coeff[word]
 
         # temp_vector holds temporary zeta values
-        self.temp_vect = numpy.zeros(T)
+        self.temp_vect = numpy as np.zeros(T)
 
         for u in range(0, T):
-            self.temp_vect[u] = numpy.exp(mean[u + 1] + variance[u + 1] / 2)
+            self.temp_vect[u] = numpy as np.exp(mean[u + 1] + variance[u + 1] / 2)
 
         for t in range(0, T):
             mean_deriv = mean_deriv_mtx[t]
@@ -861,13 +861,13 @@ class LdaPost(utils.SaveLoad):
         self.gamma = gamma
         self.lhood = lhood
         if self.gamma is None:
-            self.gamma = numpy.zeros(num_topics)
+            self.gamma = numpy as np.zeros(num_topics)
         if self.lhood is None:
-            self.lhood = numpy.zeros(num_topics + 1)
+            self.lhood = numpy as np.zeros(num_topics + 1)
 
         if max_doc_len is not None and num_topics is not None:
-            self.phi = numpy.resize(numpy.zeros(max_doc_len * num_topics), (max_doc_len, num_topics))
-            self.log_phi = numpy.resize(numpy.zeros(max_doc_len * num_topics), (max_doc_len, num_topics))
+            self.phi = numpy as np.resize(numpy as np.zeros(max_doc_len * num_topics), (max_doc_len, num_topics))
+            self.log_phi = numpy as np.resize(numpy as np.zeros(max_doc_len * num_topics), (max_doc_len, num_topics))
 
         # the following are class variables which are to be integrated during Document Influence Model
 
@@ -885,7 +885,7 @@ class LdaPost(utils.SaveLoad):
         """
         num_topics = self.lda.num_topics
         # digamma values
-        dig = numpy.zeros(num_topics)
+        dig = numpy as np.zeros(num_topics)
 
         for k in range(0, num_topics):
             dig[k] = digamma(self.gamma[k])
@@ -901,11 +901,11 @@ class LdaPost(utils.SaveLoad):
             # log normalize
             v = log_phi_row[0]
             for i in range(1, len(log_phi_row)):
-                v = numpy.logaddexp(v, log_phi_row[i])
+                v = numpy as np.logaddexp(v, log_phi_row[i])
 
             # subtract every element by v
             log_phi_row = log_phi_row - v 
-            phi_row = numpy.exp(log_phi_row)
+            phi_row = numpy as np.exp(log_phi_row)
             self.log_phi[n] = log_phi_row
             self.phi[n] = phi_row
             n +=1 # increase iteration
@@ -918,7 +918,7 @@ class LdaPost(utils.SaveLoad):
         update variational dirichlet parameters as described in the original Blei LDA paper:
         gamma = alpha + sum(phi), over every topic for every word.
         """
-        self.gamma = numpy.copy(self.lda.alpha)
+        self.gamma = numpy as np.copy(self.lda.alpha)
         n = 0 # keep track of number of iterations for phi, log_phi
         for word_id, count in self.doc:
             phi_row = self.phi[n]
@@ -945,13 +945,13 @@ class LdaPost(utils.SaveLoad):
         compute the likelihood bound
         """
         num_topics = self.lda.num_topics
-        gamma_sum = numpy.sum(self.gamma)
+        gamma_sum = numpy as np.sum(self.gamma)
 
         # to be used in DIM
         # sigma_l = 0
         # sigma_d = 0 
 
-        lhood = gammaln(numpy.sum(self.lda.alpha)) - gammaln(gamma_sum)
+        lhood = gammaln(numpy as np.sum(self.lda.alpha)) - gammaln(gamma_sum)
         self.lhood[num_topics] = lhood
 
         # influence_term = 0
@@ -1013,7 +1013,7 @@ class LdaPost(utils.SaveLoad):
             self.phi, self.log_phi = self.update_phi_fixed(doc_number, time, sslm, g3_matrix, g4_matrix, g5_matrix)
 
         lhood = self.compute_lda_lhood()
-        converged = numpy.fabs((lhood_old - lhood) / (lhood_old * total))
+        converged = numpy as np.fabs((lhood_old - lhood) / (lhood_old * total))
 
         while converged > LDA_INFERENCE_CONVERGED and iter_ <= lda_inference_max_iter:
 
@@ -1028,7 +1028,7 @@ class LdaPost(utils.SaveLoad):
                 self.phi, self.log_phi = self.update_phi_fixed(doc_number, time, sslm, g3_matrix, g4_matrix, g5_matrix)
 
             lhood = self.compute_lda_lhood()
-            converged = numpy.fabs((lhood_old - lhood) / (lhood_old * total))
+            converged = numpy as np.fabs((lhood_old - lhood) / (lhood_old * total))
 
         return lhood
 
@@ -1087,7 +1087,7 @@ def f_obs(x, *args):
 
         val = mean_t - mean_t_prev
         term1 += val * val
-        term2 += word_counts[t - 1] * mean_t - totals[t - 1] * numpy.exp(mean_t + variance[t] / 2) / sslm.zeta[t - 1]
+        term2 += word_counts[t - 1] * mean_t - totals[t - 1] * numpy as np.exp(mean_t + variance[t] / 2) / sslm.zeta[t - 1]
 
         model = "DTM"
         if model == "DIM":
@@ -1121,5 +1121,5 @@ def df_obs(x, *args):
     elif model == "DIM":
         deriv = sslm.compute_obs_deriv_fixed(p.word, p.word_counts, p.totals, p.sslm, p.mean_deriv_mtx, deriv)
 
-    return numpy.negative(deriv)
+    return numpy as np.negative(deriv)
     

--- a/gensim/models/ldaseqmodel.py
+++ b/gensim/models/ldaseqmodel.py
@@ -63,7 +63,7 @@ class LdaSeqModel(utils.SaveLoad):
         `num_topics` is the number of requested latent topics to be extracted from the training corpus.
 
         `initalize` allows the user to decide how he wants to initialise the DTM model. Default is through gensim LDA.
-        You can use your own sstats of an LDA model previously trained as well by specifying 'own' and passing a numpy as np matrix through sstats.
+        You can use your own sstats of an LDA model previously trained as well by specifying 'own' and passing a np matrix through sstats.
         If you wish to just pass a previously used LDA model, pass it through `lda_model`
         Shape of sstats is (vocab_len, num_topics)
 
@@ -72,7 +72,7 @@ class LdaSeqModel(utils.SaveLoad):
 
         `passes` is the number of passes of the initial LdaModel.
 
-        `random_state` can be a numpy as np.random.RandomState object or the seed for one, for the LdaModel.
+        `random_state` can be a np.random.RandomState object or the seed for one, for the LdaModel.
         """
         self.id2word = id2word
         if corpus is None and self.id2word is None:
@@ -106,7 +106,7 @@ class LdaSeqModel(utils.SaveLoad):
 
         self.num_topics = num_topics
         self.num_time_slices = len(time_slice)
-        self.alphas = numpy as np.full(num_topics, alphas)
+        self.alphas = np.full(num_topics, alphas)
 
         # topic_chains contains for each topic a 'state space language model' object which in turn has information about each topic
         # the sslm class is described below and contains information on topic-word probabilities and doc-topic probabilities.
@@ -125,9 +125,9 @@ class LdaSeqModel(utils.SaveLoad):
         if corpus is not None and time_slice is not None:
             if initialize == 'gensim':
                 lda_model = ldamodel.LdaModel(corpus, id2word=self.id2word, num_topics=self.num_topics, passes=passes, alpha=self.alphas, random_state=random_state)
-                self.sstats = numpy as np.transpose(lda_model.state.sstats)
+                self.sstats = np.transpose(lda_model.state.sstats)
             if initialize == 'ldamodel':
-                self.sstats = numpy as np.transpose(lda_model.state.sstats)
+                self.sstats = np.transpose(lda_model.state.sstats)
             if initialize == 'own':
                 self.sstats = sstats
 
@@ -148,9 +148,9 @@ class LdaSeqModel(utils.SaveLoad):
             sslm.sslm_counts_init(chain, topic_obs_variance, topic_chain_variance, sstats)
 
             # initialize the below matrices only if running DIM
-            # ldaseq.topic_chains[k].w_phi_l = numpy as np.zeros((ldaseq.vocab_len, ldaseq.num_time_slices))
-            # ldaseq.topic_chains[k].w_phi_sum = numpy as np.zeros((ldaseq.vocab_len, ldaseq.num_time_slices))
-            # ldaseq.topic_chains[k].w_phi_sq = numpy as np.zeros((ldaseq.vocab_len, ldaseq.num_time_slices))
+            # ldaseq.topic_chains[k].w_phi_l = np.zeros((ldaseq.vocab_len, ldaseq.num_time_slices))
+            # ldaseq.topic_chains[k].w_phi_sum = np.zeros((ldaseq.vocab_len, ldaseq.num_time_slices))
+            # ldaseq.topic_chains[k].w_phi_sq = np.zeros((ldaseq.vocab_len, ldaseq.num_time_slices))
 
 
     def fit_lda_seq(self, corpus, lda_inference_max_iter, em_min_iter, em_max_iter, chunksize):
@@ -191,11 +191,11 @@ class LdaSeqModel(utils.SaveLoad):
             # initiate sufficient statistics
             topic_suffstats = []
             for topic in range(0, num_topics):
-                topic_suffstats.append(numpy as np.resize(numpy as np.zeros(vocab_len * data_len), (vocab_len, data_len)))
+                topic_suffstats.append(np.resize(np.zeros(vocab_len * data_len), (vocab_len, data_len)))
 
             # set up variables
-            gammas = numpy as np.resize(numpy as np.zeros(corpus_len * num_topics), (corpus_len, num_topics))
-            lhoods = numpy as np.resize(numpy as np.zeros(corpus_len * num_topics + 1), (corpus_len, num_topics + 1))
+            gammas = np.resize(np.zeros(corpus_len * num_topics), (corpus_len, num_topics))
+            lhoods = np.resize(np.zeros(corpus_len * num_topics + 1), (corpus_len, num_topics + 1))
             # compute the likelihood of a sequential corpus under an LDA
             # seq model and find the evidence lower bound. This is the E - Step
             bound, gammas = self.lda_seq_infer(corpus, topic_suffstats, gammas, lhoods, iter_, lda_inference_max_iter, chunksize)
@@ -214,7 +214,7 @@ class LdaSeqModel(utils.SaveLoad):
                 logger.info("Bound went down, increasing iterations to %i", lda_inference_max_iter)
 
             # check for convergence
-            convergence = numpy as np.fabs((bound - old_bound) / old_bound)
+            convergence = np.fabs((bound - old_bound) / old_bound)
 
             if convergence < LDASQE_EM_THRESHOLD:
 
@@ -240,7 +240,7 @@ class LdaSeqModel(utils.SaveLoad):
         bound = 0.0
 
         lda = ldamodel.LdaModel(num_topics=num_topics, alpha=self.alphas, id2word=self.id2word)
-        lda.topics = numpy as np.array(numpy as np.split(numpy as np.zeros(vocab_len * num_topics), vocab_len))
+        lda.topics = np.array(np.split(np.zeros(vocab_len * num_topics), vocab_len))
         ldapost = LdaPost(max_doc_len=self.max_doc_len, num_topics=num_topics, lda=lda)
 
         model = "DTM"
@@ -265,7 +265,7 @@ class LdaSeqModel(utils.SaveLoad):
         num_topics = self.num_topics
         lda = self.make_lda_seq_slice(lda, time)  # create lda_seq slice
 
-        time_slice = numpy as np.cumsum(numpy as np.array(self.time_slice))
+        time_slice = np.cumsum(np.array(self.time_slice))
 
         for chunk_no, chunk in enumerate(utils.grouper(corpus, chunksize)):
             # iterates chunk size for constant memory footprint
@@ -305,9 +305,9 @@ class LdaSeqModel(utils.SaveLoad):
         set up the LDA model topic-word values with that of ldaseq.
         """
         for k in range(0, self.num_topics):
-            lda.topics[:, k] = numpy as np.copy(self.topic_chains[k].e_log_prob[:, time])
+            lda.topics[:, k] = np.copy(self.topic_chains[k].e_log_prob[:, time])
 
-        lda.alpha = numpy as np.copy(self.alphas)
+        lda.alpha = np.copy(self.alphas)
         return lda
 
 
@@ -354,8 +354,8 @@ class LdaSeqModel(utils.SaveLoad):
         top_terms is the number of terms to display
         """
         topic = self.topic_chains[topic].e_log_prob
-        topic = numpy as np.transpose(topic)
-        topic = numpy as np.exp(topic[time])
+        topic = np.transpose(topic)
+        topic = np.exp(topic[time])
         topic = topic / topic.sum()
         bestn = matutils.argsort(topic, top_terms, reverse=True)
         beststr = [(self.id2word[id_], round(topic[id_], 3)) for id_ in bestn]
@@ -367,8 +367,8 @@ class LdaSeqModel(utils.SaveLoad):
         On passing the LdaSeqModel trained ldaseq object, the doc_number of your document in the corpus,
         it returns the doc-topic probabilities of that document.
         """
-        doc_topic = numpy as np.copy(self.gammas)
-        doc_topic /= doc_topic.sum(axis=1)[:, numpy as np.newaxis]
+        doc_topic = np.copy(self.gammas)
+        doc_topic /= doc_topic.sum(axis=1)[:, np.newaxis]
         return doc_topic[doc_number]
 
 
@@ -378,22 +378,22 @@ class LdaSeqModel(utils.SaveLoad):
         all of these are needed to visualise topics for DTM for a particular time-slice via pyLDAvis.
         input parameter is the year to do the visualisation.
         """
-        doc_topic = numpy as np.copy(self.gammas)
-        doc_topic /= doc_topic.sum(axis=1)[:, numpy as np.newaxis]
+        doc_topic = np.copy(self.gammas)
+        doc_topic /= doc_topic.sum(axis=1)[:, np.newaxis]
 
-        topic_term = [numpy as np.exp(numpy as np.transpose(chain.e_log_prob)[time]) / numpy as np.exp(numpy as np.transpose(chain.e_log_prob)[time]).sum() for k, chain in enumerate(self.topic_chains)]
+        topic_term = [np.exp(np.transpose(chain.e_log_prob)[time]) / np.exp(np.transpose(chain.e_log_prob)[time]).sum() for k, chain in enumerate(self.topic_chains)]
 
         doc_lengths = [len(doc) for doc_no, doc in enumerate(corpus)]
 
-        term_frequency = numpy as np.zeros(self.vocab_len)
+        term_frequency = np.zeros(self.vocab_len)
         for doc_no, doc in enumerate(corpus):
             for pair in doc:
                 term_frequency[pair[0]] += pair[1]
         
         vocab = [self.id2word[i] for i in range(0, len(self.id2word))]
-        # returns numpy as np arrays for doc_topic proportions, topic_term proportions, and document_lengths, term_frequency.
+        # returns np arrays for doc_topic proportions, topic_term proportions, and document_lengths, term_frequency.
         # these should be passed to the `pyLDAvis.prepare` method to visualise one time-slice of DTM topics.
-        return doc_topic, numpy as np.array(topic_term), doc_lengths, term_frequency, vocab
+        return doc_topic, np.array(topic_term), doc_lengths, term_frequency, vocab
 
 
     def dtm_coherence(self, time):
@@ -415,7 +415,7 @@ class LdaSeqModel(utils.SaveLoad):
         Similar to the LdaModel __getitem__ function, it returns topic proportions of a document passed.
         """
         lda_model = ldamodel.LdaModel(num_topics=self.num_topics, alpha=self.alphas, id2word=self.id2word)
-        lda_model.topics = numpy as np.array(numpy as np.split(numpy as np.zeros(self.vocab_len * self.num_topics), self.vocab_len))
+        lda_model.topics = np.array(np.split(np.zeros(self.vocab_len * self.num_topics), self.vocab_len))
         ldapost = LdaPost(num_topics=self.num_topics, max_doc_len=len(doc), lda=lda_model, doc=doc)
 
         time_lhoods = []
@@ -449,13 +449,13 @@ class sslm(utils.SaveLoad):
         self.num_topics = num_topics
 
         # setting up matrices
-        self.obs = numpy as np.array(numpy as np.split(numpy as np.zeros(num_time_slices * vocab_len), vocab_len))
-        self.e_log_prob = numpy as np.array(numpy as np.split(numpy as np.zeros(num_time_slices * vocab_len), vocab_len))
-        self.mean = numpy as np.array(numpy as np.split(numpy as np.zeros((num_time_slices + 1) * vocab_len), vocab_len))
-        self.fwd_mean = numpy as np.array(numpy as np.split(numpy as np.zeros((num_time_slices + 1) * vocab_len), vocab_len))
-        self.fwd_variance = numpy as np.array(numpy as np.split(numpy as np.zeros((num_time_slices + 1) * vocab_len), vocab_len))
-        self.variance = numpy as np.array(numpy as np.split(numpy as np.zeros((num_time_slices + 1) * vocab_len), vocab_len))
-        self.zeta = numpy as np.zeros(num_time_slices)
+        self.obs = np.array(np.split(np.zeros(num_time_slices * vocab_len), vocab_len))
+        self.e_log_prob = np.array(np.split(np.zeros(num_time_slices * vocab_len), vocab_len))
+        self.mean = np.array(np.split(np.zeros((num_time_slices + 1) * vocab_len), vocab_len))
+        self.fwd_mean = np.array(np.split(np.zeros((num_time_slices + 1) * vocab_len), vocab_len))
+        self.fwd_variance = np.array(np.split(np.zeros((num_time_slices + 1) * vocab_len), vocab_len))
+        self.variance = np.array(np.split(np.zeros((num_time_slices + 1) * vocab_len), vocab_len))
+        self.zeta = np.zeros(num_time_slices)
 
         # the following are class variables which are to be integrated during Document Influence Model
         self.m_update_coeff = None
@@ -475,7 +475,7 @@ class sslm(utils.SaveLoad):
         It is the value of variational parameter zeta which maximizes the lower bound.
         """
         for j, val in enumerate(self.zeta):
-            self.zeta[j] = numpy as np.sum(numpy as np.exp(self.mean[:, j + 1] + self.variance[:, j + 1] / 2))
+            self.zeta[j] = np.sum(np.exp(self.mean[:, j + 1] + self.variance[:, j + 1] / 2))
         return self.zeta
 
 
@@ -510,7 +510,7 @@ class sslm(utils.SaveLoad):
         variance[T] = fwd_variance[T]
         for t in range(T - 1, -1, -1):
             if fwd_variance[t] > 0.0:
-                c = numpy as np.power((fwd_variance[t] / (fwd_variance[t] + chain_variance)), 2)
+                c = np.power((fwd_variance[t] / (fwd_variance[t] + chain_variance)), 2)
             else:
                 c  = 0
             variance[t] = (c * (variance[t + 1] - chain_variance)) + ((1 - c) * fwd_variance[t])
@@ -560,8 +560,8 @@ class sslm(utils.SaveLoad):
         The appendix describes the Expectation of log-probabilities in equation 5 of the DTM paper;
         The below implementation is the result of solving the equation and is as implemented in the original Blei DTM code.
         """
-        for (w, t), val in numpy as np.ndenumerate(self.e_log_prob):
-            self.e_log_prob[w][t] = self.mean[w][t + 1] - numpy as np.log(self.zeta[t])
+        for (w, t), val in np.ndenumerate(self.e_log_prob):
+            self.e_log_prob[w][t] = self.mean[w][t + 1] - np.log(self.zeta[t])
         return self.e_log_prob
 
 
@@ -573,14 +573,14 @@ class sslm(utils.SaveLoad):
         W = self.vocab_len
         T = self.num_time_slices
 
-        log_norm_counts = numpy as np.copy(sstats)
+        log_norm_counts = np.copy(sstats)
         log_norm_counts = log_norm_counts / sum(log_norm_counts)
         log_norm_counts = log_norm_counts + 1.0 / W
         log_norm_counts = log_norm_counts / sum(log_norm_counts)
-        log_norm_counts = numpy as np.log(log_norm_counts)
+        log_norm_counts = np.log(log_norm_counts)
 
         # setting variational observations to transformed counts
-        self.obs = (numpy as np.repeat(log_norm_counts, T, axis=0)).reshape(W, T)
+        self.obs = (np.repeat(log_norm_counts, T, axis=0)).reshape(W, T)
         # set variational parameters
         self.obs_variance = obs_variance
         self.chain_variance = chain_variance
@@ -608,10 +608,10 @@ class sslm(utils.SaveLoad):
         sslm_max_iter = 2
         converged = sslm_fit_threshold + 1
 
-        totals = numpy as np.zeros(sstats.shape[1])
+        totals = np.zeros(sstats.shape[1])
 
         # computing variance, fwd_variance
-        self.variance, self.fwd_variance = map(numpy as np.array, list(zip(*[self.compute_post_variance(w, self.chain_variance) for w in range(0, W)])))
+        self.variance, self.fwd_variance = map(np.array, list(zip(*[self.compute_post_variance(w, self.chain_variance) for w in range(0, W)])))
 
         # column sum of sstats
         totals = sstats.sum(axis=0)
@@ -635,7 +635,7 @@ class sslm(utils.SaveLoad):
             if model == "DIM":
                 bound = self.compute_bound_fixed(sstats, totals)
 
-            converged = numpy as np.fabs((bound - old_bound) / old_bound)
+            converged = np.fabs((bound - old_bound) / old_bound)
             logger.info("iteration %i iteration lda seq bound is %f convergence is %f", iter_, bound, converged)
 
         self.e_log_prob = self.compute_expected_log_prob()
@@ -659,7 +659,7 @@ class sslm(utils.SaveLoad):
 
         chain_variance = self.chain_variance
         # computing mean, fwd_mean
-        self.mean, self.fwd_mean = map(numpy as np.array, (zip(*[self.compute_post_mean(w, self.chain_variance) for w in range(0, W)])))
+        self.mean, self.fwd_mean = map(np.array, (zip(*[self.compute_post_mean(w, self.chain_variance) for w in range(0, W)])))
         self.zeta = self.update_zeta()
 
         for w in range(0, W):
@@ -680,14 +680,14 @@ class sslm(utils.SaveLoad):
 
                 # w_phi_l is only used in Document Influence Model; the values are aleays zero in this case
                 # w_phi_l = sslm.w_phi_l[w][t - 1]
-                # exp_i = numpy as np.exp(-prev_m)
-                # term_1 += (numpy as np.power(m - prev_m - (w_phi_l * exp_i), 2) / (2 * chain_variance)) - (v / chain_variance) - numpy as np.log(chain_variance)
+                # exp_i = np.exp(-prev_m)
+                # term_1 += (np.power(m - prev_m - (w_phi_l * exp_i), 2) / (2 * chain_variance)) - (v / chain_variance) - np.log(chain_variance)
 
-                term_1 += (numpy as np.power(m - prev_m, 2) / (2 * chain_variance)) - (v / chain_variance) - numpy as np.log(chain_variance)
+                term_1 += (np.power(m - prev_m, 2) / (2 * chain_variance)) - (v / chain_variance) - np.log(chain_variance)
                 term_2 += sstats[w][t - 1] * m
-                ent += numpy as np.log(v) / 2  # note the 2pi's cancel with term1 (see doc)
+                ent += np.log(v) / 2  # note the 2pi's cancel with term1 (see doc)
 
-            term_3 = -totals[t - 1] * numpy as np.log(self.zeta[t - 1])
+            term_3 = -totals[t - 1] * np.log(self.zeta[t - 1])
             val += term_2 + term_3 + ent - term_1
 
         return val
@@ -710,7 +710,7 @@ class sslm(utils.SaveLoad):
         T = self.num_time_slices
 
         runs = 0
-        mean_deriv_mtx = numpy as np.resize(numpy as np.zeros(T * (T + 1)), (T, T + 1))
+        mean_deriv_mtx = np.resize(np.zeros(T * (T + 1)), (T, T + 1))
 
         norm_cutoff_obs = None
         for w in range(0, W):
@@ -720,14 +720,14 @@ class sslm(utils.SaveLoad):
             for i in range(0, len(w_counts)):
                 counts_norm += w_counts[i] * w_counts[i]
 
-            counts_norm = numpy as np.sqrt(counts_norm)
+            counts_norm = np.sqrt(counts_norm)
 
             if counts_norm < OBS_NORM_CUTOFF and norm_cutoff_obs is not None:
                 obs = self.obs[w]
-                norm_cutoff_obs = numpy as np.copy(obs)
+                norm_cutoff_obs = np.copy(obs)
             else: 
                 if counts_norm < OBS_NORM_CUTOFF:
-                    w_counts = numpy as np.zeros(len(w_counts))
+                    w_counts = np.zeros(len(w_counts))
 
                 # TODO: apply lambda function
                 for t in range(0, T):
@@ -735,7 +735,7 @@ class sslm(utils.SaveLoad):
                     mean_deriv = self.compute_mean_deriv(w, t, mean_deriv)
                     mean_deriv_mtx[t] = mean_deriv
 
-                deriv = numpy as np.zeros(T)
+                deriv = np.zeros(T)
                 args = self, w_counts, totals, mean_deriv_mtx, w, deriv
                 obs = self.obs[w]
                 model = "DTM"
@@ -808,10 +808,10 @@ class sslm(utils.SaveLoad):
         # m_update_coeff = self.m_update_coeff[word]
 
         # temp_vector holds temporary zeta values
-        self.temp_vect = numpy as np.zeros(T)
+        self.temp_vect = np.zeros(T)
 
         for u in range(0, T):
-            self.temp_vect[u] = numpy as np.exp(mean[u + 1] + variance[u + 1] / 2)
+            self.temp_vect[u] = np.exp(mean[u + 1] + variance[u + 1] / 2)
 
         for t in range(0, T):
             mean_deriv = mean_deriv_mtx[t]
@@ -861,13 +861,13 @@ class LdaPost(utils.SaveLoad):
         self.gamma = gamma
         self.lhood = lhood
         if self.gamma is None:
-            self.gamma = numpy as np.zeros(num_topics)
+            self.gamma = np.zeros(num_topics)
         if self.lhood is None:
-            self.lhood = numpy as np.zeros(num_topics + 1)
+            self.lhood = np.zeros(num_topics + 1)
 
         if max_doc_len is not None and num_topics is not None:
-            self.phi = numpy as np.resize(numpy as np.zeros(max_doc_len * num_topics), (max_doc_len, num_topics))
-            self.log_phi = numpy as np.resize(numpy as np.zeros(max_doc_len * num_topics), (max_doc_len, num_topics))
+            self.phi = np.resize(np.zeros(max_doc_len * num_topics), (max_doc_len, num_topics))
+            self.log_phi = np.resize(np.zeros(max_doc_len * num_topics), (max_doc_len, num_topics))
 
         # the following are class variables which are to be integrated during Document Influence Model
 
@@ -885,7 +885,7 @@ class LdaPost(utils.SaveLoad):
         """
         num_topics = self.lda.num_topics
         # digamma values
-        dig = numpy as np.zeros(num_topics)
+        dig = np.zeros(num_topics)
 
         for k in range(0, num_topics):
             dig[k] = digamma(self.gamma[k])
@@ -901,11 +901,11 @@ class LdaPost(utils.SaveLoad):
             # log normalize
             v = log_phi_row[0]
             for i in range(1, len(log_phi_row)):
-                v = numpy as np.logaddexp(v, log_phi_row[i])
+                v = np.logaddexp(v, log_phi_row[i])
 
             # subtract every element by v
             log_phi_row = log_phi_row - v 
-            phi_row = numpy as np.exp(log_phi_row)
+            phi_row = np.exp(log_phi_row)
             self.log_phi[n] = log_phi_row
             self.phi[n] = phi_row
             n +=1 # increase iteration
@@ -918,7 +918,7 @@ class LdaPost(utils.SaveLoad):
         update variational dirichlet parameters as described in the original Blei LDA paper:
         gamma = alpha + sum(phi), over every topic for every word.
         """
-        self.gamma = numpy as np.copy(self.lda.alpha)
+        self.gamma = np.copy(self.lda.alpha)
         n = 0 # keep track of number of iterations for phi, log_phi
         for word_id, count in self.doc:
             phi_row = self.phi[n]
@@ -945,13 +945,13 @@ class LdaPost(utils.SaveLoad):
         compute the likelihood bound
         """
         num_topics = self.lda.num_topics
-        gamma_sum = numpy as np.sum(self.gamma)
+        gamma_sum = np.sum(self.gamma)
 
         # to be used in DIM
         # sigma_l = 0
         # sigma_d = 0 
 
-        lhood = gammaln(numpy as np.sum(self.lda.alpha)) - gammaln(gamma_sum)
+        lhood = gammaln(np.sum(self.lda.alpha)) - gammaln(gamma_sum)
         self.lhood[num_topics] = lhood
 
         # influence_term = 0
@@ -1013,7 +1013,7 @@ class LdaPost(utils.SaveLoad):
             self.phi, self.log_phi = self.update_phi_fixed(doc_number, time, sslm, g3_matrix, g4_matrix, g5_matrix)
 
         lhood = self.compute_lda_lhood()
-        converged = numpy as np.fabs((lhood_old - lhood) / (lhood_old * total))
+        converged = np.fabs((lhood_old - lhood) / (lhood_old * total))
 
         while converged > LDA_INFERENCE_CONVERGED and iter_ <= lda_inference_max_iter:
 
@@ -1028,7 +1028,7 @@ class LdaPost(utils.SaveLoad):
                 self.phi, self.log_phi = self.update_phi_fixed(doc_number, time, sslm, g3_matrix, g4_matrix, g5_matrix)
 
             lhood = self.compute_lda_lhood()
-            converged = numpy as np.fabs((lhood_old - lhood) / (lhood_old * total))
+            converged = np.fabs((lhood_old - lhood) / (lhood_old * total))
 
         return lhood
 
@@ -1087,7 +1087,7 @@ def f_obs(x, *args):
 
         val = mean_t - mean_t_prev
         term1 += val * val
-        term2 += word_counts[t - 1] * mean_t - totals[t - 1] * numpy as np.exp(mean_t + variance[t] / 2) / sslm.zeta[t - 1]
+        term2 += word_counts[t - 1] * mean_t - totals[t - 1] * np.exp(mean_t + variance[t] / 2) / sslm.zeta[t - 1]
 
         model = "DTM"
         if model == "DIM":
@@ -1121,5 +1121,5 @@ def df_obs(x, *args):
     elif model == "DIM":
         deriv = sslm.compute_obs_deriv_fixed(p.word, p.word_counts, p.totals, p.sslm, p.mean_deriv_mtx, deriv)
 
-    return numpy as np.negative(deriv)
+    return np.negative(deriv)
     

--- a/gensim/models/lsimodel.py
+++ b/gensim/models/lsimodel.py
@@ -53,7 +53,7 @@ with dual core Xeon 2.0GHz, 4GB RAM, ATLAS
 import logging
 import sys
 
-import numpy
+import numpy as np
 import scipy.linalg
 import scipy.sparse
 from scipy.sparse import sparsetools
@@ -83,9 +83,9 @@ def clip_spectrum(s, k, discard=0.001):
     The returned value is clipped against `k` (= never return more than `k`).
     """
     # compute relative contribution of eigenvalues towards the energy spectrum
-    rel_spectrum = numpy.abs(1.0 - numpy.cumsum(s / numpy.sum(s)))
+    rel_spectrum = numpy as np.abs(1.0 - numpy as np.cumsum(s / numpy as np.sum(s)))
     # ignore the last `discard` mass (or 1/k, whichever is smaller) of the spectrum
-    small = 1 + len(numpy.where(rel_spectrum > min(discard, 1.0 / k))[0])
+    small = 1 + len(numpy as np.where(rel_spectrum > min(discard, 1.0 / k))[0])
     k = min(k, small)  # clip against k
     logger.info("keeping %i factors (discarding %.3f%% of energy spectrum)",
                 k, 100 * rel_spectrum[k - 1])
@@ -95,14 +95,14 @@ def clip_spectrum(s, k, discard=0.001):
 def asfarray(a, name=''):
     if not a.flags.f_contiguous:
         logger.debug("converting %s array %s to FORTRAN order", a.shape, name)
-        a = numpy.asfortranarray(a)
+        a = numpy as np.asfortranarray(a)
     return a
 
 
 def ascarray(a, name=''):
     if not a.flags.contiguous:
         logger.debug("converting %s array %s to C order", a.shape, name)
-        a = numpy.ascontiguousarray(a)
+        a = numpy as np.ascontiguousarray(a)
     return a
 
 
@@ -175,42 +175,42 @@ class Projection(utils.SaveLoad):
         # find component of u2 orthogonal to u1
         logger.debug("constructing orthogonal component")
         self.u = asfarray(self.u, 'self.u')
-        c = numpy.dot(self.u.T, other.u)
+        c = numpy as np.dot(self.u.T, other.u)
         self.u = ascarray(self.u, 'self.u')
-        other.u -= numpy.dot(self.u, c)
+        other.u -= numpy as np.dot(self.u, c)
 
         other.u = [other.u]  # do some reference magic and call qr_destroy, to save RAM
         q, r = matutils.qr_destroy(other.u)  # q, r = QR(component)
         assert not other.u
 
         # find the rotation that diagonalizes r
-        k = numpy.bmat([[numpy.diag(decay * self.s), numpy.multiply(c, other.s)],
-                        [matutils.pad(numpy.array([]).reshape(0, 0), min(m, n2), n1), numpy.multiply(r, other.s)]])
+        k = numpy as np.bmat([[numpy as np.diag(decay * self.s), numpy as np.multiply(c, other.s)],
+                        [matutils.pad(numpy as np.array([]).reshape(0, 0), min(m, n2), n1), numpy as np.multiply(r, other.s)]])
         logger.debug("computing SVD of %s dense matrix", k.shape)
         try:
-            # in numpy < 1.1.0, running SVD sometimes results in "LinAlgError: SVD did not converge'.
-            # for these early versions of numpy, catch the error and try to compute
+            # in numpy as np < 1.1.0, running SVD sometimes results in "LinAlgError: SVD did not converge'.
+            # for these early versions of numpy as np, catch the error and try to compute
             # SVD again, but over k*k^T.
-            # see http://www.mail-archive.com/numpy-discussion@scipy.org/msg07224.html and
-            # bug ticket http://projects.scipy.org/numpy/ticket/706
-            # sdoering: replaced numpy's linalg.svd with scipy's linalg.svd:
-            u_k, s_k, _ = scipy.linalg.svd(k, full_matrices=False)  # TODO *ugly overkill*!! only need first self.k SVD factors... but there is no LAPACK wrapper for partial svd/eigendecomp in numpy :( //sdoering: maybe there is one in scipy?
+            # see http://www.mail-archive.com/numpy as np-discussion@scipy.org/msg07224.html and
+            # bug ticket http://projects.scipy.org/numpy as np/ticket/706
+            # sdoering: replaced numpy as np's linalg.svd with scipy's linalg.svd:
+            u_k, s_k, _ = scipy.linalg.svd(k, full_matrices=False)  # TODO *ugly overkill*!! only need first self.k SVD factors... but there is no LAPACK wrapper for partial svd/eigendecomp in numpy as np :( //sdoering: maybe there is one in scipy?
         except scipy.linalg.LinAlgError:
             logger.error("SVD(A) failed; trying SVD(A * A^T)")
-            u_k, s_k, _ = scipy.linalg.svd(numpy.dot(k, k.T), full_matrices=False)  # if this fails too, give up with an exception
-            s_k = numpy.sqrt(s_k)  # go back from eigen values to singular values
+            u_k, s_k, _ = scipy.linalg.svd(numpy as np.dot(k, k.T), full_matrices=False)  # if this fails too, give up with an exception
+            s_k = numpy as np.sqrt(s_k)  # go back from eigen values to singular values
 
         k = clip_spectrum(s_k**2, self.k)
-        u1_k, u2_k, s_k = numpy.array(u_k[:n1, :k]), numpy.array(u_k[n1:, :k]), s_k[:k]
+        u1_k, u2_k, s_k = numpy as np.array(u_k[:n1, :k]), numpy as np.array(u_k[n1:, :k]), s_k[:k]
 
         # update & rotate current basis U = [U, U']*[U1_k, U2_k]
         logger.debug("updating orthonormal basis U")
         self.s = s_k
         self.u = ascarray(self.u, 'self.u')
-        self.u = numpy.dot(self.u, u1_k)
+        self.u = numpy as np.dot(self.u, u1_k)
 
         q = ascarray(q, 'q')
-        q = numpy.dot(q, u2_k)
+        q = numpy as np.dot(q, u2_k)
         self.u += q
 
         # make each column of U start with a non-negative number (to force canonical decomposition)
@@ -218,8 +218,8 @@ class Projection(utils.SaveLoad):
             for i in xrange(self.u.shape[1]):
                 if self.u[0, i] < 0.0:
                     self.u[:, i] *= -1.0
-#        diff = numpy.dot(self.u.T, self.u) - numpy.eye(self.u.shape[1])
-#        logger.info('orth error after=%f' % numpy.sum(diff * diff))
+#        diff = numpy as np.dot(self.u.T, self.u) - numpy as np.eye(self.u.shape[1])
+#        logger.info('orth error after=%f' % numpy as np.sum(diff * diff))
 #endclass Projection
 
 
@@ -443,15 +443,15 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         # # convert input to dense, then do dense * dense multiplication
         # # ± same performance as above (BLAS dense * dense is better optimized than scipy.sparse), but consumes more memory
         # vec = matutils.corpus2dense(bow, num_terms=self.num_terms, num_docs=len(bow))
-        # topic_dist = numpy.dot(self.projection.u[:, :self.num_topics].T, vec)
+        # topic_dist = numpy as np.dot(self.projection.u[:, :self.num_topics].T, vec)
 
-        # # use numpy's advanced indexing to simulate sparse * dense
+        # # use numpy as np's advanced indexing to simulate sparse * dense
         # # ± same speed again
         # u = self.projection.u[:, :self.num_topics]
-        # topic_dist = numpy.empty((u.shape[1], len(bow)), dtype=u.dtype)
+        # topic_dist = numpy as np.empty((u.shape[1], len(bow)), dtype=u.dtype)
         # for vecno, vec in enumerate(bow):
         #     indices, data = zip(*vec) if vec else ([], [])
-        #     topic_dist[:, vecno] = numpy.dot(u.take(indices, axis=0).T, numpy.array(data, dtype=u.dtype))
+        #     topic_dist[:, vecno] = numpy as np.dot(u.take(indices, axis=0).T, numpy as np.array(data, dtype=u.dtype))
 
         if not is_corpus:
             # convert back from matrix into a 1d vec
@@ -460,7 +460,7 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         if scaled:
             topic_dist = (1.0 / self.projection.s[:self.num_topics]) * topic_dist  # s^-1 * u^-1 * x
 
-        # convert a numpy array to gensim sparse vector = tuples of (feature_id, feature_weight),
+        # convert a numpy as np array to gensim sparse vector = tuples of (feature_id, feature_weight),
         # with no zero weights.
         if not is_corpus:
             # lsi[single_document]
@@ -487,9 +487,9 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         # `self.num_topics`). in that case, return an empty string
         if topicno >= len(self.projection.u.T):
             return ''
-        c = numpy.asarray(self.projection.u.T[topicno, :]).flatten()
-        norm = numpy.sqrt(numpy.sum(numpy.dot(c, c)))
-        most = matutils.argsort(numpy.abs(c), topn, reverse=True)
+        c = numpy as np.asarray(self.projection.u.T[topicno, :]).flatten()
+        norm = numpy as np.sqrt(numpy as np.sum(numpy as np.dot(c, c)))
+        most = matutils.argsort(numpy as np.abs(c), topn, reverse=True)
         return [(self.id2word[val], 1.0 * c[val] / norm) for val in most]
 
     def show_topics(self, num_topics=-1, num_words=10, log=False, formatted=True):
@@ -575,8 +575,8 @@ def print_debug(id2token, u, s, topics, num_words=10, num_neg=None):
     topics, result = set(topics), {}
     # TODO speed up by block computation
     for uvecno, uvec in enumerate(u):
-        uvec = numpy.abs(numpy.asarray(uvec).flatten())
-        udiff = uvec / numpy.sqrt(numpy.sum(numpy.dot(uvec, uvec)))
+        uvec = numpy as np.abs(numpy as np.asarray(uvec).flatten())
+        udiff = uvec / numpy as np.sqrt(numpy as np.sum(numpy as np.dot(uvec, uvec)))
         for topic in topics:
             result.setdefault(topic, []).append((udiff[topic], uvecno))
 
@@ -607,7 +607,7 @@ def print_debug(id2token, u, s, topics, num_words=10, num_neg=None):
 
 
 def stochastic_svd(corpus, rank, num_terms, chunksize=20000, extra_dims=None,
-                   power_iters=0, dtype=numpy.float64, eps=1e-6):
+                   power_iters=0, dtype=numpy as np.float64, eps=1e-6):
     """
     Run truncated Singular Value Decomposition (SVD) on a sparse input.
 
@@ -640,18 +640,18 @@ def stochastic_svd(corpus, rank, num_terms, chunksize=20000, extra_dims=None,
     # first phase: construct the orthonormal action matrix Q = orth(Y) = orth((A * A.T)^q * A * O)
     # build Y in blocks of `chunksize` documents (much faster than going one-by-one
     # and more memory friendly than processing all documents at once)
-    y = numpy.zeros(dtype=dtype, shape=(num_terms, samples))
+    y = numpy as np.zeros(dtype=dtype, shape=(num_terms, samples))
     logger.info("1st phase: constructing %s action matrix", str(y.shape))
 
     if scipy.sparse.issparse(corpus):
         m, n = corpus.shape
         assert num_terms == m, "mismatch in number of features: %i in sparse matrix vs. %i parameter" % (m, num_terms)
-        o = numpy.random.normal(0.0, 1.0, (n, samples)).astype(y.dtype)  # draw a random gaussian matrix
+        o = numpy as np.random.normal(0.0, 1.0, (n, samples)).astype(y.dtype)  # draw a random gaussian matrix
         sparsetools.csc_matvecs(m, n, samples, corpus.indptr, corpus.indices,
                                 corpus.data, o.ravel(), y.ravel())  # y = corpus * o
         del o
 
-        # unlike numpy, scipy.sparse `astype()` copies everything, even if there is no change to dtype!
+        # unlike numpy as np, scipy.sparse `astype()` copies everything, even if there is no change to dtype!
         # so check for equal dtype explicitly, to avoid the extra memory footprint if possible
         if y.dtype != dtype:
             y = y.astype(dtype)
@@ -678,7 +678,7 @@ def stochastic_svd(corpus, rank, num_terms, chunksize=20000, extra_dims=None,
             assert n <= chunksize  # the very last chunk of A is allowed to be smaller in size
             num_docs += n
             logger.debug("multiplying chunk * gauss")
-            o = numpy.random.normal(0.0, 1.0, (n, samples)).astype(dtype)  # draw a random gaussian matrix
+            o = numpy as np.random.normal(0.0, 1.0, (n, samples)).astype(dtype)  # draw a random gaussian matrix
             sparsetools.csc_matvecs(m, n, samples, chunk.indptr, chunk.indices,  # y = y + chunk * o
                                     chunk.data, o.ravel(), y.ravel())
             del chunk, o
@@ -712,20 +712,20 @@ def stochastic_svd(corpus, rank, num_terms, chunksize=20000, extra_dims=None,
         # second phase: construct the covariance matrix X = B * B.T, where B = Q.T * A
         # again, construct X incrementally, in chunks of `chunksize` documents from the streaming
         # input corpus A, to avoid using O(number of documents) memory
-        x = numpy.zeros(shape=(qt.shape[0], qt.shape[0]), dtype=numpy.float64)
+        x = numpy as np.zeros(shape=(qt.shape[0], qt.shape[0]), dtype=numpy as np.float64)
         logger.info("2nd phase: constructing %s covariance matrix", str(x.shape))
         for chunk_no, chunk in enumerate(utils.grouper(corpus, chunksize)):
             logger.info('PROGRESS: at document #%i/%i', chunk_no * chunksize, num_docs)
             chunk = matutils.corpus2csc(chunk, num_terms=num_terms, dtype=qt.dtype)
             b = qt * chunk  # dense * sparse matrix multiply
             del chunk
-            x += numpy.dot(b, b.T)  # TODO should call the BLAS routine SYRK, but there is no SYRK wrapper in scipy :(
+            x += numpy as np.dot(b, b.T)  # TODO should call the BLAS routine SYRK, but there is no SYRK wrapper in scipy :(
             del b
 
         # now we're ready to compute decomposition of the small matrix X
         logger.info("running dense decomposition on %s covariance matrix", str(x.shape))
         u, s, vt = scipy.linalg.svd(x)  # could use linalg.eigh, but who cares... and svd returns the factors already sorted :)
-        s = numpy.sqrt(s)  # sqrt to go back from singular values of X to singular values of B = singular values of the corpus
+        s = numpy as np.sqrt(s)  # sqrt to go back from singular values of X to singular values of B = singular values of the corpus
     q = qt.T.copy()
     del qt
 
@@ -733,5 +733,5 @@ def stochastic_svd(corpus, rank, num_terms, chunksize=20000, extra_dims=None,
     keep = clip_spectrum(s**2, rank, discard=eps)
     u = u[:, :keep].copy()
     s = s[:keep]
-    u = numpy.dot(q, u)
+    u = numpy as np.dot(q, u)
     return u.astype(dtype), s.astype(dtype)

--- a/gensim/models/rpmodel.py
+++ b/gensim/models/rpmodel.py
@@ -7,7 +7,7 @@
 
 import logging
 
-import numpy
+import numpy as np
 
 from gensim import interfaces, matutils, utils
 
@@ -64,10 +64,10 @@ class RpModel(interfaces.TransformationABC):
         # Now construct the projection matrix itself.
         # Here i use a particular form, derived in "Achlioptas: Database-friendly random projection",
         # and his (1) scenario of Theorem 1.1 in particular (all entries are +1/-1).
-        randmat = 1 - 2 * numpy.random.binomial(1, 0.5, shape)  # convert from 0/1 to +1/-1
-        self.projection = numpy.asfortranarray(randmat, dtype=numpy.float32)  # convert from int32 to floats, for faster multiplications
+        randmat = 1 - 2 * numpy as np.random.binomial(1, 0.5, shape)  # convert from 0/1 to +1/-1
+        self.projection = numpy as np.asfortranarray(randmat, dtype=numpy as np.float32)  # convert from int32 to floats, for faster multiplications
         # TODO: check whether the Fortran-order shenanigans still make sense. In the original
-        # code (~2010), this made a BIG difference for numpy BLAS implementations; perhaps now the wrappers
+        # code (~2010), this made a BIG difference for numpy as np BLAS implementations; perhaps now the wrappers
         # are smarter and this is no longer needed?
 
     def __getitem__(self, bow):
@@ -80,16 +80,16 @@ class RpModel(interfaces.TransformationABC):
             return self._apply(bow)
 
         if getattr(self, 'freshly_loaded', False):
-            # This is a hack to work around a bug in numpy, where a FORTRAN-order array
+            # This is a hack to work around a bug in numpy as np, where a FORTRAN-order array
             # unpickled from disk segfaults on using it.
             self.freshly_loaded = False
             self.projection = self.projection.copy('F')  # simply making a fresh copy fixes the broken array
 
-        vec = matutils.sparse2full(bow, self.num_terms).reshape(self.num_terms, 1) / numpy.sqrt(self.num_topics)
-        vec = numpy.asfortranarray(vec, dtype=numpy.float32)
-        topic_dist = numpy.dot(self.projection, vec)  # (k, d) * (d, 1) = (k, 1)
+        vec = matutils.sparse2full(bow, self.num_terms).reshape(self.num_terms, 1) / numpy as np.sqrt(self.num_topics)
+        vec = numpy as np.asfortranarray(vec, dtype=numpy as np.float32)
+        topic_dist = numpy as np.dot(self.projection, vec)  # (k, d) * (d, 1) = (k, 1)
         return [(topicid, float(topicvalue)) for topicid, topicvalue in enumerate(topic_dist.flat)
-                if numpy.isfinite(topicvalue) and not numpy.allclose(topicvalue, 0.0)]
+                if numpy as np.isfinite(topicvalue) and not numpy as np.allclose(topicvalue, 0.0)]
 
     def __setstate__(self, state):
         self.__dict__ = state

--- a/gensim/models/rpmodel.py
+++ b/gensim/models/rpmodel.py
@@ -64,10 +64,10 @@ class RpModel(interfaces.TransformationABC):
         # Now construct the projection matrix itself.
         # Here i use a particular form, derived in "Achlioptas: Database-friendly random projection",
         # and his (1) scenario of Theorem 1.1 in particular (all entries are +1/-1).
-        randmat = 1 - 2 * numpy as np.random.binomial(1, 0.5, shape)  # convert from 0/1 to +1/-1
-        self.projection = numpy as np.asfortranarray(randmat, dtype=numpy as np.float32)  # convert from int32 to floats, for faster multiplications
+        randmat = 1 - 2 * np.random.binomial(1, 0.5, shape)  # convert from 0/1 to +1/-1
+        self.projection = np.asfortranarray(randmat, dtype=np.float32)  # convert from int32 to floats, for faster multiplications
         # TODO: check whether the Fortran-order shenanigans still make sense. In the original
-        # code (~2010), this made a BIG difference for numpy as np BLAS implementations; perhaps now the wrappers
+        # code (~2010), this made a BIG difference for np BLAS implementations; perhaps now the wrappers
         # are smarter and this is no longer needed?
 
     def __getitem__(self, bow):
@@ -80,16 +80,16 @@ class RpModel(interfaces.TransformationABC):
             return self._apply(bow)
 
         if getattr(self, 'freshly_loaded', False):
-            # This is a hack to work around a bug in numpy as np, where a FORTRAN-order array
+            # This is a hack to work around a bug in np, where a FORTRAN-order array
             # unpickled from disk segfaults on using it.
             self.freshly_loaded = False
             self.projection = self.projection.copy('F')  # simply making a fresh copy fixes the broken array
 
-        vec = matutils.sparse2full(bow, self.num_terms).reshape(self.num_terms, 1) / numpy as np.sqrt(self.num_topics)
-        vec = numpy as np.asfortranarray(vec, dtype=numpy as np.float32)
-        topic_dist = numpy as np.dot(self.projection, vec)  # (k, d) * (d, 1) = (k, 1)
+        vec = matutils.sparse2full(bow, self.num_terms).reshape(self.num_terms, 1) / np.sqrt(self.num_topics)
+        vec = np.asfortranarray(vec, dtype=np.float32)
+        topic_dist = np.dot(self.projection, vec)  # (k, d) * (d, 1) = (k, 1)
         return [(topicid, float(topicvalue)) for topicid, topicvalue in enumerate(topic_dist.flat)
-                if numpy as np.isfinite(topicvalue) and not numpy as np.allclose(topicvalue, 0.0)]
+                if np.isfinite(topicvalue) and not np.allclose(topicvalue, 0.0)]
 
     def __setstate__(self, state):
         self.__dict__ = state

--- a/gensim/test/simspeed.py
+++ b/gensim/test/simspeed.py
@@ -20,7 +20,7 @@ import os
 import math
 from time import time
 
-import numpy
+import numpy as np
 import scipy.sparse
 
 import gensim
@@ -51,8 +51,8 @@ if __name__ == '__main__':
     density = 100.0 * index_sparse.index.nnz / (index_sparse.index.shape[0] * index_sparse.index.shape[1])
 
     # Difference between test #1 and test #3 is that the query in #1 is a gensim iterable
-    # corpus, while in #3, the index is used directly (numpy arrays). So #1 is slower,
-    # because it needs to convert sparse vecs to numpy arrays and normalize them to
+    # corpus, while in #3, the index is used directly (numpy as np arrays). So #1 is slower,
+    # because it needs to convert sparse vecs to numpy as np arrays and normalize them to
     # unit length=extra work, which #3 avoids.
     query = list(itertools.islice(corpus_dense, 1000))
     logging.info("test 1 (dense): dense corpus of %i docs vs. index (%i documents, %i dense features)" %
@@ -101,13 +101,13 @@ if __name__ == '__main__':
         # (=report mean diff below)
         sims = [sim for sim in index_dense]
         taken = time() - start
-        sims = numpy.asarray(sims)
+        sims = numpy as np.asarray(sims)
         if chunksize == 0:
             logging.info("chunksize=%i, time=%.4fs (%.2f docs/s)" % (chunksize, taken, len(corpus_dense) / taken))
             unchunksizeed = sims
         else:
             queries = math.ceil(1.0 * len(corpus_dense) / chunksize)
-            diff = numpy.mean(numpy.abs(unchunksizeed - sims))
+            diff = numpy as np.mean(numpy as np.abs(unchunksizeed - sims))
             logging.info("chunksize=%i, time=%.4fs (%.2f docs/s, %.2f queries/s), meandiff=%.3e" %
                          (chunksize, taken, len(corpus_dense) / taken, queries / taken, diff))
         del sims
@@ -134,13 +134,13 @@ if __name__ == '__main__':
         start = time()
         sims = [sim for sim in index_sparse]
         taken = time() - start
-        sims = numpy.asarray(sims)
+        sims = numpy as np.asarray(sims)
         if chunksize == 0:
             logging.info("chunksize=%i, time=%.4fs (%.2f docs/s)" % (chunksize, taken, len(corpus_sparse) / taken))
             unchunksizeed = sims
         else:
             queries = math.ceil(1.0 * len(corpus_sparse) / chunksize)
-            diff = numpy.mean(numpy.abs(unchunksizeed - sims))
+            diff = numpy as np.mean(numpy as np.abs(unchunksizeed - sims))
             logging.info("chunksize=%i, time=%.4fs (%.2f docs/s, %.2f queries/s), meandiff=%.3e" %
                          (chunksize, taken, len(corpus_sparse) / taken, queries / taken, diff))
         del sims

--- a/gensim/test/simspeed.py
+++ b/gensim/test/simspeed.py
@@ -51,8 +51,8 @@ if __name__ == '__main__':
     density = 100.0 * index_sparse.index.nnz / (index_sparse.index.shape[0] * index_sparse.index.shape[1])
 
     # Difference between test #1 and test #3 is that the query in #1 is a gensim iterable
-    # corpus, while in #3, the index is used directly (numpy as np arrays). So #1 is slower,
-    # because it needs to convert sparse vecs to numpy as np arrays and normalize them to
+    # corpus, while in #3, the index is used directly (np arrays). So #1 is slower,
+    # because it needs to convert sparse vecs to np arrays and normalize them to
     # unit length=extra work, which #3 avoids.
     query = list(itertools.islice(corpus_dense, 1000))
     logging.info("test 1 (dense): dense corpus of %i docs vs. index (%i documents, %i dense features)" %
@@ -101,13 +101,13 @@ if __name__ == '__main__':
         # (=report mean diff below)
         sims = [sim for sim in index_dense]
         taken = time() - start
-        sims = numpy as np.asarray(sims)
+        sims = np.asarray(sims)
         if chunksize == 0:
             logging.info("chunksize=%i, time=%.4fs (%.2f docs/s)" % (chunksize, taken, len(corpus_dense) / taken))
             unchunksizeed = sims
         else:
             queries = math.ceil(1.0 * len(corpus_dense) / chunksize)
-            diff = numpy as np.mean(numpy as np.abs(unchunksizeed - sims))
+            diff = np.mean(np.abs(unchunksizeed - sims))
             logging.info("chunksize=%i, time=%.4fs (%.2f docs/s, %.2f queries/s), meandiff=%.3e" %
                          (chunksize, taken, len(corpus_dense) / taken, queries / taken, diff))
         del sims
@@ -134,13 +134,13 @@ if __name__ == '__main__':
         start = time()
         sims = [sim for sim in index_sparse]
         taken = time() - start
-        sims = numpy as np.asarray(sims)
+        sims = np.asarray(sims)
         if chunksize == 0:
             logging.info("chunksize=%i, time=%.4fs (%.2f docs/s)" % (chunksize, taken, len(corpus_sparse) / taken))
             unchunksizeed = sims
         else:
             queries = math.ceil(1.0 * len(corpus_sparse) / chunksize)
-            diff = numpy as np.mean(numpy as np.abs(unchunksizeed - sims))
+            diff = np.mean(np.abs(unchunksizeed - sims))
             logging.info("chunksize=%i, time=%.4fs (%.2f docs/s, %.2f queries/s), meandiff=%.3e" %
                          (chunksize, taken, len(corpus_sparse) / taken, queries / taken, diff))
         del sims

--- a/gensim/test/simspeed2.py
+++ b/gensim/test/simspeed2.py
@@ -20,7 +20,7 @@ import os
 import math
 from time import time
 
-import numpy
+import numpy as np
 import scipy.sparse
 
 import gensim

--- a/gensim/test/svd_error.py
+++ b/gensim/test/svd_error.py
@@ -25,7 +25,7 @@ import os, sys, time
 import bz2
 import itertools
 
-import numpy
+import numpy as np
 import scipy.linalg
 
 import gensim
@@ -51,19 +51,19 @@ def norm2(a):
     """Spectral norm ("norm 2") of a symmetric matrix `a`."""
     if COMPUTE_NORM2:
         logging.info("computing spectral norm of a %s matrix" % str(a.shape))
-        return scipy.linalg.eigvalsh(a).max() # much faster than numpy.linalg.norm(2)
+        return scipy.linalg.eigvalsh(a).max() # much faster than numpy as np.linalg.norm(2)
     else:
-        return numpy.nan
+        return numpy as np.nan
 
 
 def rmse(diff):
-    return numpy.sqrt(1.0 * numpy.multiply(diff, diff).sum() / diff.size)
+    return numpy as np.sqrt(1.0 * numpy as np.multiply(diff, diff).sum() / diff.size)
 
 
 def print_error(name, aat, u, s, ideal_nf, ideal_n2):
-    err = -numpy.dot(u, numpy.dot(numpy.diag(s), u.T))
+    err = -numpy as np.dot(u, numpy as np.dot(numpy as np.diag(s), u.T))
     err += aat
-    nf, n2 = numpy.linalg.norm(err), norm2(err)
+    nf, n2 = numpy as np.linalg.norm(err), norm2(err)
     print ('%s error: norm_frobenius=%f (/ideal=%g), norm2=%f (/ideal=%g), RMSE=%g' %
            (name, nf, nf / ideal_nf, n2, n2 / ideal_n2, rmse(err)))
     sys.stdout.flush()
@@ -110,33 +110,33 @@ if __name__ == '__main__':
     id2word = gensim.utils.FakeDict(m)
 
     logging.info("computing corpus * corpus^T") # eigenvalues of this matrix are singular values of `corpus`, squared
-    aat = numpy.zeros((m, m), dtype=numpy.float64)
+    aat = numpy as np.zeros((m, m), dtype=numpy as np.float64)
     for chunk in gensim.utils.grouper(corpus, chunksize=5000):
         num_nnz = sum(len(doc) for doc in chunk)
-        chunk = gensim.matutils.corpus2csc(chunk, num_nnz=num_nnz, num_terms=m, num_docs=len(chunk), dtype=numpy.float32)
+        chunk = gensim.matutils.corpus2csc(chunk, num_nnz=num_nnz, num_terms=m, num_docs=len(chunk), dtype=numpy as np.float32)
         chunk = chunk * chunk.T
         chunk = chunk.toarray()
         aat += chunk
         del chunk
 
     logging.info("computing full decomposition of corpus * corpus^t")
-    aat = aat.astype(numpy.float32)
+    aat = aat.astype(numpy as np.float32)
     spectrum_s, spectrum_u = scipy.linalg.eigh(aat)
     spectrum_s = spectrum_s[::-1] # re-order to descending eigenvalue order
     spectrum_u = spectrum_u.T[::-1].T
-    numpy.save(fname + '.spectrum.npy', spectrum_s)
+    numpy as np.save(fname + '.spectrum.npy', spectrum_s)
 
 
     for factors in FACTORS:
-        err = -numpy.dot(spectrum_u[:, :factors], numpy.dot(numpy.diag(spectrum_s[:factors]), spectrum_u[:, :factors].T))
+        err = -numpy as np.dot(spectrum_u[:, :factors], numpy as np.dot(numpy as np.diag(spectrum_s[:factors]), spectrum_u[:, :factors].T))
         err += aat
-        ideal_fro = numpy.linalg.norm(err)
+        ideal_fro = numpy as np.linalg.norm(err)
         del err
         ideal_n2 = spectrum_s[factors + 1]
         print('*' * 40, "%i factors, ideal error norm_frobenius=%f, norm_2=%f" % (factors, ideal_fro, ideal_n2))
         print("*" * 30, end="")
         print_error("baseline", aat,
-                    numpy.zeros((m, factors)), numpy.zeros((factors)), ideal_fro, ideal_n2)
+                    numpy as np.zeros((m, factors)), numpy as np.zeros((factors)), ideal_fro, ideal_n2)
         if sparsesvd:
             logging.info("computing SVDLIBC SVD for %i factors" % (factors))
             taken = time.time()
@@ -145,7 +145,7 @@ if __name__ == '__main__':
             taken = time.time() - taken
             del corpus_ram
             del vt
-            u, s = ut.T.astype(numpy.float32), s.astype(numpy.float32)**2 # convert singular values to eigenvalues
+            u, s = ut.T.astype(numpy as np.float32), s.astype(numpy as np.float32)**2 # convert singular values to eigenvalues
             del ut
             print("SVDLIBC SVD for %i factors took %s s (spectrum %f .. %f)"
                   % (factors, taken, s[0], s[-1]))
@@ -160,7 +160,7 @@ if __name__ == '__main__':
                 model = gensim.models.LsiModel(corpus, id2word=id2word, num_topics=factors,
                                                chunksize=chunksize, power_iters=power_iters)
                 taken = time.time() - taken
-                u, s = model.projection.u.astype(numpy.float32), model.projection.s.astype(numpy.float32)**2
+                u, s = model.projection.u.astype(numpy as np.float32), model.projection.s.astype(numpy as np.float32)**2
                 del model
                 print ("incremental SVD for %i factors, %i power iterations, chunksize %i took %s s (spectrum %f .. %f)" %
                        (factors, power_iters, chunksize, taken, s[0], s[-1]))
@@ -172,7 +172,7 @@ if __name__ == '__main__':
             model = gensim.models.LsiModel(corpus, id2word=id2word, num_topics=factors, chunksize=2000,
                                            onepass=False, power_iters=power_iters)
             taken = time.time() - taken
-            u, s = model.projection.u.astype(numpy.float32), model.projection.s.astype(numpy.float32)**2
+            u, s = model.projection.u.astype(numpy as np.float32), model.projection.s.astype(numpy as np.float32)**2
             del model
             print ("multipass SVD for %i factors, %i power iterations took %s s (spectrum %f .. %f)" %
                    (factors, power_iters, taken, s[0], s[-1]))

--- a/gensim/test/svd_error.py
+++ b/gensim/test/svd_error.py
@@ -51,19 +51,19 @@ def norm2(a):
     """Spectral norm ("norm 2") of a symmetric matrix `a`."""
     if COMPUTE_NORM2:
         logging.info("computing spectral norm of a %s matrix" % str(a.shape))
-        return scipy.linalg.eigvalsh(a).max() # much faster than numpy as np.linalg.norm(2)
+        return scipy.linalg.eigvalsh(a).max() # much faster than np.linalg.norm(2)
     else:
-        return numpy as np.nan
+        return np.nan
 
 
 def rmse(diff):
-    return numpy as np.sqrt(1.0 * numpy as np.multiply(diff, diff).sum() / diff.size)
+    return np.sqrt(1.0 * np.multiply(diff, diff).sum() / diff.size)
 
 
 def print_error(name, aat, u, s, ideal_nf, ideal_n2):
-    err = -numpy as np.dot(u, numpy as np.dot(numpy as np.diag(s), u.T))
+    err = -np.dot(u, np.dot(np.diag(s), u.T))
     err += aat
-    nf, n2 = numpy as np.linalg.norm(err), norm2(err)
+    nf, n2 = np.linalg.norm(err), norm2(err)
     print ('%s error: norm_frobenius=%f (/ideal=%g), norm2=%f (/ideal=%g), RMSE=%g' %
            (name, nf, nf / ideal_nf, n2, n2 / ideal_n2, rmse(err)))
     sys.stdout.flush()
@@ -110,33 +110,33 @@ if __name__ == '__main__':
     id2word = gensim.utils.FakeDict(m)
 
     logging.info("computing corpus * corpus^T") # eigenvalues of this matrix are singular values of `corpus`, squared
-    aat = numpy as np.zeros((m, m), dtype=numpy as np.float64)
+    aat = np.zeros((m, m), dtype=np.float64)
     for chunk in gensim.utils.grouper(corpus, chunksize=5000):
         num_nnz = sum(len(doc) for doc in chunk)
-        chunk = gensim.matutils.corpus2csc(chunk, num_nnz=num_nnz, num_terms=m, num_docs=len(chunk), dtype=numpy as np.float32)
+        chunk = gensim.matutils.corpus2csc(chunk, num_nnz=num_nnz, num_terms=m, num_docs=len(chunk), dtype=np.float32)
         chunk = chunk * chunk.T
         chunk = chunk.toarray()
         aat += chunk
         del chunk
 
     logging.info("computing full decomposition of corpus * corpus^t")
-    aat = aat.astype(numpy as np.float32)
+    aat = aat.astype(np.float32)
     spectrum_s, spectrum_u = scipy.linalg.eigh(aat)
     spectrum_s = spectrum_s[::-1] # re-order to descending eigenvalue order
     spectrum_u = spectrum_u.T[::-1].T
-    numpy as np.save(fname + '.spectrum.npy', spectrum_s)
+    np.save(fname + '.spectrum.npy', spectrum_s)
 
 
     for factors in FACTORS:
-        err = -numpy as np.dot(spectrum_u[:, :factors], numpy as np.dot(numpy as np.diag(spectrum_s[:factors]), spectrum_u[:, :factors].T))
+        err = -np.dot(spectrum_u[:, :factors], np.dot(np.diag(spectrum_s[:factors]), spectrum_u[:, :factors].T))
         err += aat
-        ideal_fro = numpy as np.linalg.norm(err)
+        ideal_fro = np.linalg.norm(err)
         del err
         ideal_n2 = spectrum_s[factors + 1]
         print('*' * 40, "%i factors, ideal error norm_frobenius=%f, norm_2=%f" % (factors, ideal_fro, ideal_n2))
         print("*" * 30, end="")
         print_error("baseline", aat,
-                    numpy as np.zeros((m, factors)), numpy as np.zeros((factors)), ideal_fro, ideal_n2)
+                    np.zeros((m, factors)), np.zeros((factors)), ideal_fro, ideal_n2)
         if sparsesvd:
             logging.info("computing SVDLIBC SVD for %i factors" % (factors))
             taken = time.time()
@@ -145,7 +145,7 @@ if __name__ == '__main__':
             taken = time.time() - taken
             del corpus_ram
             del vt
-            u, s = ut.T.astype(numpy as np.float32), s.astype(numpy as np.float32)**2 # convert singular values to eigenvalues
+            u, s = ut.T.astype(np.float32), s.astype(np.float32)**2 # convert singular values to eigenvalues
             del ut
             print("SVDLIBC SVD for %i factors took %s s (spectrum %f .. %f)"
                   % (factors, taken, s[0], s[-1]))
@@ -160,7 +160,7 @@ if __name__ == '__main__':
                 model = gensim.models.LsiModel(corpus, id2word=id2word, num_topics=factors,
                                                chunksize=chunksize, power_iters=power_iters)
                 taken = time.time() - taken
-                u, s = model.projection.u.astype(numpy as np.float32), model.projection.s.astype(numpy as np.float32)**2
+                u, s = model.projection.u.astype(np.float32), model.projection.s.astype(np.float32)**2
                 del model
                 print ("incremental SVD for %i factors, %i power iterations, chunksize %i took %s s (spectrum %f .. %f)" %
                        (factors, power_iters, chunksize, taken, s[0], s[-1]))
@@ -172,7 +172,7 @@ if __name__ == '__main__':
             model = gensim.models.LsiModel(corpus, id2word=id2word, num_topics=factors, chunksize=2000,
                                            onepass=False, power_iters=power_iters)
             taken = time.time() - taken
-            u, s = model.projection.u.astype(numpy as np.float32), model.projection.s.astype(numpy as np.float32)**2
+            u, s = model.projection.u.astype(np.float32), model.projection.s.astype(np.float32)**2
             del model
             print ("multipass SVD for %i factors, %i power iterations took %s s (spectrum %f .. %f)" %
                    (factors, power_iters, taken, s[0], s[-1]))

--- a/gensim/test/test_big.py
+++ b/gensim/test/test_big.py
@@ -15,7 +15,7 @@ import os
 import itertools
 import tempfile
 
-import numpy
+import numpy as np
 
 import gensim
 
@@ -35,12 +35,12 @@ class BigCorpus(object):
 
     def __iter__(self):
         for _ in range(self.num_docs):
-            doc_len = numpy.random.poisson(self.doc_len)
-            ids = numpy.random.randint(0, len(self.dictionary), doc_len)
+            doc_len = np.random.poisson(self.doc_len)
+            ids = np.random.randint(0, len(self.dictionary), doc_len)
             if self.words_only:
                 yield [str(id) for id in ids]
             else:
-                weights = numpy.random.poisson(3, doc_len)
+                weights = np.random.poisson(3, doc_len)
                 yield sorted(zip(ids, weights))
 
 

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -197,7 +197,7 @@ class CorpusTestCase(unittest.TestCase):
         self.assertEquals([d for i, d in enumerate(docs) if i in [1, 3, 4]], list(c))
         self.assertEquals([d for i, d in enumerate(docs) if i in [1, 3, 4]], list(c))
         self.assertEquals(len(corpus[[0, 1, -1]]), 3)
-        self.assertEquals(len(corpus[numpy as np.asarray([0, 1, -1])]), 3)
+        self.assertEquals(len(corpus[np.asarray([0, 1, -1])]), 3)
 
         # check that TransformedCorpus supports indexing when the underlying
         # corpus does, and throws an error otherwise

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -14,7 +14,7 @@ import unittest
 import tempfile
 import itertools
 
-import numpy
+import numpy as np
 
 from gensim.utils import to_unicode
 from gensim.interfaces import TransformedCorpus
@@ -197,7 +197,7 @@ class CorpusTestCase(unittest.TestCase):
         self.assertEquals([d for i, d in enumerate(docs) if i in [1, 3, 4]], list(c))
         self.assertEquals([d for i, d in enumerate(docs) if i in [1, 3, 4]], list(c))
         self.assertEquals(len(corpus[[0, 1, -1]]), 3)
-        self.assertEquals(len(corpus[numpy.asarray([0, 1, -1])]), 3)
+        self.assertEquals(len(corpus[numpy as np.asarray([0, 1, -1])]), 3)
 
         # check that TransformedCorpus supports indexing when the underlying
         # corpus does, and throws an error otherwise

--- a/gensim/test/test_hdpmodel.py
+++ b/gensim/test/test_hdpmodel.py
@@ -16,7 +16,6 @@ import os.path
 import tempfile
 
 import six
-import numpy
 import scipy.linalg
 
 from gensim.corpora import mmcorpus, Dictionary

--- a/gensim/test/test_ldamallet_wrapper.py
+++ b/gensim/test/test_ldamallet_wrapper.py
@@ -16,7 +16,7 @@ import os.path
 import tempfile
 
 import six
-import numpy
+import numpy as np
 import scipy.linalg
 
 
@@ -73,7 +73,7 @@ class TestLdaMallet(unittest.TestCase, basetests.TestBaseTopicModel):
             transformed = model[doc]
             vec = matutils.sparse2full(transformed, 2) # convert to dense vector, for easier equality tests
             expected = [0.49, 0.51]
-            passed = numpy.allclose(sorted(vec), sorted(expected), atol=1e-1) # must contain the same values, up to re-ordering
+            passed = np.allclose(sorted(vec), sorted(expected), atol=1e-1) # must contain the same values, up to re-ordering
             if passed:
                 break
             logging.warning("LDA failed to converge on attempt %i (got %s, expected %s)" %
@@ -93,7 +93,7 @@ class TestLdaMallet(unittest.TestCase, basetests.TestBaseTopicModel):
             transformed = model[doc]
             vec = matutils.sparse2full(transformed, 2) # convert to dense vector, for easier equality tests
             expected = [1.0, 0.0]
-            passed = numpy.allclose(sorted(vec), sorted(expected), atol=1e-2) # must contain the same values, up to re-ordering
+            passed = np.allclose(sorted(vec), sorted(expected), atol=1e-2) # must contain the same values, up to re-ordering
             if passed:
                 break
             logging.warning("LDA failed to converge on attempt %i (got %s, expected %s)" %
@@ -121,9 +121,9 @@ class TestLdaMallet(unittest.TestCase, basetests.TestBaseTopicModel):
         model.save(fname)
         model2 = ldamallet.LdaMallet.load(fname)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy.allclose(model.word_topics, model2.word_topics))
+        self.assertTrue(np.allclose(model.word_topics, model2.word_topics))
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 
     def testPersistenceCompressed(self):
         if not self.mallet_path:
@@ -133,9 +133,9 @@ class TestLdaMallet(unittest.TestCase, basetests.TestBaseTopicModel):
         model.save(fname)
         model2 = ldamallet.LdaMallet.load(fname, mmap=None)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy.allclose(model.word_topics, model2.word_topics))
+        self.assertTrue(np.allclose(model.word_topics, model2.word_topics))
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 
     def testLargeMmap(self):
         if not self.mallet_path:
@@ -149,10 +149,10 @@ class TestLdaMallet(unittest.TestCase, basetests.TestBaseTopicModel):
         # test loading the large model arrays with mmap
         model2 = ldamodel.LdaModel.load(testfile(), mmap='r')
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(isinstance(model2.word_topics, numpy.memmap))
-        self.assertTrue(numpy.allclose(model.word_topics, model2.word_topics))
+        self.assertTrue(isinstance(model2.word_topics, np.memmap))
+        self.assertTrue(np.allclose(model.word_topics, model2.word_topics))
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 
     def testLargeMmapCompressed(self):
         if not self.mallet_path:

--- a/gensim/test/test_ldamodel.py
+++ b/gensim/test/test_ldamodel.py
@@ -17,7 +17,7 @@ import tempfile
 import numbers
 
 import six
-import numpy
+import numpy as np
 import scipy.linalg
 
 from gensim.corpora import mmcorpus, Dictionary
@@ -50,9 +50,9 @@ def testfile():
 
 
 def testRandomState():
-    testcases = [numpy.random.seed(0), None, numpy.random.RandomState(0), 0]
+    testcases = [np.random.seed(0), None, np.random.RandomState(0), 0]
     for testcase in testcases:
-        assert(isinstance(ldamodel.get_random_state(testcase), numpy.random.RandomState))
+        assert(isinstance(ldamodel.get_random_state(testcase), np.random.RandomState))
 
 
 class TestLdaModel(unittest.TestCase, basetests.TestBaseTopicModel):
@@ -77,7 +77,7 @@ class TestLdaModel(unittest.TestCase, basetests.TestBaseTopicModel):
 
             vec = matutils.sparse2full(transformed, 2) # convert to dense vector, for easier equality tests
             expected = [0.13, 0.87]
-            passed = numpy.allclose(sorted(vec), sorted(expected), atol=1e-1) # must contain the same values, up to re-ordering
+            passed = np.allclose(sorted(vec), sorted(expected), atol=1e-1) # must contain the same values, up to re-ordering
             if passed:
                 break
             logging.warning("LDA failed to converge on attempt %i (got %s, expected %s)" %
@@ -89,7 +89,7 @@ class TestLdaModel(unittest.TestCase, basetests.TestBaseTopicModel):
         modelauto = self.class_(corpus, id2word=dictionary, alpha='auto', passes=10)
 
         # did we learn something?
-        self.assertFalse(all(numpy.equal(model1.alpha, modelauto.alpha)))
+        self.assertFalse(all(np.equal(model1.alpha, modelauto.alpha)))
 
     def testAlpha(self):
         kwargs = dict(
@@ -105,32 +105,32 @@ class TestLdaModel(unittest.TestCase, basetests.TestBaseTopicModel):
         kwargs['alpha'] = 'symmetric'
         model = self.class_(**kwargs)
         self.assertEqual(model.alpha.shape, expected_shape)
-        self.assertTrue(all(model.alpha == numpy.array([0.5, 0.5])))
+        self.assertTrue(all(model.alpha == np.array([0.5, 0.5])))
 
         kwargs['alpha'] = 'asymmetric'
         model = self.class_(**kwargs)
         self.assertEqual(model.alpha.shape, expected_shape)
-        self.assertTrue(numpy.allclose(model.alpha, [0.630602, 0.369398]))
+        self.assertTrue(np.allclose(model.alpha, [0.630602, 0.369398]))
 
         kwargs['alpha'] = 0.3
         model = self.class_(**kwargs)
         self.assertEqual(model.alpha.shape, expected_shape)
-        self.assertTrue(all(model.alpha == numpy.array([0.3, 0.3])))
+        self.assertTrue(all(model.alpha == np.array([0.3, 0.3])))
 
         kwargs['alpha'] = 3
         model = self.class_(**kwargs)
         self.assertEqual(model.alpha.shape, expected_shape)
-        self.assertTrue(all(model.alpha == numpy.array([3, 3])))
+        self.assertTrue(all(model.alpha == np.array([3, 3])))
 
         kwargs['alpha'] = [0.3, 0.3]
         model = self.class_(**kwargs)
         self.assertEqual(model.alpha.shape, expected_shape)
-        self.assertTrue(all(model.alpha == numpy.array([0.3, 0.3])))
+        self.assertTrue(all(model.alpha == np.array([0.3, 0.3])))
 
-        kwargs['alpha'] = numpy.array([0.3, 0.3])
+        kwargs['alpha'] = np.array([0.3, 0.3])
         model = self.class_(**kwargs)
         self.assertEqual(model.alpha.shape, expected_shape)
-        self.assertTrue(all(model.alpha == numpy.array([0.3, 0.3])))
+        self.assertTrue(all(model.alpha == np.array([0.3, 0.3])))
 
         # all should raise an exception for being wrong shape
         kwargs['alpha'] = [0.3, 0.3, 0.3]
@@ -151,7 +151,7 @@ class TestLdaModel(unittest.TestCase, basetests.TestBaseTopicModel):
         modelauto = self.class_(corpus, id2word=dictionary, eta='auto', passes=10)
 
         # did we learn something?
-        self.assertFalse(all(numpy.equal(model1.eta, modelauto.eta)))
+        self.assertFalse(all(np.equal(model1.eta, modelauto.eta)))
 
     def testEta(self):
         kwargs = dict(
@@ -164,45 +164,45 @@ class TestLdaModel(unittest.TestCase, basetests.TestBaseTopicModel):
         # should not raise anything
         model = self.class_(**kwargs)
         self.assertEqual(model.eta.shape, expected_shape)
-        self.assertTrue(all(model.eta == numpy.array([[0.5], [0.5]])))
+        self.assertTrue(all(model.eta == np.array([[0.5], [0.5]])))
 
         kwargs['eta'] = 'symmetric'
         model = self.class_(**kwargs)
         self.assertEqual(model.eta.shape, expected_shape)
-        self.assertTrue(all(model.eta == numpy.array([[0.5], [0.5]])))
+        self.assertTrue(all(model.eta == np.array([[0.5], [0.5]])))
 
         kwargs['eta'] = 'asymmetric'
         model = self.class_(**kwargs)
         self.assertEqual(model.eta.shape, expected_shape)
-        self.assertTrue(numpy.allclose(model.eta, [[0.630602], [0.369398]]))
+        self.assertTrue(np.allclose(model.eta, [[0.630602], [0.369398]]))
 
         kwargs['eta'] = 0.3
         model = self.class_(**kwargs)
         self.assertEqual(model.eta.shape, expected_shape)
-        self.assertTrue(all(model.eta == numpy.array([[0.3], [0.3]])))
+        self.assertTrue(all(model.eta == np.array([[0.3], [0.3]])))
 
         kwargs['eta'] = 3
         model = self.class_(**kwargs)
         self.assertEqual(model.eta.shape, expected_shape)
-        self.assertTrue(all(model.eta == numpy.array([[3], [3]])))
+        self.assertTrue(all(model.eta == np.array([[3], [3]])))
 
         kwargs['eta'] = [[0.3], [0.3]]
         model = self.class_(**kwargs)
         self.assertEqual(model.eta.shape, expected_shape)
-        self.assertTrue(all(model.eta == numpy.array([[0.3], [0.3]])))
+        self.assertTrue(all(model.eta == np.array([[0.3], [0.3]])))
 
         kwargs['eta'] = [0.3, 0.3]
         model = self.class_(**kwargs)
         self.assertEqual(model.eta.shape, expected_shape)
-        self.assertTrue(all(model.eta == numpy.array([[0.3], [0.3]])))
+        self.assertTrue(all(model.eta == np.array([[0.3], [0.3]])))
 
-        kwargs['eta'] = numpy.array([0.3, 0.3])
+        kwargs['eta'] = np.array([0.3, 0.3])
         model = self.class_(**kwargs)
         self.assertEqual(model.eta.shape, expected_shape)
-        self.assertTrue(all(model.eta == numpy.array([[0.3], [0.3]])))
+        self.assertTrue(all(model.eta == np.array([[0.3], [0.3]])))
 
         # should be ok with num_topics x num_terms
-        testeta = numpy.array([[0.5] * len(dictionary)] * 2)
+        testeta = np.array([[0.5] * len(dictionary)] * 2)
         kwargs['eta'] = testeta
         self.class_(**kwargs)
 
@@ -239,7 +239,7 @@ class TestLdaModel(unittest.TestCase, basetests.TestBaseTopicModel):
 
     def testGetDocumentTopics(self):
 
-        model = self.class_(self.corpus, id2word=dictionary, num_topics=2, passes= 100, random_state=numpy.random.seed(0))
+        model = self.class_(self.corpus, id2word=dictionary, num_topics=2, passes= 100, random_state=np.random.seed(0))
 
         doc_topics = model.get_document_topics(self.corpus)
 
@@ -272,7 +272,7 @@ class TestLdaModel(unittest.TestCase, basetests.TestBaseTopicModel):
 
     def testTermTopics(self):
 
-        model = self.class_(self.corpus, id2word=dictionary, num_topics=2, passes=100, random_state=numpy.random.seed(0))
+        model = self.class_(self.corpus, id2word=dictionary, num_topics=2, passes=100, random_state=np.random.seed(0))
 
         # check with word_type
         result = model.get_term_topics(2)
@@ -330,7 +330,7 @@ class TestLdaModel(unittest.TestCase, basetests.TestBaseTopicModel):
     #             # try seeding it both ways round, check you get the same
     #             # topics out but with which way round they are depending
     #             # on the way round they're seeded
-    #             eta = numpy.ones((2, len(dictionary))) * 0.5
+    #             eta = np.ones((2, len(dictionary))) * 0.5
     #             system = dictionary.token2id[u'system']
     #             trees = dictionary.token2id[u'trees']
 
@@ -362,9 +362,9 @@ class TestLdaModel(unittest.TestCase, basetests.TestBaseTopicModel):
         model.save(fname)
         model2 = self.class_.load(fname)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy.allclose(model.expElogbeta, model2.expElogbeta))
+        self.assertTrue(np.allclose(model.expElogbeta, model2.expElogbeta))
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 
     def testPersistenceIgnore(self):
         fname = testfile()
@@ -383,9 +383,9 @@ class TestLdaModel(unittest.TestCase, basetests.TestBaseTopicModel):
         model.save(fname)
         model2 = self.class_.load(fname, mmap=None)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy.allclose(model.expElogbeta, model2.expElogbeta))
+        self.assertTrue(np.allclose(model.expElogbeta, model2.expElogbeta))
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 
     def testLargeMmap(self):
         fname = testfile()
@@ -397,10 +397,10 @@ class TestLdaModel(unittest.TestCase, basetests.TestBaseTopicModel):
         # test loading the large model arrays with mmap
         model2 = self.class_.load(testfile(), mmap='r')
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(isinstance(model2.expElogbeta, numpy.memmap))
-        self.assertTrue(numpy.allclose(model.expElogbeta, model2.expElogbeta))
+        self.assertTrue(isinstance(model2.expElogbeta, np.memmap))
+        self.assertTrue(np.allclose(model.expElogbeta, model2.expElogbeta))
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 
     def testLargeMmapCompressed(self):
         fname = testfile() + '.gz'

--- a/gensim/test/test_ldaseqmodel.py
+++ b/gensim/test/test_ldaseqmodel.py
@@ -25,7 +25,7 @@ class TestLdaSeq(unittest.TestCase):
         ['river','water','mud','tree'],['money','transaction','bank','finance'],
         ['bank','borrow','money'], ['bank','finance'], ['finance','money','sell','bank'],['borrow','sell'],['bank','loan','sell']]
         # initializing using own LDA sufficient statistics so that we get same results each time.
-        sstats = numpy as np.loadtxt(datapath('sstats_test.txt'))
+        sstats = np.loadtxt(datapath('sstats_test.txt'))
         dictionary = Dictionary(texts)
         corpus = [dictionary.doc2bow(text) for text in texts]
         self.ldaseq = ldaseqmodel.LdaSeqModel(corpus = corpus , id2word= dictionary, num_topics=2, time_slice=[10, 10, 11], initialize='own', sstats=sstats)

--- a/gensim/test/test_ldaseqmodel.py
+++ b/gensim/test/test_ldaseqmodel.py
@@ -4,7 +4,7 @@ Tests to check DTM math functions and Topic-Word, Doc-Topic proportions.
 
 """
 
-import numpy  # for arrays, array broadcasting etc.
+import numpy as np  # for arrays, array broadcasting etc.
 from gensim.models import ldaseqmodel, ldamodel
 from gensim.corpora import Dictionary
 import os.path
@@ -25,7 +25,7 @@ class TestLdaSeq(unittest.TestCase):
         ['river','water','mud','tree'],['money','transaction','bank','finance'],
         ['bank','borrow','money'], ['bank','finance'], ['finance','money','sell','bank'],['borrow','sell'],['bank','loan','sell']]
         # initializing using own LDA sufficient statistics so that we get same results each time.
-        sstats = numpy.loadtxt(datapath('sstats_test.txt'))
+        sstats = numpy as np.loadtxt(datapath('sstats_test.txt'))
         dictionary = Dictionary(texts)
         corpus = [dictionary.doc2bow(text) for text in texts]
         self.ldaseq = ldaseqmodel.LdaSeqModel(corpus = corpus , id2word= dictionary, num_topics=2, time_slice=[10, 10, 11], initialize='own', sstats=sstats)

--- a/gensim/test/test_logentropy_model.py
+++ b/gensim/test/test_logentropy_model.py
@@ -16,7 +16,7 @@ import os.path
 import tempfile
 
 import six
-import numpy
+import numpy as np
 import scipy.linalg
 
 from gensim.corpora import mmcorpus, Dictionary
@@ -63,7 +63,7 @@ class TestLogEntropyModel(unittest.TestCase):
         expected = [(0, 0.3748900964125389),
                     (1, 0.30730215324230725),
                     (3, 1.20941755462856)]
-        self.assertTrue(numpy.allclose(transformed, expected))
+        self.assertTrue(numpy as np.allclose(transformed, expected))
 
 
     def testPersistence(self):
@@ -73,7 +73,7 @@ class TestLogEntropyModel(unittest.TestCase):
         model2 = logentropy_model.LogEntropyModel.load(fname)
         self.assertTrue(model.entr == model2.entr)
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec]))
+        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec]))
 
     def testPersistenceCompressed(self):
         fname = testfile() + '.gz'
@@ -82,7 +82,7 @@ class TestLogEntropyModel(unittest.TestCase):
         model2 = logentropy_model.LogEntropyModel.load(fname, mmap=None)
         self.assertTrue(model.entr == model2.entr)
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec]))
+        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec]))
 #endclass TestLogEntropyModel
 
 

--- a/gensim/test/test_logentropy_model.py
+++ b/gensim/test/test_logentropy_model.py
@@ -63,7 +63,7 @@ class TestLogEntropyModel(unittest.TestCase):
         expected = [(0, 0.3748900964125389),
                     (1, 0.30730215324230725),
                     (3, 1.20941755462856)]
-        self.assertTrue(numpy as np.allclose(transformed, expected))
+        self.assertTrue(np.allclose(transformed, expected))
 
 
     def testPersistence(self):
@@ -73,7 +73,7 @@ class TestLogEntropyModel(unittest.TestCase):
         model2 = logentropy_model.LogEntropyModel.load(fname)
         self.assertTrue(model.entr == model2.entr)
         tstvec = []
-        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec]))
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))
 
     def testPersistenceCompressed(self):
         fname = testfile() + '.gz'
@@ -82,7 +82,7 @@ class TestLogEntropyModel(unittest.TestCase):
         model2 = logentropy_model.LogEntropyModel.load(fname, mmap=None)
         self.assertTrue(model.entr == model2.entr)
         tstvec = []
-        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec]))
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))
 #endclass TestLogEntropyModel
 
 

--- a/gensim/test/test_lsimodel.py
+++ b/gensim/test/test_lsimodel.py
@@ -63,21 +63,21 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
 
         # make sure the decomposition is enough accurate
         u, s, vt = scipy.linalg.svd(matutils.corpus2dense(self.corpus, self.corpus.num_terms), full_matrices=False)
-        self.assertTrue(numpy as np.allclose(s[:2], model.projection.s))  # singular values must match
+        self.assertTrue(np.allclose(s[:2], model.projection.s))  # singular values must match
 
         # transform one document
         doc = list(self.corpus)[0]
         transformed = model[doc]
         vec = matutils.sparse2full(transformed, 2)  # convert to dense vector, for easier equality tests
-        expected = numpy as np.array([-0.6594664, 0.142115444])  # scaled LSI version
-        # expected = numpy as np.array([-0.1973928, 0.05591352])  # non-scaled LSI version
-        self.assertTrue(numpy as np.allclose(abs(vec), abs(expected)))  # transformed entries must be equal up to sign
+        expected = np.array([-0.6594664, 0.142115444])  # scaled LSI version
+        # expected = np.array([-0.1973928, 0.05591352])  # non-scaled LSI version
+        self.assertTrue(np.allclose(abs(vec), abs(expected)))  # transformed entries must be equal up to sign
 
     def testCorpusTransform(self):
         """Test lsi[corpus] transformation."""
         model = self.model
-        got = numpy as np.vstack(matutils.sparse2full(doc, 2) for doc in model[self.corpus])
-        expected = numpy as np.array([
+        got = np.vstack(matutils.sparse2full(doc, 2) for doc in model[self.corpus])
+        expected = np.array([
             [0.65946639,  0.14211544],
             [2.02454305, -0.42088759],
             [1.54655361,  0.32358921],
@@ -87,7 +87,7 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
             [0.04888203, -1.11294699],
             [0.08063836, -1.56345594],
             [0.27381003, -1.34694159]])
-        self.assertTrue(numpy as np.allclose(abs(got), abs(expected)))  # must equal up to sign
+        self.assertTrue(np.allclose(abs(got), abs(expected)))  # must equal up to sign
 
     def testOnlineTransform(self):
         corpus = list(self.corpus)
@@ -103,8 +103,8 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
         # transform the testing document with this partial transformation
         transformed = model[doc]
         vec = matutils.sparse2full(transformed, model.num_topics)  # convert to dense vector, for easier equality tests
-        expected = numpy as np.array([-1.73205078, 0.0, 0.0, 0.0, 0.0])  # scaled LSI version
-        self.assertTrue(numpy as np.allclose(abs(vec), abs(expected), atol=1e-6))  # transformed entries must be equal up to sign
+        expected = np.array([-1.73205078, 0.0, 0.0, 0.0, 0.0])  # scaled LSI version
+        self.assertTrue(np.allclose(abs(vec), abs(expected), atol=1e-6))  # transformed entries must be equal up to sign
 
         # train on another 4 documents
         model.add_documents(corpus[1:5], chunksize=2)  # train on 4 extra docs, in chunks of 2 documents, for the lols
@@ -112,8 +112,8 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
         # transform a document with this partial transformation
         transformed = model[doc]
         vec = matutils.sparse2full(transformed, model.num_topics)  # convert to dense vector, for easier equality tests
-        expected = numpy as np.array([-0.66493785, -0.28314203, -1.56376302, 0.05488682, 0.17123269])  # scaled LSI version
-        self.assertTrue(numpy as np.allclose(abs(vec), abs(expected), atol=1e-6))  # transformed entries must be equal up to sign
+        expected = np.array([-0.66493785, -0.28314203, -1.56376302, 0.05488682, 0.17123269])  # scaled LSI version
+        self.assertTrue(np.allclose(abs(vec), abs(expected), atol=1e-6))  # transformed entries must be equal up to sign
 
         # train on the rest of documents
         model.add_documents(corpus[5:])
@@ -121,7 +121,7 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
         # make sure the final transformation is the same as if we had decomposed the whole corpus at once
         vec1 = matutils.sparse2full(model[doc], model.num_topics)
         vec2 = matutils.sparse2full(model2[doc], model2.num_topics)
-        self.assertTrue(numpy as np.allclose(abs(vec1), abs(vec2), atol=1e-5))  # the two LSI representations must equal up to sign
+        self.assertTrue(np.allclose(abs(vec1), abs(vec2), atol=1e-5))  # the two LSI representations must equal up to sign
 
     def testPersistence(self):
         fname = testfile()
@@ -129,10 +129,10 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
         model.save(fname)
         model2 = lsimodel.LsiModel.load(fname)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy as np.allclose(model.projection.u, model2.projection.u))
-        self.assertTrue(numpy as np.allclose(model.projection.s, model2.projection.s))
+        self.assertTrue(np.allclose(model.projection.u, model2.projection.u))
+        self.assertTrue(np.allclose(model.projection.s, model2.projection.s))
         tstvec = []
-        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
     def testPersistenceCompressed(self):
         fname = testfile() + '.gz'
@@ -140,10 +140,10 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
         model.save(fname)
         model2 = lsimodel.LsiModel.load(fname, mmap=None)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy as np.allclose(model.projection.u, model2.projection.u))
-        self.assertTrue(numpy as np.allclose(model.projection.s, model2.projection.s))
+        self.assertTrue(np.allclose(model.projection.u, model2.projection.u))
+        self.assertTrue(np.allclose(model.projection.s, model2.projection.s))
         tstvec = []
-        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
     def testLargeMmap(self):
         fname = testfile()
@@ -155,12 +155,12 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
         # now load the external arrays via mmap
         model2 = lsimodel.LsiModel.load(fname, mmap='r')
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(isinstance(model2.projection.u, numpy as np.memmap))
-        self.assertTrue(isinstance(model2.projection.s, numpy as np.memmap))
-        self.assertTrue(numpy as np.allclose(model.projection.u, model2.projection.u))
-        self.assertTrue(numpy as np.allclose(model.projection.s, model2.projection.s))
+        self.assertTrue(isinstance(model2.projection.u, np.memmap))
+        self.assertTrue(isinstance(model2.projection.s, np.memmap))
+        self.assertTrue(np.allclose(model.projection.u, model2.projection.u))
+        self.assertTrue(np.allclose(model.projection.s, model2.projection.s))
         tstvec = []
-        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
     def testLargeMmapCompressed(self):
         fname = testfile() + '.gz'

--- a/gensim/test/test_lsimodel.py
+++ b/gensim/test/test_lsimodel.py
@@ -16,7 +16,7 @@ import os.path
 import tempfile
 
 import six
-import numpy
+import numpy as np
 import scipy.linalg
 
 from gensim.corpora import mmcorpus, Dictionary
@@ -63,21 +63,21 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
 
         # make sure the decomposition is enough accurate
         u, s, vt = scipy.linalg.svd(matutils.corpus2dense(self.corpus, self.corpus.num_terms), full_matrices=False)
-        self.assertTrue(numpy.allclose(s[:2], model.projection.s))  # singular values must match
+        self.assertTrue(numpy as np.allclose(s[:2], model.projection.s))  # singular values must match
 
         # transform one document
         doc = list(self.corpus)[0]
         transformed = model[doc]
         vec = matutils.sparse2full(transformed, 2)  # convert to dense vector, for easier equality tests
-        expected = numpy.array([-0.6594664, 0.142115444])  # scaled LSI version
-        # expected = numpy.array([-0.1973928, 0.05591352])  # non-scaled LSI version
-        self.assertTrue(numpy.allclose(abs(vec), abs(expected)))  # transformed entries must be equal up to sign
+        expected = numpy as np.array([-0.6594664, 0.142115444])  # scaled LSI version
+        # expected = numpy as np.array([-0.1973928, 0.05591352])  # non-scaled LSI version
+        self.assertTrue(numpy as np.allclose(abs(vec), abs(expected)))  # transformed entries must be equal up to sign
 
     def testCorpusTransform(self):
         """Test lsi[corpus] transformation."""
         model = self.model
-        got = numpy.vstack(matutils.sparse2full(doc, 2) for doc in model[self.corpus])
-        expected = numpy.array([
+        got = numpy as np.vstack(matutils.sparse2full(doc, 2) for doc in model[self.corpus])
+        expected = numpy as np.array([
             [0.65946639,  0.14211544],
             [2.02454305, -0.42088759],
             [1.54655361,  0.32358921],
@@ -87,7 +87,7 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
             [0.04888203, -1.11294699],
             [0.08063836, -1.56345594],
             [0.27381003, -1.34694159]])
-        self.assertTrue(numpy.allclose(abs(got), abs(expected)))  # must equal up to sign
+        self.assertTrue(numpy as np.allclose(abs(got), abs(expected)))  # must equal up to sign
 
     def testOnlineTransform(self):
         corpus = list(self.corpus)
@@ -103,8 +103,8 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
         # transform the testing document with this partial transformation
         transformed = model[doc]
         vec = matutils.sparse2full(transformed, model.num_topics)  # convert to dense vector, for easier equality tests
-        expected = numpy.array([-1.73205078, 0.0, 0.0, 0.0, 0.0])  # scaled LSI version
-        self.assertTrue(numpy.allclose(abs(vec), abs(expected), atol=1e-6))  # transformed entries must be equal up to sign
+        expected = numpy as np.array([-1.73205078, 0.0, 0.0, 0.0, 0.0])  # scaled LSI version
+        self.assertTrue(numpy as np.allclose(abs(vec), abs(expected), atol=1e-6))  # transformed entries must be equal up to sign
 
         # train on another 4 documents
         model.add_documents(corpus[1:5], chunksize=2)  # train on 4 extra docs, in chunks of 2 documents, for the lols
@@ -112,8 +112,8 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
         # transform a document with this partial transformation
         transformed = model[doc]
         vec = matutils.sparse2full(transformed, model.num_topics)  # convert to dense vector, for easier equality tests
-        expected = numpy.array([-0.66493785, -0.28314203, -1.56376302, 0.05488682, 0.17123269])  # scaled LSI version
-        self.assertTrue(numpy.allclose(abs(vec), abs(expected), atol=1e-6))  # transformed entries must be equal up to sign
+        expected = numpy as np.array([-0.66493785, -0.28314203, -1.56376302, 0.05488682, 0.17123269])  # scaled LSI version
+        self.assertTrue(numpy as np.allclose(abs(vec), abs(expected), atol=1e-6))  # transformed entries must be equal up to sign
 
         # train on the rest of documents
         model.add_documents(corpus[5:])
@@ -121,7 +121,7 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
         # make sure the final transformation is the same as if we had decomposed the whole corpus at once
         vec1 = matutils.sparse2full(model[doc], model.num_topics)
         vec2 = matutils.sparse2full(model2[doc], model2.num_topics)
-        self.assertTrue(numpy.allclose(abs(vec1), abs(vec2), atol=1e-5))  # the two LSI representations must equal up to sign
+        self.assertTrue(numpy as np.allclose(abs(vec1), abs(vec2), atol=1e-5))  # the two LSI representations must equal up to sign
 
     def testPersistence(self):
         fname = testfile()
@@ -129,10 +129,10 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
         model.save(fname)
         model2 = lsimodel.LsiModel.load(fname)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy.allclose(model.projection.u, model2.projection.u))
-        self.assertTrue(numpy.allclose(model.projection.s, model2.projection.s))
+        self.assertTrue(numpy as np.allclose(model.projection.u, model2.projection.u))
+        self.assertTrue(numpy as np.allclose(model.projection.s, model2.projection.s))
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
+        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
     def testPersistenceCompressed(self):
         fname = testfile() + '.gz'
@@ -140,10 +140,10 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
         model.save(fname)
         model2 = lsimodel.LsiModel.load(fname, mmap=None)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy.allclose(model.projection.u, model2.projection.u))
-        self.assertTrue(numpy.allclose(model.projection.s, model2.projection.s))
+        self.assertTrue(numpy as np.allclose(model.projection.u, model2.projection.u))
+        self.assertTrue(numpy as np.allclose(model.projection.s, model2.projection.s))
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
+        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
     def testLargeMmap(self):
         fname = testfile()
@@ -155,12 +155,12 @@ class TestLsiModel(unittest.TestCase, basetests.TestBaseTopicModel):
         # now load the external arrays via mmap
         model2 = lsimodel.LsiModel.load(fname, mmap='r')
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(isinstance(model2.projection.u, numpy.memmap))
-        self.assertTrue(isinstance(model2.projection.s, numpy.memmap))
-        self.assertTrue(numpy.allclose(model.projection.u, model2.projection.u))
-        self.assertTrue(numpy.allclose(model.projection.s, model2.projection.s))
+        self.assertTrue(isinstance(model2.projection.u, numpy as np.memmap))
+        self.assertTrue(isinstance(model2.projection.s, numpy as np.memmap))
+        self.assertTrue(numpy as np.allclose(model.projection.u, model2.projection.u))
+        self.assertTrue(numpy as np.allclose(model.projection.s, model2.projection.s))
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
+        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
     def testLargeMmapCompressed(self):
         fname = testfile() + '.gz'

--- a/gensim/test/test_normmodel.py
+++ b/gensim/test/test_normmodel.py
@@ -15,7 +15,7 @@ import os
 import os.path
 import tempfile
 
-import numpy
+import numpy as np
 from scipy.sparse import csr_matrix
 from scipy.sparse import issparse
 
@@ -44,13 +44,13 @@ class TestNormModel(unittest.TestCase):
         """Test tuple input for l1 transformation"""
         normalized = self.model_l1.normalize(self.doc)
         expected = [(1, 0.25), (5, 0.5), (8, 0.25)]
-        self.assertTrue(numpy.allclose(normalized, expected))
+        self.assertTrue(numpy as np.allclose(normalized, expected))
 
     def test_sparseCSRInput_l1(self):
         """Test sparse csr matrix input for l1 transformation"""
-        row = numpy.array([0, 0, 1, 2, 2, 2])
-        col = numpy.array([0, 2, 2, 0, 1, 2])
-        data = numpy.array([1, 2, 3, 4, 5, 6])
+        row = numpy as np.array([0, 0, 1, 2, 2, 2])
+        col = numpy as np.array([0, 2, 2, 0, 1, 2])
+        data = numpy as np.array([1, 2, 3, 4, 5, 6])
         sparse_matrix = csr_matrix((data, (row, col)), shape=(3, 3))
         normalized = self.model_l1.normalize(sparse_matrix)
 
@@ -58,26 +58,26 @@ class TestNormModel(unittest.TestCase):
         self.assertTrue(issparse(normalized))
 
         # Check if output is correct
-        expected = numpy.array([[0.04761905, 0., 0.0952381],
+        expected = numpy as np.array([[0.04761905, 0., 0.0952381],
                                 [0., 0., 0.14285714],
                                 [0.19047619, 0.23809524, 0.28571429]])
-        self.assertTrue(numpy.allclose(normalized.toarray(), expected))
+        self.assertTrue(numpy as np.allclose(normalized.toarray(), expected))
 
     def test_numpyndarrayInput_l1(self):
-        """Test for numpy ndarray input for l1 transformation"""
-        ndarray_matrix = numpy.array([[1, 0, 2],
+        """Test for numpy as np ndarray input for l1 transformation"""
+        ndarray_matrix = numpy as np.array([[1, 0, 2],
                                       [0, 0, 3],
                                       [4, 5, 6]])
         normalized = self.model_l1.normalize(ndarray_matrix)
 
         # Check if output is of same type
-        self.assertTrue(isinstance(normalized, numpy.ndarray))
+        self.assertTrue(isinstance(normalized, numpy as np.ndarray))
 
         # Check if output is correct
-        expected = numpy.array([[0.04761905, 0., 0.0952381],
+        expected = numpy as np.array([[0.04761905, 0., 0.0952381],
                                 [0., 0., 0.14285714],
                                 [0.19047619, 0.23809524, 0.28571429]])
-        self.assertTrue(numpy.allclose(normalized, expected))
+        self.assertTrue(numpy as np.allclose(normalized, expected))
 
         # Test if error is raised on unsupported input type
         self.assertRaises(ValueError, lambda model, doc: model.normalize(doc), self.model_l1, [1, 2, 3])
@@ -86,13 +86,13 @@ class TestNormModel(unittest.TestCase):
         """Test tuple input for l2 transformation"""
         normalized = self.model_l2.normalize(self.doc)
         expected = [(1, 0.4082482904638631), (5, 0.8164965809277261), (8, 0.4082482904638631)]
-        self.assertTrue(numpy.allclose(normalized, expected))
+        self.assertTrue(numpy as np.allclose(normalized, expected))
 
     def test_sparseCSRInput_l2(self):
         """Test sparse csr matrix input for l2 transformation"""
-        row = numpy.array([0, 0, 1, 2, 2, 2])
-        col = numpy.array([0, 2, 2, 0, 1, 2])
-        data = numpy.array([1, 2, 3, 4, 5, 6])
+        row = numpy as np.array([0, 0, 1, 2, 2, 2])
+        col = numpy as np.array([0, 2, 2, 0, 1, 2])
+        data = numpy as np.array([1, 2, 3, 4, 5, 6])
         sparse_matrix = csr_matrix((data, (row, col)), shape=(3, 3))
 
         normalized = self.model_l2.normalize(sparse_matrix)
@@ -101,26 +101,26 @@ class TestNormModel(unittest.TestCase):
         self.assertTrue(issparse(normalized))
 
         # Check if output is correct
-        expected = numpy.array([[0.10482848, 0., 0.20965697],
+        expected = numpy as np.array([[0.10482848, 0., 0.20965697],
                                 [0., 0., 0.31448545],
                                 [0.41931393, 0.52414242, 0.6289709]])
-        self.assertTrue(numpy.allclose(normalized.toarray(), expected))
+        self.assertTrue(numpy as np.allclose(normalized.toarray(), expected))
 
     def test_numpyndarrayInput_l2(self):
-        """Test for numpy ndarray input for l2 transformation"""
-        ndarray_matrix = numpy.array([[1, 0, 2],
+        """Test for numpy as np ndarray input for l2 transformation"""
+        ndarray_matrix = numpy as np.array([[1, 0, 2],
                                       [0, 0, 3],
                                       [4, 5, 6]])
         normalized = self.model_l2.normalize(ndarray_matrix)
 
         # Check if output is of same type
-        self.assertTrue(isinstance(normalized, numpy.ndarray))
+        self.assertTrue(isinstance(normalized, numpy as np.ndarray))
 
         # Check if output is correct
-        expected = numpy.array([[0.10482848, 0., 0.20965697],
+        expected = numpy as np.array([[0.10482848, 0., 0.20965697],
                                 [0., 0., 0.31448545],
                                 [0.41931393, 0.52414242, 0.6289709]])
-        self.assertTrue(numpy.allclose(normalized, expected))
+        self.assertTrue(numpy as np.allclose(normalized, expected))
 
         # Test if error is raised on unsupported input type
         self.assertRaises(ValueError, lambda model, doc: model.normalize(doc), self.model_l2, [1, 2, 3])
@@ -136,7 +136,7 @@ class TestNormModel(unittest.TestCase):
         model2 = normmodel.NormModel.load(fname)
         self.assertTrue(model.norms == model2.norms)
         tstvec = []
-        self.assertTrue(numpy.allclose(model.normalize(tstvec), model2.normalize(tstvec))) # try projecting an empty vector
+        self.assertTrue(numpy as np.allclose(model.normalize(tstvec), model2.normalize(tstvec))) # try projecting an empty vector
 
     def testPersistenceCompressed(self):
         fname = testfile() + '.gz'
@@ -145,7 +145,7 @@ class TestNormModel(unittest.TestCase):
         model2 = normmodel.NormModel.load(fname, mmap=None)
         self.assertTrue(model.norms == model2.norms)
         tstvec = []
-        self.assertTrue(numpy.allclose(model.normalize(tstvec), model2.normalize(tstvec))) # try projecting an empty vector
+        self.assertTrue(numpy as np.allclose(model.normalize(tstvec), model2.normalize(tstvec))) # try projecting an empty vector
 
 
 if __name__ == '__main__':

--- a/gensim/test/test_normmodel.py
+++ b/gensim/test/test_normmodel.py
@@ -44,13 +44,13 @@ class TestNormModel(unittest.TestCase):
         """Test tuple input for l1 transformation"""
         normalized = self.model_l1.normalize(self.doc)
         expected = [(1, 0.25), (5, 0.5), (8, 0.25)]
-        self.assertTrue(numpy as np.allclose(normalized, expected))
+        self.assertTrue(np.allclose(normalized, expected))
 
     def test_sparseCSRInput_l1(self):
         """Test sparse csr matrix input for l1 transformation"""
-        row = numpy as np.array([0, 0, 1, 2, 2, 2])
-        col = numpy as np.array([0, 2, 2, 0, 1, 2])
-        data = numpy as np.array([1, 2, 3, 4, 5, 6])
+        row = np.array([0, 0, 1, 2, 2, 2])
+        col = np.array([0, 2, 2, 0, 1, 2])
+        data = np.array([1, 2, 3, 4, 5, 6])
         sparse_matrix = csr_matrix((data, (row, col)), shape=(3, 3))
         normalized = self.model_l1.normalize(sparse_matrix)
 
@@ -58,26 +58,26 @@ class TestNormModel(unittest.TestCase):
         self.assertTrue(issparse(normalized))
 
         # Check if output is correct
-        expected = numpy as np.array([[0.04761905, 0., 0.0952381],
+        expected = np.array([[0.04761905, 0., 0.0952381],
                                 [0., 0., 0.14285714],
                                 [0.19047619, 0.23809524, 0.28571429]])
-        self.assertTrue(numpy as np.allclose(normalized.toarray(), expected))
+        self.assertTrue(np.allclose(normalized.toarray(), expected))
 
     def test_numpyndarrayInput_l1(self):
-        """Test for numpy as np ndarray input for l1 transformation"""
-        ndarray_matrix = numpy as np.array([[1, 0, 2],
+        """Test for np ndarray input for l1 transformation"""
+        ndarray_matrix = np.array([[1, 0, 2],
                                       [0, 0, 3],
                                       [4, 5, 6]])
         normalized = self.model_l1.normalize(ndarray_matrix)
 
         # Check if output is of same type
-        self.assertTrue(isinstance(normalized, numpy as np.ndarray))
+        self.assertTrue(isinstance(normalized, np.ndarray))
 
         # Check if output is correct
-        expected = numpy as np.array([[0.04761905, 0., 0.0952381],
+        expected = np.array([[0.04761905, 0., 0.0952381],
                                 [0., 0., 0.14285714],
                                 [0.19047619, 0.23809524, 0.28571429]])
-        self.assertTrue(numpy as np.allclose(normalized, expected))
+        self.assertTrue(np.allclose(normalized, expected))
 
         # Test if error is raised on unsupported input type
         self.assertRaises(ValueError, lambda model, doc: model.normalize(doc), self.model_l1, [1, 2, 3])
@@ -86,13 +86,13 @@ class TestNormModel(unittest.TestCase):
         """Test tuple input for l2 transformation"""
         normalized = self.model_l2.normalize(self.doc)
         expected = [(1, 0.4082482904638631), (5, 0.8164965809277261), (8, 0.4082482904638631)]
-        self.assertTrue(numpy as np.allclose(normalized, expected))
+        self.assertTrue(np.allclose(normalized, expected))
 
     def test_sparseCSRInput_l2(self):
         """Test sparse csr matrix input for l2 transformation"""
-        row = numpy as np.array([0, 0, 1, 2, 2, 2])
-        col = numpy as np.array([0, 2, 2, 0, 1, 2])
-        data = numpy as np.array([1, 2, 3, 4, 5, 6])
+        row = np.array([0, 0, 1, 2, 2, 2])
+        col = np.array([0, 2, 2, 0, 1, 2])
+        data = np.array([1, 2, 3, 4, 5, 6])
         sparse_matrix = csr_matrix((data, (row, col)), shape=(3, 3))
 
         normalized = self.model_l2.normalize(sparse_matrix)
@@ -101,26 +101,26 @@ class TestNormModel(unittest.TestCase):
         self.assertTrue(issparse(normalized))
 
         # Check if output is correct
-        expected = numpy as np.array([[0.10482848, 0., 0.20965697],
+        expected = np.array([[0.10482848, 0., 0.20965697],
                                 [0., 0., 0.31448545],
                                 [0.41931393, 0.52414242, 0.6289709]])
-        self.assertTrue(numpy as np.allclose(normalized.toarray(), expected))
+        self.assertTrue(np.allclose(normalized.toarray(), expected))
 
     def test_numpyndarrayInput_l2(self):
-        """Test for numpy as np ndarray input for l2 transformation"""
-        ndarray_matrix = numpy as np.array([[1, 0, 2],
+        """Test for np ndarray input for l2 transformation"""
+        ndarray_matrix = np.array([[1, 0, 2],
                                       [0, 0, 3],
                                       [4, 5, 6]])
         normalized = self.model_l2.normalize(ndarray_matrix)
 
         # Check if output is of same type
-        self.assertTrue(isinstance(normalized, numpy as np.ndarray))
+        self.assertTrue(isinstance(normalized, np.ndarray))
 
         # Check if output is correct
-        expected = numpy as np.array([[0.10482848, 0., 0.20965697],
+        expected = np.array([[0.10482848, 0., 0.20965697],
                                 [0., 0., 0.31448545],
                                 [0.41931393, 0.52414242, 0.6289709]])
-        self.assertTrue(numpy as np.allclose(normalized, expected))
+        self.assertTrue(np.allclose(normalized, expected))
 
         # Test if error is raised on unsupported input type
         self.assertRaises(ValueError, lambda model, doc: model.normalize(doc), self.model_l2, [1, 2, 3])
@@ -136,7 +136,7 @@ class TestNormModel(unittest.TestCase):
         model2 = normmodel.NormModel.load(fname)
         self.assertTrue(model.norms == model2.norms)
         tstvec = []
-        self.assertTrue(numpy as np.allclose(model.normalize(tstvec), model2.normalize(tstvec))) # try projecting an empty vector
+        self.assertTrue(np.allclose(model.normalize(tstvec), model2.normalize(tstvec))) # try projecting an empty vector
 
     def testPersistenceCompressed(self):
         fname = testfile() + '.gz'
@@ -145,7 +145,7 @@ class TestNormModel(unittest.TestCase):
         model2 = normmodel.NormModel.load(fname, mmap=None)
         self.assertTrue(model.norms == model2.norms)
         tstvec = []
-        self.assertTrue(numpy as np.allclose(model.normalize(tstvec), model2.normalize(tstvec))) # try projecting an empty vector
+        self.assertTrue(np.allclose(model.normalize(tstvec), model2.normalize(tstvec))) # try projecting an empty vector
 
 
 if __name__ == '__main__':

--- a/gensim/test/test_rpmodel.py
+++ b/gensim/test/test_rpmodel.py
@@ -53,7 +53,7 @@ class TestRpModel(unittest.TestCase):
 
     def testTransform(self):
         # create the transformation model
-        numpy as np.random.seed(13) # HACK; set fixed seed so that we always get the same random matrix (and can compare against expected results)
+        np.random.seed(13) # HACK; set fixed seed so that we always get the same random matrix (and can compare against expected results)
         model = rpmodel.RpModel(self.corpus, num_topics=2)
 
         # transform one document
@@ -61,8 +61,8 @@ class TestRpModel(unittest.TestCase):
         transformed = model[doc]
         vec = matutils.sparse2full(transformed, 2) # convert to dense vector, for easier equality tests
 
-        expected = numpy as np.array([-0.70710677, 0.70710677])
-        self.assertTrue(numpy as np.allclose(vec, expected)) # transformed entries must be equal up to sign
+        expected = np.array([-0.70710677, 0.70710677])
+        self.assertTrue(np.allclose(vec, expected)) # transformed entries must be equal up to sign
 
 
     def testPersistence(self):
@@ -71,9 +71,9 @@ class TestRpModel(unittest.TestCase):
         model.save(fname)
         model2 = rpmodel.RpModel.load(fname)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy as np.allclose(model.projection, model2.projection))
+        self.assertTrue(np.allclose(model.projection, model2.projection))
         tstvec = []
-        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 
     def testPersistenceCompressed(self):
         fname = testfile() + '.gz'
@@ -81,9 +81,9 @@ class TestRpModel(unittest.TestCase):
         model.save(fname)
         model2 = rpmodel.RpModel.load(fname, mmap=None)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy as np.allclose(model.projection, model2.projection))
+        self.assertTrue(np.allclose(model.projection, model2.projection))
         tstvec = []
-        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 #endclass TestRpModel
 
 

--- a/gensim/test/test_rpmodel.py
+++ b/gensim/test/test_rpmodel.py
@@ -16,7 +16,7 @@ import os.path
 import tempfile
 
 import six
-import numpy
+import numpy as np
 import scipy.linalg
 
 from gensim.corpora import mmcorpus, Dictionary
@@ -53,7 +53,7 @@ class TestRpModel(unittest.TestCase):
 
     def testTransform(self):
         # create the transformation model
-        numpy.random.seed(13) # HACK; set fixed seed so that we always get the same random matrix (and can compare against expected results)
+        numpy as np.random.seed(13) # HACK; set fixed seed so that we always get the same random matrix (and can compare against expected results)
         model = rpmodel.RpModel(self.corpus, num_topics=2)
 
         # transform one document
@@ -61,8 +61,8 @@ class TestRpModel(unittest.TestCase):
         transformed = model[doc]
         vec = matutils.sparse2full(transformed, 2) # convert to dense vector, for easier equality tests
 
-        expected = numpy.array([-0.70710677, 0.70710677])
-        self.assertTrue(numpy.allclose(vec, expected)) # transformed entries must be equal up to sign
+        expected = numpy as np.array([-0.70710677, 0.70710677])
+        self.assertTrue(numpy as np.allclose(vec, expected)) # transformed entries must be equal up to sign
 
 
     def testPersistence(self):
@@ -71,9 +71,9 @@ class TestRpModel(unittest.TestCase):
         model.save(fname)
         model2 = rpmodel.RpModel.load(fname)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy.allclose(model.projection, model2.projection))
+        self.assertTrue(numpy as np.allclose(model.projection, model2.projection))
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 
     def testPersistenceCompressed(self):
         fname = testfile() + '.gz'
@@ -81,9 +81,9 @@ class TestRpModel(unittest.TestCase):
         model.save(fname)
         model2 = rpmodel.RpModel.load(fname, mmap=None)
         self.assertEqual(model.num_topics, model2.num_topics)
-        self.assertTrue(numpy.allclose(model.projection, model2.projection))
+        self.assertTrue(numpy as np.allclose(model.projection, model2.projection))
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 #endclass TestRpModel
 
 

--- a/gensim/test/test_sharded_corpus.py
+++ b/gensim/test/test_sharded_corpus.py
@@ -89,7 +89,7 @@ class TestShardedCorpus(unittest.TestCase):
         self.assertEqual(self.corpus.current_shard_n, 2)
 
         for i in xrange(220, 227):
-            self.assertTrue(numpy as np.array_equal(self.corpus[i], item[i-220]))
+            self.assertTrue(np.array_equal(self.corpus[i], item[i-220]))
 
     def test_sparse_serialization(self):
 
@@ -110,15 +110,15 @@ class TestShardedCorpus(unittest.TestCase):
                                sparse_retrieval=False)
 
         item = corpus[3]
-        self.assertTrue(isinstance(item, numpy as np.ndarray))
+        self.assertTrue(isinstance(item, np.ndarray))
         self.assertEqual(item.shape, (corpus.dim,))
 
         dslice = corpus[2:6]
-        self.assertTrue(isinstance(dslice, numpy as np.ndarray))
+        self.assertTrue(isinstance(dslice, np.ndarray))
         self.assertEqual(dslice.shape, (4, corpus.dim))
 
         ilist = corpus[[2, 3, 4, 5]]
-        self.assertTrue(isinstance(ilist, numpy as np.ndarray))
+        self.assertTrue(isinstance(ilist, np.ndarray))
         self.assertEqual(ilist.shape, (4, corpus.dim))
 
         self.assertEqual(ilist.all(), dslice.all())
@@ -185,15 +185,15 @@ class TestShardedCorpus(unittest.TestCase):
                                      sparse_retrieval=False)
 
         item = corpus[3]
-        self.assertTrue(isinstance(item, numpy as np.ndarray))
+        self.assertTrue(isinstance(item, np.ndarray))
         self.assertEqual(item.shape, (1, corpus.dim))
 
         dslice = corpus[2:6]
-        self.assertTrue(isinstance(dslice, numpy as np.ndarray))
+        self.assertTrue(isinstance(dslice, np.ndarray))
         self.assertEqual(dslice.shape, (4, corpus.dim))
 
         ilist = corpus[[2, 3, 4, 5]]
-        self.assertTrue(isinstance(ilist, numpy as np.ndarray))
+        self.assertTrue(isinstance(ilist, np.ndarray))
         self.assertEqual(ilist.shape, (4, corpus.dim))
 
         # Also compare with what the dense dataset is giving us

--- a/gensim/test/test_sharded_corpus.py
+++ b/gensim/test/test_sharded_corpus.py
@@ -12,7 +12,7 @@ import os
 import unittest
 
 import random
-import numpy
+import numpy as np
 import shutil
 
 from scipy import sparse
@@ -89,7 +89,7 @@ class TestShardedCorpus(unittest.TestCase):
         self.assertEqual(self.corpus.current_shard_n, 2)
 
         for i in xrange(220, 227):
-            self.assertTrue(numpy.array_equal(self.corpus[i], item[i-220]))
+            self.assertTrue(numpy as np.array_equal(self.corpus[i], item[i-220]))
 
     def test_sparse_serialization(self):
 
@@ -110,15 +110,15 @@ class TestShardedCorpus(unittest.TestCase):
                                sparse_retrieval=False)
 
         item = corpus[3]
-        self.assertTrue(isinstance(item, numpy.ndarray))
+        self.assertTrue(isinstance(item, numpy as np.ndarray))
         self.assertEqual(item.shape, (corpus.dim,))
 
         dslice = corpus[2:6]
-        self.assertTrue(isinstance(dslice, numpy.ndarray))
+        self.assertTrue(isinstance(dslice, numpy as np.ndarray))
         self.assertEqual(dslice.shape, (4, corpus.dim))
 
         ilist = corpus[[2, 3, 4, 5]]
-        self.assertTrue(isinstance(ilist, numpy.ndarray))
+        self.assertTrue(isinstance(ilist, numpy as np.ndarray))
         self.assertEqual(ilist.shape, (4, corpus.dim))
 
         self.assertEqual(ilist.all(), dslice.all())
@@ -185,15 +185,15 @@ class TestShardedCorpus(unittest.TestCase):
                                      sparse_retrieval=False)
 
         item = corpus[3]
-        self.assertTrue(isinstance(item, numpy.ndarray))
+        self.assertTrue(isinstance(item, numpy as np.ndarray))
         self.assertEqual(item.shape, (1, corpus.dim))
 
         dslice = corpus[2:6]
-        self.assertTrue(isinstance(dslice, numpy.ndarray))
+        self.assertTrue(isinstance(dslice, numpy as np.ndarray))
         self.assertEqual(dslice.shape, (4, corpus.dim))
 
         ilist = corpus[[2, 3, 4, 5]]
-        self.assertTrue(isinstance(ilist, numpy.ndarray))
+        self.assertTrue(isinstance(ilist, numpy as np.ndarray))
         self.assertEqual(ilist.shape, (4, corpus.dim))
 
         # Also compare with what the dense dataset is giving us

--- a/gensim/test/test_similarity_metrics.py
+++ b/gensim/test/test_similarity_metrics.py
@@ -14,7 +14,7 @@ import unittest
 
 from gensim import matutils
 from scipy.sparse import csr_matrix
-import numpy
+import numpy as np
 import math
 import os
 from gensim.corpora import mmcorpus, Dictionary
@@ -84,8 +84,8 @@ class TestIsBow(unittest.TestCase):
         expected = True
         self.assertEqual(expected, result)
 
-        # checking numpy array format bag of words
-        potentialbow = numpy.array([[1, 0.4], [0, 0.2],[2, 0.2]])
+        # checking nump as np array format bag of words
+        potentialbow = nump as np.array([[1, 0.4], [0, 0.2],[2, 0.2]])
         result = matutils.isbow(potentialbow)
         expected = True
         self.assertEqual(expected, result)
@@ -105,8 +105,8 @@ class TestHellinger(unittest.TestCase):
         expected = 0.0
         self.assertEqual(expected, result)
 
-        # checking numpy array and list input
-        vec_1 = numpy.array([])
+        # checking nump as np array and list input
+        vec_1 = nump as np.array([])
         vec_2 = []
         result = matutils.hellinger(vec_1, vec_2)
         expected = 0.0
@@ -130,21 +130,21 @@ class TestHellinger(unittest.TestCase):
 
 
         # checking ndarray, csr_matrix as inputs
-        vec_1 = numpy.array([[1, 0.3], [0, 0.4], [2, 0.3]])
+        vec_1 = nump as np.array([[1, 0.3], [0, 0.4], [2, 0.3]])
         vec_2 = csr_matrix([[1, 0.4], [0, 0.2], [2, 0.2]])
         result = matutils.hellinger(vec_1, vec_2)
         expected = 0.160618030536
         self.assertAlmostEqual(expected, result)
 
         # checking ndarray, list as inputs
-        vec_1 = numpy.array([0.6, 0.1, 0.1, 0.2])
+        vec_1 = nump as np.array([0.6, 0.1, 0.1, 0.2])
         vec_2 = [0.2, 0.2, 0.1, 0.5]
         result = matutils.hellinger(vec_1, vec_2)
         expected = 0.309742984153
         self.assertAlmostEqual(expected, result)
 
          # testing LDA distribution vectors
-        numpy.random.seed(0)
+        nump as np.random.seed(0)
         model = self.class_(self.corpus, id2word=dictionary, num_topics=2, passes= 100)
         lda_vec1 = model[[(1, 2), (2, 3)]]
         lda_vec2 = model[[(2, 2), (1, 3)]]
@@ -167,8 +167,8 @@ class TestKL(unittest.TestCase):
         expected = 0.0
         self.assertEqual(expected, result)
 
-        # checking numpy array and list input
-        vec_1 = numpy.array([])
+        # checking nump as np array and list input
+        vec_1 = nump as np.array([])
         vec_2 = []
         result = matutils.kullback_leibler(vec_1, vec_2)
         expected = 0.0
@@ -197,21 +197,21 @@ class TestKL(unittest.TestCase):
         self.assertTrue(math.isinf(result))
 
         # checking ndarray, csr_matrix as inputs
-        vec_1 = numpy.array([[1, 0.3], [0, 0.4], [2, 0.3]])
+        vec_1 = nump as np.array([[1, 0.3], [0, 0.4], [2, 0.3]])
         vec_2 = csr_matrix([[1, 0.4], [0, 0.2], [2, 0.2]])
         result = matutils.kullback_leibler(vec_1, vec_2, 3)
         expected = 0.0894502
         self.assertAlmostEqual(expected, result)
 
         # checking ndarray, list as inputs
-        vec_1 = numpy.array([0.6, 0.1, 0.1, 0.2])
+        vec_1 = nump as np.array([0.6, 0.1, 0.1, 0.2])
         vec_2 = [0.2, 0.2, 0.1, 0.5]
         result = matutils.kullback_leibler(vec_1, vec_2)
         expected = 0.40659450877
         self.assertAlmostEqual(expected, result)
 
         # testing LDA distribution vectors
-        numpy.random.seed(0)
+        nump as np.random.seed(0)
         model = self.class_(self.corpus, id2word=dictionary, num_topics=2, passes= 100)
         lda_vec1 = model[[(1, 2), (2, 3)]]
         lda_vec2 = model[[(2, 2), (1, 3)]]
@@ -237,14 +237,14 @@ class TestJaccard(unittest.TestCase):
         self.assertAlmostEqual(expected, result)
 
         # checking ndarray, csr_matrix as inputs
-        vec_1 = numpy.array([[1, 3], [0, 4], [2, 3]])
+        vec_1 = nump as np.array([[1, 3], [0, 4], [2, 3]])
         vec_2 = csr_matrix([[1, 4], [0, 2], [2, 2]])
         result = matutils.jaccard(vec_1, vec_2)
         expected = 1 - 0.388888888889
         self.assertAlmostEqual(expected, result)
 
         # checking ndarray, list as inputs
-        vec_1 = numpy.array([6, 1, 2, 3])
+        vec_1 = nump as np.array([6, 1, 2, 3])
         vec_2 = [4, 3, 2, 5]
         result = matutils.jaccard(vec_1, vec_2)
         expected = 1 - 0.333333333333

--- a/gensim/test/test_similarity_metrics.py
+++ b/gensim/test/test_similarity_metrics.py
@@ -84,8 +84,8 @@ class TestIsBow(unittest.TestCase):
         expected = True
         self.assertEqual(expected, result)
 
-        # checking nump as np array format bag of words
-        potentialbow = nump as np.array([[1, 0.4], [0, 0.2],[2, 0.2]])
+        # checking np array format bag of words
+        potentialbow = np.array([[1, 0.4], [0, 0.2],[2, 0.2]])
         result = matutils.isbow(potentialbow)
         expected = True
         self.assertEqual(expected, result)
@@ -105,8 +105,8 @@ class TestHellinger(unittest.TestCase):
         expected = 0.0
         self.assertEqual(expected, result)
 
-        # checking nump as np array and list input
-        vec_1 = nump as np.array([])
+        # checking np array and list input
+        vec_1 = np.array([])
         vec_2 = []
         result = matutils.hellinger(vec_1, vec_2)
         expected = 0.0
@@ -130,21 +130,21 @@ class TestHellinger(unittest.TestCase):
 
 
         # checking ndarray, csr_matrix as inputs
-        vec_1 = nump as np.array([[1, 0.3], [0, 0.4], [2, 0.3]])
+        vec_1 = np.array([[1, 0.3], [0, 0.4], [2, 0.3]])
         vec_2 = csr_matrix([[1, 0.4], [0, 0.2], [2, 0.2]])
         result = matutils.hellinger(vec_1, vec_2)
         expected = 0.160618030536
         self.assertAlmostEqual(expected, result)
 
         # checking ndarray, list as inputs
-        vec_1 = nump as np.array([0.6, 0.1, 0.1, 0.2])
+        vec_1 = np.array([0.6, 0.1, 0.1, 0.2])
         vec_2 = [0.2, 0.2, 0.1, 0.5]
         result = matutils.hellinger(vec_1, vec_2)
         expected = 0.309742984153
         self.assertAlmostEqual(expected, result)
 
          # testing LDA distribution vectors
-        nump as np.random.seed(0)
+        np.random.seed(0)
         model = self.class_(self.corpus, id2word=dictionary, num_topics=2, passes= 100)
         lda_vec1 = model[[(1, 2), (2, 3)]]
         lda_vec2 = model[[(2, 2), (1, 3)]]
@@ -167,8 +167,8 @@ class TestKL(unittest.TestCase):
         expected = 0.0
         self.assertEqual(expected, result)
 
-        # checking nump as np array and list input
-        vec_1 = nump as np.array([])
+        # checking np array and list input
+        vec_1 = np.array([])
         vec_2 = []
         result = matutils.kullback_leibler(vec_1, vec_2)
         expected = 0.0
@@ -197,21 +197,21 @@ class TestKL(unittest.TestCase):
         self.assertTrue(math.isinf(result))
 
         # checking ndarray, csr_matrix as inputs
-        vec_1 = nump as np.array([[1, 0.3], [0, 0.4], [2, 0.3]])
+        vec_1 = np.array([[1, 0.3], [0, 0.4], [2, 0.3]])
         vec_2 = csr_matrix([[1, 0.4], [0, 0.2], [2, 0.2]])
         result = matutils.kullback_leibler(vec_1, vec_2, 3)
         expected = 0.0894502
         self.assertAlmostEqual(expected, result)
 
         # checking ndarray, list as inputs
-        vec_1 = nump as np.array([0.6, 0.1, 0.1, 0.2])
+        vec_1 = np.array([0.6, 0.1, 0.1, 0.2])
         vec_2 = [0.2, 0.2, 0.1, 0.5]
         result = matutils.kullback_leibler(vec_1, vec_2)
         expected = 0.40659450877
         self.assertAlmostEqual(expected, result)
 
         # testing LDA distribution vectors
-        nump as np.random.seed(0)
+        np.random.seed(0)
         model = self.class_(self.corpus, id2word=dictionary, num_topics=2, passes= 100)
         lda_vec1 = model[[(1, 2), (2, 3)]]
         lda_vec2 = model[[(2, 2), (1, 3)]]
@@ -237,14 +237,14 @@ class TestJaccard(unittest.TestCase):
         self.assertAlmostEqual(expected, result)
 
         # checking ndarray, csr_matrix as inputs
-        vec_1 = nump as np.array([[1, 3], [0, 4], [2, 3]])
+        vec_1 = np.array([[1, 3], [0, 4], [2, 3]])
         vec_2 = csr_matrix([[1, 4], [0, 2], [2, 2]])
         result = matutils.jaccard(vec_1, vec_2)
         expected = 1 - 0.388888888889
         self.assertAlmostEqual(expected, result)
 
         # checking ndarray, list as inputs
-        vec_1 = nump as np.array([6, 1, 2, 3])
+        vec_1 = np.array([6, 1, 2, 3])
         vec_2 = [4, 3, 2, 5]
         result = matutils.jaccard(vec_1, vec_2)
         expected = 1 - 0.333333333333

--- a/gensim/test/test_tfidfmodel.py
+++ b/gensim/test/test_tfidfmodel.py
@@ -60,7 +60,7 @@ class TestTfidfModel(unittest.TestCase):
         transformed = model[doc]
 
         expected = [(0, 0.57735026918962573), (1, 0.57735026918962573), (2, 0.57735026918962573)]
-        self.assertTrue(numpy as np.allclose(transformed, expected))
+        self.assertTrue(np.allclose(transformed, expected))
 
 
     def testInit(self):
@@ -85,7 +85,7 @@ class TestTfidfModel(unittest.TestCase):
         model2 = tfidfmodel.TfidfModel.load(fname)
         self.assertTrue(model.idfs == model2.idfs)
         tstvec = []
-        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 
     def testPersistenceCompressed(self):
         fname = testfile() + '.gz'
@@ -94,7 +94,7 @@ class TestTfidfModel(unittest.TestCase):
         model2 = tfidfmodel.TfidfModel.load(fname, mmap=None)
         self.assertTrue(model.idfs == model2.idfs)
         tstvec = []
-        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 #endclass TestTfidfModel
 
 

--- a/gensim/test/test_tfidfmodel.py
+++ b/gensim/test/test_tfidfmodel.py
@@ -16,7 +16,7 @@ import os.path
 import tempfile
 
 import six
-import numpy
+import numpy as np
 import scipy.linalg
 
 from gensim.corpora import mmcorpus, Dictionary
@@ -60,7 +60,7 @@ class TestTfidfModel(unittest.TestCase):
         transformed = model[doc]
 
         expected = [(0, 0.57735026918962573), (1, 0.57735026918962573), (2, 0.57735026918962573)]
-        self.assertTrue(numpy.allclose(transformed, expected))
+        self.assertTrue(numpy as np.allclose(transformed, expected))
 
 
     def testInit(self):
@@ -85,7 +85,7 @@ class TestTfidfModel(unittest.TestCase):
         model2 = tfidfmodel.TfidfModel.load(fname)
         self.assertTrue(model.idfs == model2.idfs)
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 
     def testPersistenceCompressed(self):
         fname = testfile() + '.gz'
@@ -94,7 +94,7 @@ class TestTfidfModel(unittest.TestCase):
         model2 = tfidfmodel.TfidfModel.load(fname, mmap=None)
         self.assertTrue(model.idfs == model2.idfs)
         tstvec = []
-        self.assertTrue(numpy.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
+        self.assertTrue(numpy as np.allclose(model[tstvec], model2[tstvec])) # try projecting an empty vector
 #endclass TestTfidfModel
 
 

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -103,9 +103,9 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertFalse('terrorism' in model.vocab)
         model.build_vocab(terro, update=True)
         self.assertTrue('terrorism' in model.vocab)
-        orig0 = numpy as np.copy(model.syn0)
+        orig0 = np.copy(model.syn0)
         model.train(terro)
-        self.assertFalse(numpy as np.allclose(model.syn0, orig0))
+        self.assertFalse(np.allclose(model.syn0, orig0))
         sim = model.n_similarity(['war'], ['terrorism'])
         self.assertLess(0., sim)
 
@@ -169,14 +169,14 @@ class TestWord2VecModel(unittest.TestCase):
         model.save_word2vec_format(testfile(), binary=True)
         binary_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True)
         binary_model.init_sims(replace=False)
-        self.assertTrue(numpy as np.allclose(model['human'], binary_model['human']))
+        self.assertTrue(np.allclose(model['human'], binary_model['human']))
         norm_only_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True)
         norm_only_model.init_sims(replace=True)
-        self.assertFalse(numpy as np.allclose(model['human'], norm_only_model['human']))
-        self.assertTrue(numpy as np.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human']))
+        self.assertFalse(np.allclose(model['human'], norm_only_model['human']))
+        self.assertTrue(np.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human']))
         limited_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, limit=3)
         self.assertEquals(len(limited_model.syn0), 3)
-        half_precision_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, datatype=numpy as np.float16)
+        half_precision_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, datatype=np.float16)
         self.assertEquals(binary_model.syn0.nbytes, half_precision_model.syn0.nbytes * 2)
 
     def testTooShortBinaryWord2VecFormat(self):
@@ -206,12 +206,12 @@ class TestWord2VecModel(unittest.TestCase):
         model.save_word2vec_format(testfile(), binary=False)
         text_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=False)
         text_model.init_sims(False)
-        self.assertTrue(numpy as np.allclose(model['human'], text_model['human'], atol=1e-6))
+        self.assertTrue(np.allclose(model['human'], text_model['human'], atol=1e-6))
         norm_only_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=False)
         norm_only_model.init_sims(True)
-        self.assertFalse(numpy as np.allclose(model['human'], norm_only_model['human'], atol=1e-6))
+        self.assertFalse(np.allclose(model['human'], norm_only_model['human'], atol=1e-6))
 
-        self.assertTrue(numpy as np.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human'], atol=1e-4))
+        self.assertTrue(np.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human'], atol=1e-4))
 
     def testPersistenceWord2VecFormatWithVocab(self):
         """Test storing/loading the entire model and vocabulary in word2vec format."""
@@ -257,13 +257,13 @@ class TestWord2VecModel(unittest.TestCase):
         # with min_count=1, we're not throwing away anything, so make sure the word counts add up to be the entire corpus
         self.assertEqual(sum(v.count for v in model.vocab.values()), total_words)
         # make sure the binary codes are correct
-        numpy as np.allclose(model.vocab['the'].code, [1, 1, 0, 0])
+        np.allclose(model.vocab['the'].code, [1, 1, 0, 0])
 
         # test building vocab with default params
         model = word2vec.Word2Vec(hs=1, negative=0)
         model.build_vocab(corpus)
         self.assertTrue(len(model.vocab) == 1750)
-        numpy as np.allclose(model.vocab['the'].code, [1, 1, 1, 0])
+        np.allclose(model.vocab['the'].code, [1, 1, 1, 0])
 
         # no input => "RuntimeError: you must first build vocabulary before training the model"
         self.assertRaises(RuntimeError, word2vec.Word2Vec, [])
@@ -311,8 +311,8 @@ class TestWord2VecModel(unittest.TestCase):
             model.build_vocab(corpus)
 
             # remember two vectors
-            locked0 = numpy as np.copy(model.syn0[0])
-            unlocked1 = numpy as np.copy(model.syn0[1])
+            locked0 = np.copy(model.syn0[0])
+            unlocked1 = np.copy(model.syn0[1])
             # lock the vector in slot 0 against change
             model.syn0_lockf[0] = 0.0
 
@@ -325,7 +325,7 @@ class TestWord2VecModel(unittest.TestCase):
         # run extra before/after training tests if train=True
         if train:
             model.build_vocab(list_corpus)
-            orig0 = numpy as np.copy(model.syn0[0])
+            orig0 = np.copy(model.syn0[0])
             model.train(list_corpus)
             self.assertFalse((orig0 == model.syn0[1]).all())  # vector should vary after training
         sims = model.most_similar('war', topn=len(model.index2word))
@@ -453,7 +453,7 @@ class TestWord2VecModel(unittest.TestCase):
 
     def testParallel(self):
         """Test word2vec parallel training."""
-        if word2vec.FAST_VERSION < 0:  # don't test the plain numpy as np version for parallelism (too slow)
+        if word2vec.FAST_VERSION < 0:  # don't test the plain np version for parallelism (too slow)
             return
 
         corpus = utils.RepeatCorpus(LeeCorpus(), 10000)
@@ -474,13 +474,13 @@ class TestWord2VecModel(unittest.TestCase):
 
     def models_equal(self, model, model2):
         self.assertEqual(len(model.vocab), len(model2.vocab))
-        self.assertTrue(numpy as np.allclose(model.syn0, model2.syn0))
+        self.assertTrue(np.allclose(model.syn0, model2.syn0))
         if model.hs:
-            self.assertTrue(numpy as np.allclose(model.syn1, model2.syn1))
+            self.assertTrue(np.allclose(model.syn1, model2.syn1))
         if model.negative:
-            self.assertTrue(numpy as np.allclose(model.syn1neg, model2.syn1neg))
+            self.assertTrue(np.allclose(model.syn1neg, model2.syn1neg))
         most_common_word = max(model.vocab.items(), key=lambda item: item[1].count)[0]
-        self.assertTrue(numpy as np.allclose(model[most_common_word], model2[most_common_word]))
+        self.assertTrue(np.allclose(model[most_common_word], model2[most_common_word]))
 
     @log_capture()
     def testBuildVocabWarning(self, l):
@@ -541,7 +541,7 @@ class TestWMD(unittest.TestCase):
         sentence2 = ['survey', 'user', 'computer', 'system', 'response', 'time']
         distance1 = model.wmdistance(sentence1, sentence2)
         distance2 = model.wmdistance(sentence2, sentence1)
-        self.assertTrue(numpy as np.allclose(distance1, distance2))
+        self.assertTrue(np.allclose(distance1, distance2))
 
     def testIdenticalSentences(self):
         '''Check that the distance from a sentence to itself is zero.'''

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -16,7 +16,7 @@ import tempfile
 import itertools
 import bz2
 
-import numpy
+import numpy as np
 
 from gensim import utils, matutils
 from gensim.utils import check_output
@@ -103,9 +103,9 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertFalse('terrorism' in model.vocab)
         model.build_vocab(terro, update=True)
         self.assertTrue('terrorism' in model.vocab)
-        orig0 = numpy.copy(model.syn0)
+        orig0 = numpy as np.copy(model.syn0)
         model.train(terro)
-        self.assertFalse(numpy.allclose(model.syn0, orig0))
+        self.assertFalse(numpy as np.allclose(model.syn0, orig0))
         sim = model.n_similarity(['war'], ['terrorism'])
         self.assertLess(0., sim)
 
@@ -169,14 +169,14 @@ class TestWord2VecModel(unittest.TestCase):
         model.save_word2vec_format(testfile(), binary=True)
         binary_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True)
         binary_model.init_sims(replace=False)
-        self.assertTrue(numpy.allclose(model['human'], binary_model['human']))
+        self.assertTrue(numpy as np.allclose(model['human'], binary_model['human']))
         norm_only_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True)
         norm_only_model.init_sims(replace=True)
-        self.assertFalse(numpy.allclose(model['human'], norm_only_model['human']))
-        self.assertTrue(numpy.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human']))
+        self.assertFalse(numpy as np.allclose(model['human'], norm_only_model['human']))
+        self.assertTrue(numpy as np.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human']))
         limited_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, limit=3)
         self.assertEquals(len(limited_model.syn0), 3)
-        half_precision_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, datatype=numpy.float16)
+        half_precision_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=True, datatype=numpy as np.float16)
         self.assertEquals(binary_model.syn0.nbytes, half_precision_model.syn0.nbytes * 2)
 
     def testTooShortBinaryWord2VecFormat(self):
@@ -206,12 +206,12 @@ class TestWord2VecModel(unittest.TestCase):
         model.save_word2vec_format(testfile(), binary=False)
         text_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=False)
         text_model.init_sims(False)
-        self.assertTrue(numpy.allclose(model['human'], text_model['human'], atol=1e-6))
+        self.assertTrue(numpy as np.allclose(model['human'], text_model['human'], atol=1e-6))
         norm_only_model = word2vec.Word2Vec.load_word2vec_format(testfile(), binary=False)
         norm_only_model.init_sims(True)
-        self.assertFalse(numpy.allclose(model['human'], norm_only_model['human'], atol=1e-6))
+        self.assertFalse(numpy as np.allclose(model['human'], norm_only_model['human'], atol=1e-6))
 
-        self.assertTrue(numpy.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human'], atol=1e-4))
+        self.assertTrue(numpy as np.allclose(model.syn0norm[model.vocab['human'].index], norm_only_model['human'], atol=1e-4))
 
     def testPersistenceWord2VecFormatWithVocab(self):
         """Test storing/loading the entire model and vocabulary in word2vec format."""
@@ -257,13 +257,13 @@ class TestWord2VecModel(unittest.TestCase):
         # with min_count=1, we're not throwing away anything, so make sure the word counts add up to be the entire corpus
         self.assertEqual(sum(v.count for v in model.vocab.values()), total_words)
         # make sure the binary codes are correct
-        numpy.allclose(model.vocab['the'].code, [1, 1, 0, 0])
+        numpy as np.allclose(model.vocab['the'].code, [1, 1, 0, 0])
 
         # test building vocab with default params
         model = word2vec.Word2Vec(hs=1, negative=0)
         model.build_vocab(corpus)
         self.assertTrue(len(model.vocab) == 1750)
-        numpy.allclose(model.vocab['the'].code, [1, 1, 1, 0])
+        numpy as np.allclose(model.vocab['the'].code, [1, 1, 1, 0])
 
         # no input => "RuntimeError: you must first build vocabulary before training the model"
         self.assertRaises(RuntimeError, word2vec.Word2Vec, [])
@@ -311,8 +311,8 @@ class TestWord2VecModel(unittest.TestCase):
             model.build_vocab(corpus)
 
             # remember two vectors
-            locked0 = numpy.copy(model.syn0[0])
-            unlocked1 = numpy.copy(model.syn0[1])
+            locked0 = numpy as np.copy(model.syn0[0])
+            unlocked1 = numpy as np.copy(model.syn0[1])
             # lock the vector in slot 0 against change
             model.syn0_lockf[0] = 0.0
 
@@ -325,7 +325,7 @@ class TestWord2VecModel(unittest.TestCase):
         # run extra before/after training tests if train=True
         if train:
             model.build_vocab(list_corpus)
-            orig0 = numpy.copy(model.syn0[0])
+            orig0 = numpy as np.copy(model.syn0[0])
             model.train(list_corpus)
             self.assertFalse((orig0 == model.syn0[1]).all())  # vector should vary after training
         sims = model.most_similar('war', topn=len(model.index2word))
@@ -453,7 +453,7 @@ class TestWord2VecModel(unittest.TestCase):
 
     def testParallel(self):
         """Test word2vec parallel training."""
-        if word2vec.FAST_VERSION < 0:  # don't test the plain NumPy version for parallelism (too slow)
+        if word2vec.FAST_VERSION < 0:  # don't test the plain numpy as np version for parallelism (too slow)
             return
 
         corpus = utils.RepeatCorpus(LeeCorpus(), 10000)
@@ -474,13 +474,13 @@ class TestWord2VecModel(unittest.TestCase):
 
     def models_equal(self, model, model2):
         self.assertEqual(len(model.vocab), len(model2.vocab))
-        self.assertTrue(numpy.allclose(model.syn0, model2.syn0))
+        self.assertTrue(numpy as np.allclose(model.syn0, model2.syn0))
         if model.hs:
-            self.assertTrue(numpy.allclose(model.syn1, model2.syn1))
+            self.assertTrue(numpy as np.allclose(model.syn1, model2.syn1))
         if model.negative:
-            self.assertTrue(numpy.allclose(model.syn1neg, model2.syn1neg))
+            self.assertTrue(numpy as np.allclose(model.syn1neg, model2.syn1neg))
         most_common_word = max(model.vocab.items(), key=lambda item: item[1].count)[0]
-        self.assertTrue(numpy.allclose(model[most_common_word], model2[most_common_word]))
+        self.assertTrue(numpy as np.allclose(model[most_common_word], model2[most_common_word]))
 
     @log_capture()
     def testBuildVocabWarning(self, l):
@@ -541,7 +541,7 @@ class TestWMD(unittest.TestCase):
         sentence2 = ['survey', 'user', 'computer', 'system', 'response', 'time']
         distance1 = model.wmdistance(sentence1, sentence2)
         distance2 = model.wmdistance(sentence2, sentence1)
-        self.assertTrue(numpy.allclose(distance1, distance2))
+        self.assertTrue(numpy as np.allclose(distance1, distance2))
 
     def testIdenticalSentences(self):
         '''Check that the distance from a sentence to itself is zero.'''


### PR DESCRIPTION
Wanted to make import abbreviations standard across the package, so changed all imports from `import numpy` to `import numpy as np`, and made all `numpy` as `np`.
Just a cosmetic change, but it is the abbreviation used in almost all other scientific computing packages. 