### PR TITLE
added Word2vec to Tensorflow 2D tensor file

### DIFF
--- a/gensim/scripts/word2vec2tensor.py
+++ b/gensim/scripts/word2vec2tensor.py
@@ -47,7 +47,7 @@ def word2vec2tensor(word2vec_model_path,tensor_filename):
     
     with open(outfiletsv, 'w+') as file_vector:
         with open(outfiletsvmeta, 'w+') as file_metadata:
-            for word in model.index2word:
+            for word in model.wv.index2word:
                 file_metadata.write(word.encode('utf-8') + '\n')
                 vector_row = '\t'.join(map(str, model[word]))
                 file_vector.write(vector_row + '\n')

--- a/gensim/scripts/word2vec2tensor.py
+++ b/gensim/scripts/word2vec2tensor.py
@@ -14,7 +14,15 @@ Output:
     The script will create two TSV files. A 2d tensor format file, and a Word Embedding metadata file. Both files will
     us the --output file name as prefix
 This script is used to convert the word2vec format to Tensorflow 2D tensor and metadata formats for Embedding Visualization
-For more information about TensorBoard format see: https://www.tensorflow.org/versions/master/how_tos/embedding_viz/
+To use the generated TSV 2D tensor and metadata file in the Projector Visualizer, please 
+1) Open http://projector.tensorflow.org/. 
+2) Choose "Load Data" from the left menu.
+3) Select "Choose file" in "Load a TSV file of vectors." and choose you local "_tensor.tsv" file
+4) Select "Choose file" in "Load a TSV file of metadata." and choose you local "_metadata.tsv" file
+
+For more information about TensorBoard TSV format please visit:
+https://www.tensorflow.org/versions/master/how_tos/embedding_viz/
+
 """
 
 import os

--- a/gensim/scripts/word2vec2tensor.py
+++ b/gensim/scripts/word2vec2tensor.py
@@ -50,7 +50,7 @@ def word2vec2tensor(word2vec_model_path,tensor_filename, binary=False):
     
     with open(outfiletsv, 'w+') as file_vector:
         with open(outfiletsvmeta, 'w+') as file_metadata:
-            for word in model.wv.index2word:
+            for word in model.index2word:
                 file_metadata.write(word.encode('utf-8') + '\n')
                 vector_row = '\t'.join(map(str, model[word]))
                 file_vector.write(vector_row + '\n')

--- a/gensim/scripts/word2vec2tensor.py
+++ b/gensim/scripts/word2vec2tensor.py
@@ -51,6 +51,9 @@ def word2vec2tensor(word2vec_model_path,tensor_filename):
                 file_metadata.write(word.encode('utf-8') + '\n')
                 vector_row = '\t'.join(map(str, model[word]))
                 file_vector.write(vector_row + '\n')
+    
+    logger.info("2D tensor file saved to %s" % outfiletsv)
+    logger.info("Tensor metadata file saved to %s" % outfiletsvmeta)
 
 if __name__ == "__main__":
     logging.basicConfig(format='%(asctime)s : %(threadName)s : %(levelname)s : %(message)s', level=logging.INFO)

--- a/gensim/scripts/word2vec2tensor.py
+++ b/gensim/scripts/word2vec2tensor.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2016 Loreto Parisi <loretoparisi@gmail.com>
+# Copyright (C) 2016 Silvio Ogliastri <silvio.olivastri@gmail.com>
+# Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
+
+"""
+USAGE: $ python -m gensim.scripts.word2vec2tensor --input <Word2Vec model file> --output <TSV tensor filename prefix>
+Where:
+    <Word2Vec model file>: Input Word2Vec model
+    <TSV tensor filename prefix>: 2D tensor TSV output file name prefix
+Output:
+    The script will create two TSV files. A 2d tensor format file, and a Word Embedding metadata file. Both files will
+    us the --output file name as prefix
+This script is used to convert the word2vec format to Tensorflow 2D tensor and metadata formats for Embedding Visualization
+For more information about TensorBoard format see: https://www.tensorflow.org/versions/master/how_tos/embedding_viz/
+"""
+
+import os
+import sys
+import random
+import logging
+import argparse
+
+import gensim
+
+logger = logging.getLogger(__name__)
+
+'''
+    Convert Word2Vec mode to 2D tensor TSV file and metadata file 
+    @word2vec_model_path word2vec model
+    @tensor_filename tensor filename prefix
+'''
+def word2vec2tensor(word2vec_model_path,tensor_filename):
+    
+    model = gensim.models.Word2Vec.load_word2vec_format(word2vec_model_path, binary=True)
+    outfiletsv = tensor_filename + '_tensor.tsv'
+    outfiletsvmeta = tensor_filename + '_metadata.tsv'
+    
+    with open(outfiletsv, 'w+') as file_vector:
+        with open(outfiletsvmeta, 'w+') as file_metadata:
+            for word in model.index2word:
+                file_metadata.write(word.encode('utf-8') + '\n')
+                vector_row = '\t'.join(map(str, model[word]))
+                file_vector.write(vector_row + '\n')
+
+if __name__ == "__main__":
+    logging.basicConfig(format='%(asctime)s : %(threadName)s : %(levelname)s : %(message)s', level=logging.INFO)
+    logging.root.setLevel(level=logging.INFO)
+    logger.info("running %s", ' '.join(sys.argv))
+
+    # check and process cmdline input
+    program = os.path.basename(sys.argv[0])
+    if len(sys.argv) < 2:
+        print(globals()['__doc__'] % locals())
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-i", "--input", required=True,
+        help="Input word2vec model")
+    parser.add_argument(
+        "-o", "--output", required=True,
+        help="Output tensor file name prefix")
+    args = parser.parse_args()
+
+    word2vec2tensor(args.input, args.output)
+
+    logger.info("finished running %s", program)

--- a/gensim/scripts/word2vec2tensor.py
+++ b/gensim/scripts/word2vec2tensor.py
@@ -6,10 +6,11 @@
 # Copyright (C) 2016 Radim Rehurek <radim@rare-technologies.com>
 
 """
