### PR TITLE
Update Transformation and Topics link from quick start notebook

### DIFF
--- a/docs/notebooks/gensim Quick Start.ipynb
+++ b/docs/notebooks/gensim Quick Start.ipynb
@@ -292,7 +292,7 @@
    "source": [
     "The `tfidf` model agains returns a list of tuples, where the first entry is the token ID and the second entry is the tf-idf weighting. Note that the ID corresponding to \"system\" (which occurred 4 times in the original corpus) has been weighted lower than the ID corresponding to \"minors\" (which only occurred twice).\n",
     "\n",
-    "`gensim` offers a number of different models/transformations. See [Transformations and Topics](https://radimrehurek.com/gensim/tut2.html) for details."
+    "`gensim` offers a number of different models/transformations. See [Transformations and Topics](https://github.com/RaRe-Technologies/gensim/blob/develop/docs/notebooks/Topics_and_Transformations.ipynb) for details."
    ]
   }
  ],


### PR DESCRIPTION
"Transformation and Topics" link was changed to redirect to the github page