### PR TITLE
Disable direct access to KeyedVectors warning save and load of Word2vec/Doc2vec

### DIFF
--- a/docs/notebooks/word2vec.ipynb
+++ b/docs/notebooks/word2vec.ipynb
@@ -42,7 +42,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [
     {
@@ -134,7 +134,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [
     {
@@ -162,7 +162,7 @@
      "output_type": "stream",
      "text": [
       "Word2Vec(vocab=3, size=100, alpha=0.025)\n",
-      "{'second': <gensim.models.word2vec.Vocab object at 0x7fb2639b6f90>, 'first': <gensim.models.word2vec.Vocab object at 0x7fb293914590>, 'sentence': <gensim.models.word2vec.Vocab object at 0x7fb293914850>}\n"
+      "{'second': <gensim.models.word2vec.Vocab object at 0x7fed6d4faf50>, 'first': <gensim.models.word2vec.Vocab object at 0x7fed6d4fafd0>, 'sentence': <gensim.models.word2vec.Vocab object at 0x7fed6d4faf90>}\n"
      ]
     }
    ],
@@ -188,7 +188,7 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [
     {
@@ -228,7 +228,7 @@
      "output_type": "stream",
      "text": [
       "Word2Vec(vocab=3, size=100, alpha=0.025)\n",
-      "{'second': <gensim.models.word2vec.Vocab object at 0x7fb2639b6f90>, 'first': <gensim.models.word2vec.Vocab object at 0x7fb293914590>, 'sentence': <gensim.models.word2vec.Vocab object at 0x7fb293914850>}\n"
+      "{'second': <gensim.models.word2vec.Vocab object at 0x7fed6d4faf50>, 'first': <gensim.models.word2vec.Vocab object at 0x7fed6d4fafd0>, 'sentence': <gensim.models.word2vec.Vocab object at 0x7fed6d4faf90>}\n"
      ]
     }
    ],
@@ -269,7 +269,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<__main__.MyText object at 0x7fb2639539d0>\n"
+      "<__main__.MyText object at 0x7fed6d495810>\n"
      ]
     }
    ],
@@ -332,7 +332,7 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [
     {
@@ -655,8 +655,8 @@
     {
      "data": {
       "text/plain": [
-       "((0.10128579883072975, 0.47943282766520035),\n",
-       " SpearmanrResult(correlation=0.072904174848358635, pvalue=0.61116578621439932),\n",
+       "((0.093652497483521988, 0.51332382076991245),\n",
+       " SpearmanrResult(correlation=0.079058717231584447, pvalue=0.58131863093325009),\n",
        " 85.55240793201133)"
       ]
      },
@@ -686,22 +686,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 17,
    "metadata": {
     "collapsed": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:gensim.models.word2vec:direct access to syn0norm will not be supported in future gensim releases, please use model.wv.syn0norm\n",
-      "WARNING:gensim.models.word2vec:direct access to syn0norm will not be supported in future gensim releases, please use model.wv.syn0norm\n",
-      "WARNING:gensim.models.word2vec:direct access to syn0norm will not be supported in future gensim releases, please use model.wv.syn0norm\n",
-      "WARNING:gensim.models.word2vec:direct access to syn0norm will not be supported in future gensim releases, please use model.wv.syn0norm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from tempfile import mkstemp\n",
     "\n",
@@ -712,20 +701,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 18,
    "metadata": {
     "collapsed": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:gensim.models.word2vec:direct access to syn0norm will not be supported in future gensim releases, please use model.wv.syn0norm\n",
-      "WARNING:gensim.models.word2vec:direct access to index2word will not be supported in future gensim releases, please use model.wv.index2word\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "new_model = gensim.models.Word2Vec.load(temp_path)  # open the model"
    ]
@@ -753,26 +733,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 19,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING:gensim.models.word2vec:direct access to syn0norm will not be supported in future gensim releases, please use model.wv.syn0norm\n",
-      "WARNING:gensim.models.word2vec:direct access to index2word will not be supported in future gensim releases, please use model.wv.index2word\n",
-      "WARNING:gensim.models.word2vec:Each 'sentences' item should be a list of words (usually unicode strings).First item here is instead plain <type 'str'>.\n",
       "WARNING:gensim.models.word2vec:under 10 jobs per worker: consider setting a smaller `batch_words' for smoother alpha decay\n"
      ]
     }
    ],
    "source": [
     "model = gensim.models.Word2Vec.load(temp_path)\n",
-    "more_sentences = ['Advanced', 'users', 'can', 'load', 'a', 'model', 'and', 'continue', \n",
-    "                  'training', 'it', 'with', 'more', 'sentences']\n",
+    "more_sentences = [['Advanced', 'users', 'can', 'load', 'a', 'model', 'and', 'continue', \n",
+    "                  'training', 'it', 'with', 'more', 'sentences']]\n",
     "model.build_vocab(more_sentences, update=True)\n",
     "model.train(more_sentences, )\n",
     "\n",
@@ -795,7 +772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 20,
    "metadata": {
     "collapsed": false
    },
@@ -803,10 +780,10 @@
     {
      "data": {
       "text/plain": [
-       "[('ensure', 0.9957192540168762)]"
+       "[('longer', 0.9889242649078369)]"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -817,7 +794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false
    },
@@ -828,7 +805,7 @@
        "'sentence'"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -839,7 +816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 22,
    "metadata": {
     "collapsed": false
    },
@@ -848,8 +825,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.999075350666\n",
-      "0.994927937956\n"
+      "0.999177346162\n",
+      "0.9956625533\n"
      ]
     }
    ],
@@ -874,7 +851,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false
    },
