### PR TITLE
Pin PyEMD version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 install:
   - conda create --yes -n gensim-test python=$TRAVIS_PYTHON_VERSION pip atlas numpy scipy
   - source activate gensim-test
-  - pip install pyemd==0.4.0
+  - pip install pyemd==0.3.0
   - pip install annoy
   - pip install testfixtures
   - pip install unittest2

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 install:
   - conda create --yes -n gensim-test python=$TRAVIS_PYTHON_VERSION pip atlas numpy scipy
   - source activate gensim-test
-  - pip install pyemd
+  - pip install pyemd==0.4.0
   - pip install annoy
   - pip install testfixtures
   - pip install unittest2


### PR DESCRIPTION
It is an optional dependency for word movers distance.
Latest version dropped support for Python 2.6 and 3.3 but added access to flows.