### PR TITLE
word2vec2tensor with python 3

### DIFF
--- a/gensim/scripts/word2vec2tensor.py
+++ b/gensim/scripts/word2vec2tensor.py
@@ -51,7 +51,7 @@ def word2vec2tensor(word2vec_model_path,tensor_filename, binary=False):
     with open(outfiletsv, 'w+') as file_vector:
         with open(outfiletsvmeta, 'w+') as file_metadata:
             for word in model.index2word:
-                file_metadata.write(word.encode('utf-8') + '\n')
+                file_metadata.write(gensim.utils.to_unicode(word) + '\n')
                 vector_row = '\t'.join(map(str, model[word]))
                 file_vector.write(vector_row + '\n')
     


### PR DESCRIPTION
As discussed with @tmylk in issue [1126](https://github.com/RaRe-Technologies/gensim/issues/1126), python 3 does not support `word.encode('utf-8')`. Changing to `gensim.utils.to_unicode(word)` worked. Tested with Python 3.5 in Ubuntu 16.04.