@@ -882,29 +859,29 @@
     {
      "data": {
       "text/plain": [
-       "array([ 0.0044026 ,  0.0197748 , -0.02639075, -0.00805756, -0.02940564,\n",
-       "       -0.03424382,  0.00585153, -0.08163424, -0.01097746, -0.01996135,\n",
-       "        0.02069173, -0.02237663, -0.06126078, -0.01786143, -0.01912139,\n",
-       "        0.04299303, -0.02625322, -0.00262815,  0.02180346, -0.02537277,\n",
-       "       -0.06165754, -0.00596116,  0.0625946 ,  0.04605089,  0.02265292,\n",
-       "        0.01248171, -0.00406209,  0.01647919, -0.01257895,  0.00213343,\n",
-       "        0.0013593 ,  0.06606596,  0.00893093, -0.00202957,  0.02115596,\n",
-       "        0.0191715 , -0.03835866,  0.01671978,  0.01097227, -0.06311714,\n",
-       "       -0.07220271,  0.00545426, -0.04120893, -0.02457557,  0.02904521,\n",
-       "       -0.05145161,  0.03559498,  0.00507238, -0.01168406,  0.03649417,\n",
-       "        0.01431915,  0.00701938, -0.03449947,  0.00628083,  0.01424492,\n",
-       "       -0.01694195,  0.05345082, -0.02725438,  0.02032493, -0.03279101,\n",
-       "       -0.02823507, -0.04623265,  0.01619413, -0.03048068, -0.01032882,\n",
-       "       -0.05897115, -0.07391553,  0.03485925,  0.04940247, -0.00280599,\n",
-       "       -0.00966417,  0.00758454, -0.04670098,  0.01224129, -0.04389989,\n",
-       "       -0.05034593,  0.03377169, -0.00763094,  0.04285096,  0.03868506,\n",
-       "       -0.01992619,  0.03243366, -0.01554415,  0.00177458,  0.01495264,\n",
-       "        0.00747898, -0.08512215, -0.07518613,  0.06046252, -0.0258348 ,\n",
-       "       -0.05520898, -0.04187159, -0.04409514, -0.00446168, -0.02488452,\n",
-       "       -0.02667282, -0.02259186,  0.01971211, -0.04830339, -0.00232734], dtype=float32)"
+       "array([ 0.00437901,  0.02313748, -0.02936309, -0.008752  , -0.03265081,\n",
+       "       -0.03857959,  0.00654852, -0.0923382 , -0.01189023, -0.02187135,\n",
+       "        0.02219572, -0.02655028, -0.06957301, -0.02087111, -0.02286052,\n",
+       "        0.04829395, -0.03034872, -0.00357749,  0.02391322, -0.02807236,\n",
+       "       -0.06825348, -0.00669135,  0.06967571,  0.05163613,  0.02806929,\n",
+       "        0.01239634, -0.00480743,  0.01985245, -0.01433731,  0.00375685,\n",
+       "        0.00060874,  0.07473379,  0.01165777, -0.00219114,  0.02414591,\n",
+       "        0.02177458, -0.04234934,  0.01883218,  0.01372305, -0.07125106,\n",
+       "       -0.07948184,  0.00423239, -0.0464657 , -0.02693122,  0.03259234,\n",
+       "       -0.05827391,  0.03877009,  0.00561458, -0.01218846,  0.04278557,\n",
+       "        0.01462523,  0.007201  , -0.03836477,  0.00855641,  0.0169761 ,\n",
+       "       -0.01902537,  0.05948593, -0.03107592,  0.02312824, -0.03672323,\n",
+       "       -0.03216219, -0.05264312,  0.01833   , -0.03556807, -0.01106968,\n",
+       "       -0.06612992, -0.08438165,  0.04030743,  0.05524538, -0.00266636,\n",
+       "       -0.00996253,  0.00714844, -0.05092834,  0.01251214, -0.05092845,\n",
+       "       -0.05681988,  0.03765561, -0.00957785,  0.04912213,  0.04425321,\n",
+       "       -0.021587  ,  0.03699207, -0.01726504,  0.00114953,  0.01761538,\n",
+       "        0.00806294, -0.09447837, -0.08522288,  0.06803837, -0.02660622,\n",
+       "       -0.06076197, -0.04739827, -0.05012174, -0.0040967 , -0.02732807,\n",
+       "       -0.02925751, -0.02515732,  0.0224477 , -0.05377112, -0.00109009], dtype=float32)"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1486,7 +1486,6 @@ class Word2Vec(utils.SaveLoad):
         if not hasattr(model, 'train_count'):
             model.train_count = 0
             model.total_train_time = 0
-
         Word2Vec.enable_keyed_vectors_warnings()
         return model
 


### PR DESCRIPTION
These warnings will be gone automatically when direct access is removed in the next release. However in the meanwhile they are silenced by a `Word2vec.keyed_vector_warnings` flag.