### PR TITLE
Add restrict_vocab in Fasttext comparison tutorial

### DIFF
--- a/docs/notebooks/Word2Vec_FastText_Comparison.ipynb
+++ b/docs/notebooks/Word2Vec_FastText_Comparison.ipynb
@@ -459,6 +459,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The `accuracy` takes an optional parameter `restrict_vocab`, which limits the vocabulary of model considered for fast approximate evaluation (default is 30000).\n",
+    "\n",
     "Word2Vec embeddings seem to be slightly better than fastText embeddings at the semantic tasks, while the fastText embeddings do significantly better on the syntactic analogies. Makes sense, since fastText embeddings are trained for understanding morphological nuances, and most of the syntactic analogies are morphology based. \n",
     "\n",
     "Let me explain that better.\n",


### PR DESCRIPTION
This PR adds a mention about `restrict_vocab` as though the default value for it gives better accuracy in tutorial, but user may want to change it depending on different dataset sizes. 