-USAGE: $ python -m gensim.scripts.word2vec2tensor --input <Word2Vec model file> --output <TSV tensor filename prefix>
+USAGE: $ python -m gensim.scripts.word2vec2tensor --input <Word2Vec model file> --output <TSV tensor filename prefix> [--binary] <Word2Vec binary flag>
 Where:
     <Word2Vec model file>: Input Word2Vec model
     <TSV tensor filename prefix>: 2D tensor TSV output file name prefix
+    <Word2Vec binary flag>: Set True if Word2Vec model is binary. Defaults to False.
 Output:
     The script will create two TSV files. A 2d tensor format file, and a Word Embedding metadata file. Both files will
     us the --output file name as prefix

--- a/gensim/scripts/word2vec2tensor.py
+++ b/gensim/scripts/word2vec2tensor.py
@@ -35,14 +35,15 @@ import gensim
 
 logger = logging.getLogger(__name__)
 
-def word2vec2tensor(word2vec_model_path,tensor_filename):
+def word2vec2tensor(word2vec_model_path,tensor_filename, binary=False):
     '''
     Convert Word2Vec mode to 2D tensor TSV file and metadata file
     Args:
         param1 (str): word2vec model file path
         param2 (str): filename prefix
+        param2 (bool): set True to use a binary Word2Vec model, defaults to False
     '''    
-    model = gensim.models.Word2Vec.load_word2vec_format(word2vec_model_path, binary=True)
+    model = gensim.models.Word2Vec.load_word2vec_format(word2vec_model_path, binary=binary)
     outfiletsv = tensor_filename + '_tensor.tsv'
     outfiletsvmeta = tensor_filename + '_metadata.tsv'
     
@@ -74,8 +75,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "-o", "--output", required=True,
         help="Output tensor file name prefix")
+    parser.add_argument( "-b", "--binary", 
+                        required=False, 
+                        help="If word2vec model in binary format, set True, else False")
     args = parser.parse_args()
 
-    word2vec2tensor(args.input, args.output)
+    word2vec2tensor(args.input, args.output, args.binary)
 
     logger.info("finished running %s", program)

--- a/gensim/scripts/word2vec2tensor.py
+++ b/gensim/scripts/word2vec2tensor.py
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2016 Loreto Parisi <loretoparisi@gmail.com>
 # Copyright (C) 2016 Silvio Ogliastri <silvio.olivastri@gmail.com>
-# Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
+# Copyright (C) 2016 Radim Rehurek <radim@rare-technologies.com>
 
 """
 USAGE: $ python -m gensim.scripts.word2vec2tensor --input <Word2Vec model file> --output <TSV tensor filename prefix>

--- a/gensim/scripts/word2vec2tensor.py
+++ b/gensim/scripts/word2vec2tensor.py
@@ -27,13 +27,12 @@ import gensim
 
 logger = logging.getLogger(__name__)
 
-'''
+def word2vec2tensor(word2vec_model_path,tensor_filename):
+    '''
     Convert Word2Vec mode to 2D tensor TSV file and metadata file 
     @word2vec_model_path word2vec model
     @tensor_filename tensor filename prefix
-'''
-def word2vec2tensor(word2vec_model_path,tensor_filename):
-    
+    '''    
     model = gensim.models.Word2Vec.load_word2vec_format(word2vec_model_path, binary=True)
     outfiletsv = tensor_filename + '_tensor.tsv'
     outfiletsvmeta = tensor_filename + '_metadata.tsv'

--- a/gensim/scripts/word2vec2tensor.py
+++ b/gensim/scripts/word2vec2tensor.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2016 Loreto Parisi <loretoparisi@gmail.com>
-# Copyright (C) 2016 Silvio Ogliastri <silvio.olivastri@gmail.com>
+# Copyright (C) 2016 Silvio Olivastri <silvio.olivastri@gmail.com>
 # Copyright (C) 2016 Radim Rehurek <radim@rare-technologies.com>
 
 """

--- a/gensim/scripts/word2vec2tensor.py
+++ b/gensim/scripts/word2vec2tensor.py
@@ -37,9 +37,10 @@ logger = logging.getLogger(__name__)
 
 def word2vec2tensor(word2vec_model_path,tensor_filename):
     '''
-    Convert Word2Vec mode to 2D tensor TSV file and metadata file 
-    @word2vec_model_path word2vec model
-    @tensor_filename tensor filename prefix
+    Convert Word2Vec mode to 2D tensor TSV file and metadata file
+    Args:
+        param1 (str): word2vec model file path
+        param2 (str): filename prefix
     '''    
     model = gensim.models.Word2Vec.load_word2vec_format(word2vec_model_path, binary=True)
     outfiletsv = tensor_filename + '_tensor.tsv'


### PR DESCRIPTION
This script is used to convert the word2vec format to Tensorflow 2D tensor and metadata formats for Embedding Projector Visualization
For more information about TensorBoard format see: https://www.tensorflow.org/versions/master/how_tos/embedding_viz/