### PR TITLE
Improve topics and transformations

### DIFF
--- a/docs/notebooks/Topics_and_Transformations.ipynb
+++ b/docs/notebooks/Topics_and_Transformations.ipynb
@@ -298,7 +298,8 @@
     "\n",
     "Gensim implements several popular Vector Space Model algorithms:\n",
     "\n",
-    "* [Term Frequency * Inverse Document Frequency](http://en.wikipedia.org/wiki/Tf–idf), Tf-Idf expects a bag-of-words (integer values) training corpus during initialization. During transformation, it will take a vector and return another vector of the same dimensionality, except that features which were rare in the training corpus will have their value increased. It therefore converts integer-valued vectors into real-valued ones, while leaving the number of dimensions intact. It can also optionally normalize the resulting vectors to (Euclidean) unit length."
+    "### [Term Frequency * Inverse Document Frequency](http://en.wikipedia.org/wiki/Tf–idf) \n",
+    "Tf-Idf expects a bag-of-words (integer values) training corpus during initialization. During transformation, it will take a vector and return another vector of the same dimensionality, except that features which were rare in the training corpus will have their value increased. It therefore converts integer-valued vectors into real-valued ones, while leaving the number of dimensions intact. It can also optionally normalize the resulting vectors to (Euclidean) unit length."
    ]
   },
   {
@@ -316,7 +317,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Latent Semantic Indexing, LSI (or sometimes LSA)](http://en.wikipedia.org/wiki/Latent_semantic_indexing) transforms documents from either bag-of-words or (preferrably) TfIdf-weighted space into a latent space of a lower dimensionality. For the toy corpus above we used only 2 latent dimensions, but on real corpora, target dimensionality of 200–500 is recommended as a “golden standard” [1]."
+    "### [Latent Semantic Indexing, LSI (or sometimes LSA)](http://en.wikipedia.org/wiki/Latent_semantic_indexing) \n",
+    "LSI transforms documents from either bag-of-words or (preferrably) TfIdf-weighted space into a latent space of a lower dimensionality. For the toy corpus above we used only 2 latent dimensions, but on real corpora, target dimensionality of 200–500 is recommended as a “golden standard” [1]."
    ]
   },
   {
@@ -364,7 +366,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Random Projections](http://www.cis.hut.fi/ella/publications/randproj_kdd.pdf), RP aim to reduce vector space dimensionality. This is a very efficient (both memory- and CPU-friendly) approach to approximating TfIdf distances between documents, by throwing in a little randomness. Recommended target dimensionality is again in the hundreds/thousands, depending on your dataset."
+    "### [Random Projections](http://www.cis.hut.fi/ella/publications/randproj_kdd.pdf)\n",
+    "RP aim to reduce vector space dimensionality. This is a very efficient (both memory- and CPU-friendly) approach to approximating TfIdf distances between documents, by throwing in a little randomness. Recommended target dimensionality is again in the hundreds/thousands, depending on your dataset."
    ]
   },
   {
@@ -382,7 +385,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Latent Dirichlet Allocation, LDA](http://en.wikipedia.org/wiki/Latent_Dirichlet_allocation) is yet another transformation from bag-of-words counts into a topic space of lower dimensionality. LDA is a probabilistic extension of LSA (also called multinomial PCA), so LDA’s topics can be interpreted as probability distributions over words. These distributions are, just like with LSA, inferred automatically from a training corpus. Documents are in turn interpreted as a (soft) mixture of these topics (again, just like with LSA)."
+    "### [Latent Dirichlet Allocation, LDA](http://en.wikipedia.org/wiki/Latent_Dirichlet_allocation) \n",
+    "LDA is yet another transformation from bag-of-words counts into a topic space of lower dimensionality. LDA is a probabilistic extension of LSA (also called multinomial PCA), so LDA’s topics can be interpreted as probability distributions over words. These distributions are, just like with LSA, inferred automatically from a training corpus. Documents are in turn interpreted as a (soft) mixture of these topics (again, just like with LSA)."
    ]
   },
   {
@@ -407,7 +411,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Hierarchical Dirichlet Process, HDP](http://jmlr.csail.mit.edu/proceedings/papers/v15/wang11a/wang11a.pdf) is a non-parametric bayesian method (note the missing number of requested topics):"
+    "### [Hierarchical Dirichlet Process, HDP](http://jmlr.csail.mit.edu/proceedings/papers/v15/wang11a/wang11a.pdf) \n",
+    "HDP is a non-parametric bayesian method (note the missing number of requested topics):"
    ]
   },
   {

--- a/docs/notebooks/Topics_and_Transformations.ipynb
+++ b/docs/notebooks/Topics_and_Transformations.ipynb
@@ -441,7 +441,7 @@
     "\n",
     "It is worth repeating that these are all unique, incremental implementations, which do not require the whole training corpus to be present in main memory all at once. With memory taken care of, I am now improving Distributed Computing, to improve CPU efficiency, too. If you feel you could contribute (by testing, providing use-cases or code), please let me know.\n",
     "\n",
-    "Continue on to the next tutorial on Similarity Queries.\n"
+    "Continue on to the next tutorial on [Similarity Queries](./Similarity_Queries.ipynb)."
    ]
   },
   {


### PR DESCRIPTION
* Improve Available transformations section indentation 

The previous one, bullet point based, looked really bad on python notebook. 
It was hard to follow and understand

* Add relative to link to next tutorial.