### PR TITLE
Fix #865

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -474,7 +474,7 @@ class Word2Vec(utils.SaveLoad):
         for word_index in xrange(vocab_size):
             train_words_pow += self.wv.vocab[self.wv.index2word[word_index]].count**power
         cumulative = 0.0
-        for word_index in range(vocab_size):
+        for word_index in xrange(vocab_size):
             cumulative += self.wv.vocab[self.wv.index2word[word_index]].count**power
             self.cum_table[word_index] = round(cumulative / train_words_pow * domain)
         if len(self.cum_table) > 0:

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -470,7 +470,9 @@ class Word2Vec(utils.SaveLoad):
         vocab_size = len(self.wv.index2word)
         self.cum_table = zeros(vocab_size, dtype=uint32)
         # compute sum of all power (Z in paper)
-        train_words_pow = float(sum([self.wv.vocab[word].count**power for word in self.wv.vocab]))
+        train_words_pow = 0.0
+        for word_index in xrange(vocab_size):
+            train_words_pow += self.wv.vocab[self.wv.index2word[word_index]].count**power
         cumulative = 0.0
         for word_index in range(vocab_size):
             cumulative += self.wv.vocab[self.wv.index2word[word_index]].count**power


### PR DESCRIPTION
as per the comments in issue #865 calculate `train_words_pow` the same way `cumulative` to ensure they're equal and prevent assert error. Additionally use xrange instead of range.