### PR TITLE
Corpora_and_Vector_Spaces tutorial text fix

### DIFF
--- a/docs/notebooks/Corpora_and_Vector_Spaces.ipynb
+++ b/docs/notebooks/Corpora_and_Vector_Spaces.ipynb
@@ -213,7 +213,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The function `doc2bow()` simply counts the number of occurrences of each distinct word, converts the word to its integer word id and returns the result as a sparse vector. The sparse vector `[(0, 1), (1, 1)]` therefore reads: in the document *“Human computer interaction”*, the words computer (id 0) and human (id 1) appear once; the other ten dictionary words appear (implicitly) zero times."
+    "The function `doc2bow()` simply counts the number of occurrences of each distinct word, converts the word to its integer word id and returns the result as a sparse vector. The sparse vector `[(word_id, 1), (word_id, 1)]` therefore reads: in the document *“Human computer interaction”*, the words *\"computer\"* and *\"human\"*, identified by an integer id given by the built dictionary, appear once; the other ten dictionary words appear (implicitly) zero times. Check their id at the dictionary displayed in the previous cell and see that they match."
    ]
   },
   {
@@ -250,7 +250,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By now it should be clear that the vector feature with `id=10 stands` for the question “How many times does the word graph appear in the document?” and that the answer is “zero” for the first six documents and “one” for the remaining three. As a matter of fact, we have arrived at exactly the same corpus of vectors as in the [Quick Example](https://radimrehurek.com/gensim/tutorial.html#first-example).\n",
+    "By now it should be clear that the vector feature with `id=10 stands` for the question “How many times does the word graph appear in the document?” and that the answer is “zero” for the first six documents and “one” for the remaining three. As a matter of fact, we have arrived at exactly the same corpus of vectors as in the [Quick Example](https://radimrehurek.com/gensim/tutorial.html#first-example). If you're running this notebook by your own, the words id may differ, but you should be able to check the consistency between documents comparing their vectors. \n",
     "\n",
     "## Corpus Streaming – One Document at a Time\n",
     "\n",
@@ -616,7 +616,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
It's just a text fix to make the tutorial more friendly. It's about the words id given by the built dictionary.

Some places assume it'll be the same and explain the output using fixed ids, that might be confusing. like in:
> The sparse vector [(0, 1), (1, 1)] therefore reads: in the document “Human computer interaction”, the words computer (id 0) and human (id 1) appear once; the other ten dictionary words appear (implicitly) zero times.

I'm suggesting a change to:
> The sparse vector `[(word_id, 1), (word_id, 1)]` therefore reads: in the document *“Human computer interaction”*, the words "computer" and "human", identified by an integer id given by the built dictionary, appear once; the other ten dictionary words appear (implicitly) zero times. Check their id at the dictionary displayed in the previous cell and see that they match.

Since the user can check what was the id given to a word in the previous cell's output, where it prints the dictionary.token2id.

And it has too a little warning about the ids being different from runned notebooks, or the link provided for comparison ([Quick Example](https://radimrehurek.com/gensim/tutorial.html#first-example)), so beginners won't find it strange.