### PR TITLE
Dependencies description on doc2vec-IMDB notebook

### DIFF
--- a/docs/notebooks/doc2vec-IMDB.ipynb
+++ b/docs/notebooks/doc2vec-IMDB.ipynb
@@ -13,7 +13,13 @@
    "source": [
     "TODO: section on introduction & motivation\n",
     "\n",
-    "TODO: prerequisites + dependencies (statsmodels, patsy, ?)"
+    "TODO: prerequisites + dependencies (statsmodels, patsy, ?)\n",
+    "\n",
+    "### Requirements\n",
+    "Following are the dependencies for this tutorial:\n",
+    "    - testfixtures\n",
+    "    - statsmodels\n",
+    "    "
    ]
   },
   {


### PR DESCRIPTION
Added the python package dependencies I could find on the doc2vec-IMDB tutorial.
Not sure if it's all of them, in fact.

Signed-off-by: Luiz Carlos Cavalcanti <cavalcanti.luiz@gmail.com>