### PR TITLE
Text clarification and typo correction

### DIFF
--- a/docs/notebooks/gensim Quick Start.ipynb
+++ b/docs/notebooks/gensim Quick Start.ipynb
@@ -249,7 +249,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that while this list lives entirely in memory, while in most applications you will want a more scalable solution. Luckily, `gensim` allows you to use any iterator that returns a single document vector at a time. See the documentation for more details.\n",
+    "Note that while this list lives entirely in memory, in most applications you will want a more scalable solution. Luckily, `gensim` allows you to use any iterator that returns a single document vector at a time. See the documentation for more details.\n",
     "\n",
     "### Model\n",
     "\n",
@@ -282,7 +282,7 @@
     "from gensim import models\n",
     "# train the model\n",
     "tfidf = models.TfidfModel(bow_corpus)\n",
-    "# transform the \"system minors\" sting\n",
+    "# transform the \"system minors\" string\n",
     "tfidf[dictionary.doc2bow(\"system minors\".lower().split())]"
    ]
   },


### PR DESCRIPTION
Corrects a typo in code comment and removes a term for text
clarification in "gensim Quick Start"

Signed-off-by: Luiz Carlos Cavalcanti <cavalcanti.luiz@gmail.com>