### PR TITLE
Phrases and Phraser allow a generator corpus

### DIFF
--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -64,7 +64,7 @@ import warnings
 from collections import defaultdict
 import itertools as it
 
-from six import iteritems, string_types
+from six import iteritems, string_types, next
 
 from gensim import utils, interfaces
 
@@ -82,7 +82,7 @@ def _is_single(obj):
     """
     obj_iter = iter(obj)
     try:
-        peek = obj_iter.next()
+        peek = next(obj_iter)
         obj_iter = it.chain([peek], obj_iter)
     except StopIteration:
         # An empty object is a single document
@@ -91,7 +91,7 @@ def _is_single(obj):
         # It's a document, return the iterator
         return True, obj_iter
     else:
-        # If the first item isn't a string, assume it's a document
+        # If the first item isn't a string, assume obj is a corpus
         return False, obj_iter
 
 
@@ -251,7 +251,6 @@ class Phrases(interfaces.TransformationABC):
                             continue
                         last_bigram = False
 
-    # TODO: Modify type in docstring to indicate that generators work too
     def __getitem__(self, sentence):
         """
         Convert the input tokens `sentence` (=list of unicode strings) into phrase
@@ -351,7 +350,6 @@ class Phraser(interfaces.TransformationABC):
                 logger.info('Phraser added %i phrasegrams', count)
         logger.info('Phraser built with %i %i phrasegrams', count, len(self.phrasegrams))
 
-    # TODO: Modify type in docstring to indicate that generators work too
     def __getitem__(self, sentence):
         """
         Convert the input tokens `sentence` (=list of unicode strings) into phrase

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -50,6 +50,19 @@ class TestPhrasesCommon(unittest.TestCase):
         self.bigram_utf8 = Phrases(sentences, min_count=1, threshold=1)
         self.bigram_unicode = Phrases(unicode_sentences, min_count=1, threshold=1)
 
+    def testEmptyInputsOnBigramConstruction(self):
+        """Test that empty inputs don't throw errors and return the expected result."""
+        # Empty list -> empty list
+        self.assertEqual(list(self.bigram_default[[]]), [])
+        # Empty iterator -> empty list
+        self.assertEqual(list(self.bigram_default[iter(())]), [])
+        # List of empty list -> list of empty list
+        self.assertEqual(list(self.bigram_default[[[], []]]), [[], []])
+        # Iterator of empty list -> list of empty list
+        self.assertEqual(list(self.bigram_default[iter([[], []])]), [[], []])
+        # Iterator of empty iterator -> list of empty list
+        self.assertEqual(list(self.bigram_default[(iter(()) for i in range(2))]), [[], []])
+
     def testSentenceGeneration(self):
         """Test basic bigram using a dummy corpus."""
         # test that we generate the same amount of sentences as the input

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -38,6 +38,10 @@ sentences = [
 unicode_sentences = [[utils.to_unicode(w) for w in sentence] for sentence in sentences]
 
 
+def gen_sentences():
+    return ((w for w in sentence) for sentence in sentences)
+
+
 class TestPhrasesCommon(unittest.TestCase):
     """ Tests that need to be run for both Prases and Phraser classes."""
     def setUp(self):
@@ -50,6 +54,11 @@ class TestPhrasesCommon(unittest.TestCase):
         """Test basic bigram using a dummy corpus."""
         # test that we generate the same amount of sentences as the input
         self.assertEqual(len(sentences), len(list(self.bigram_default[sentences])))
+
+    def testSentenceGenerationWithGenerator(self):
+        """Test basic bigram production when corpus is a generator."""
+        self.assertEqual(len(list(gen_sentences())),
+                         len(list(self.bigram_default[gen_sentences()])))
 
     def testBigramConstruction(self):
         """Test Phrases bigram construction building."""
@@ -74,6 +83,20 @@ class TestPhrasesCommon(unittest.TestCase):
         self.assertTrue(u'graph_minors' in self.bigram[sentences[-2]])
         self.assertTrue(u'graph_minors' in self.bigram[sentences[-1]])
         self.assertTrue(u'human_interface' in self.bigram[sentences[-1]])
+
+    def testBigramConstructionFromGenerator(self):
+        """Test Phrases bigram construction building when corpus is a generator"""
+        bigram1_seen = False
+        bigram2_seen = False
+
+        for s in self.bigram[gen_sentences()]:
+            if not bigram1_seen and 'response_time' in s:
+                bigram1_seen = True
+            if not bigram2_seen and 'graph_minors' in s:
+                bigram2_seen = True
+            if bigram1_seen and bigram2_seen:
+                break
+        self.assertTrue(bigram1_seen and bigram2_seen)
 
     def testEncoding(self):
         """Test that both utf8 and unicode input work; output must be unicode."""


### PR DESCRIPTION
Allow Phrases and Phraser models to take a generator
function/expression as input to the transformation method. Previously,
only indexable iterables could be used which is problematic for large
corpora.

Add additional tests to test_phrases using a generator as input.

I was trying to build a Phrases model with a corpus bigger than 1GB.  My corpora are always generators and usually that's fine with gensim but it didn't work this time so I fixed it.  The fix is basically just adding a function in [phrases.py](https://github.com/ELind77/gensim/blob/phrases_with_generator_corpus/gensim/models/phrases.py#L75) to do some more checking as to the type of the input.  It also accommodates a generator of generators in case each document/token is undergoing some kind of transformation as it's pulled through.

This PR does still need a small modification to the docstings in Phraser and Phrases in order to indicate that the input type can be a generator and not just a list but my rst isn't all that great.  Maybe if someone reviews this I could get a pointer on that?