### PR TITLE
Note added to annoytutorial.ipynb

### DIFF
--- a/docs/notebooks/annoytutorial.ipynb
+++ b/docs/notebooks/annoytutorial.ipynb
@@ -179,7 +179,7 @@
     "\n",
     ">**Note**: Initialization time for the annoy indexer was not included in the times. The optimal knn algorithm for you to use will depend on how many queries you need to make and the size of the corpus. If you are making very few similarity queries, the time taken to initialize the annoy indexer will be longer than the time it would take the brute force method to retrieve results. If you are making many queries however, the time it takes to initialize the annoy indexer will be made up for by the incredibly fast retrieval times for queries once the indexer has been initialized\n",
     "\n",
-    ">**Note** : **If you are using gensim, it'll run on multiple cores**. Gensim's 'most_similar' method is using numpy operations in the form of dot product whereas Annoy's method isnt. If 'numpy' on your machine is using one of the BLAS libraries like ATLAS or LAPACK, it'll run on multiple cores(only if your machine has multicore support ). "
+    ">**Note** : Gensim's 'most_similar' method is using numpy operations in the form of dot product whereas Annoy's method isnt. If 'numpy' on your machine is using one of the BLAS libraries like ATLAS or LAPACK, it'll run on multiple cores(only if your machine has multicore support ). "
    ]
   },
   {

--- a/docs/notebooks/annoytutorial.ipynb
+++ b/docs/notebooks/annoytutorial.ipynb
@@ -179,7 +179,7 @@
     "\n",
     ">**Note**: Initialization time for the annoy indexer was not included in the times. The optimal knn algorithm for you to use will depend on how many queries you need to make and the size of the corpus. If you are making very few similarity queries, the time taken to initialize the annoy indexer will be longer than the time it would take the brute force method to retrieve results. If you are making many queries however, the time it takes to initialize the annoy indexer will be made up for by the incredibly fast retrieval times for queries once the indexer has been initialized\n",
     "\n",
-    ">**Note** : Gensim's 'most_similar' method is using numpy operations in the form of dot product whereas Annoy's method isnt. If 'numpy' on your machine is using one of the BLAS libraries like ATLAS or LAPACK, it'll run on multiple cores(only if your machine has multicore support ). "
+    ">**Note** : Gensim's 'most_similar' method is using numpy operations in the form of dot product whereas Annoy's method isnt. If 'numpy' on your machine is using one of the BLAS libraries like ATLAS or LAPACK, it'll run on multiple cores(only if your machine has multicore support ). Check [SciPy Cookbook](http://scipy-cookbook.readthedocs.io/items/ParallelProgramming.html) for more details."
    ]
   },
   {

--- a/docs/notebooks/annoytutorial.ipynb
+++ b/docs/notebooks/annoytutorial.ipynb
@@ -177,7 +177,9 @@
     "\n",
     "**This speedup factor is by no means constant** and will vary greatly from run to run and is particular to this data set, BLAS setup, Annoy parameters(as tree size increases speedup factor decreases), machine specifications, among other factors.\n",
     "\n",
-    ">**Note**: Initialization time for the annoy indexer was not included in the times. The optimal knn algorithm for you to use will depend on how many queries you need to make and the size of the corpus. If you are making very few similarity queries, the time taken to initialize the annoy indexer will be longer than the time it would take the brute force method to retrieve results. If you are making many queries however, the time it takes to initialize the annoy indexer will be made up for by the incredibly fast retrieval times for queries once the indexer has been initialized"
+    ">**Note**: Initialization time for the annoy indexer was not included in the times. The optimal knn algorithm for you to use will depend on how many queries you need to make and the size of the corpus. If you are making very few similarity queries, the time taken to initialize the annoy indexer will be longer than the time it would take the brute force method to retrieve results. If you are making many queries however, the time it takes to initialize the annoy indexer will be made up for by the incredibly fast retrieval times for queries once the indexer has been initialized\n",
+    "\n",
+    ">**Note** : Annoy library is single threaded by design. When you use Annoy's 'most_similar' method it runs on a single core. Linux users can check this with its 'htop' utility. Whereas gensim's 'most_similar' method uses numpy operations in the form of matrix multiplication(dot). While doing numpy operations python releases GLobal Interpreter Lock(GIL) which makes gensim's 'most_similar' method possible to run on multiple cores. Check \"http://scipy-cookbook.readthedocs.io/items/ParallelProgramming.html\" for further details."
    ]
   },
   {

--- a/docs/notebooks/annoytutorial.ipynb
+++ b/docs/notebooks/annoytutorial.ipynb
@@ -179,7 +179,7 @@
     "\n",
     ">**Note**: Initialization time for the annoy indexer was not included in the times. The optimal knn algorithm for you to use will depend on how many queries you need to make and the size of the corpus. If you are making very few similarity queries, the time taken to initialize the annoy indexer will be longer than the time it would take the brute force method to retrieve results. If you are making many queries however, the time it takes to initialize the annoy indexer will be made up for by the incredibly fast retrieval times for queries once the indexer has been initialized\n",
     "\n",
-    ">**Note** : Annoy library is single threaded by design. When you use Annoy's 'most_similar' method it runs on a single core. Linux users can check this with its 'htop' utility. Whereas gensim's 'most_similar' method uses numpy operations in the form of matrix multiplication(dot). While doing numpy operations python releases GLobal Interpreter Lock(GIL) which makes gensim's 'most_similar' method possible to run on multiple cores. Check \"http://scipy-cookbook.readthedocs.io/items/ParallelProgramming.html\" for further details."
+    ">**Note** : Annoy library is single threaded by design. If you use annoy_index, it will run on a single core.Linux users can check this with 'htop' utility. Whereas gensim's 'most_similar'(in keyedvectors.py) method uses numpy operations in the form of matrix multiplication(dot). Python releases GLobal Interpreter Lock(GIL) for numpy matrix multiplications and makes it possible for gensim's 'most_similar' method to run on multiple cores. Check \"http://scipy-cookbook.readthedocs.io/items/ParallelProgramming.html\" for further details."
    ]
   },
   {

--- a/docs/notebooks/annoytutorial.ipynb
+++ b/docs/notebooks/annoytutorial.ipynb
@@ -179,7 +179,7 @@
     "\n",
     ">**Note**: Initialization time for the annoy indexer was not included in the times. The optimal knn algorithm for you to use will depend on how many queries you need to make and the size of the corpus. If you are making very few similarity queries, the time taken to initialize the annoy indexer will be longer than the time it would take the brute force method to retrieve results. If you are making many queries however, the time it takes to initialize the annoy indexer will be made up for by the incredibly fast retrieval times for queries once the indexer has been initialized\n",
     "\n",
-    ">**Note** : Annoy library is single threaded by design. If you use annoy_index, it will run on a single core.Linux users can check this with 'htop' utility. Whereas gensim's 'most_similar'(in keyedvectors.py) method uses numpy operations in the form of matrix multiplication(dot). Python releases GLobal Interpreter Lock(GIL) for numpy matrix multiplications and makes it possible for gensim's 'most_similar' method to run on multiple cores. Check \"http://scipy-cookbook.readthedocs.io/items/ParallelProgramming.html\" for further details."
+    ">**Note** : **If you are using gensim, it'll run on multiple cores**. Gensim's 'most_similar' method is using numpy operations in the form of dot product whereas Annoy's method isnt. If 'numpy' on your machine is using one of the BLAS libraries like ATLAS or LAPACK, it'll run on multiple cores(only if your machine has multicore support ). "
    ]
   },
   {


### PR DESCRIPTION
Note explaining why gensim's 'most_similar'  method uses multicore whereas annoy's 'most_similar' runs on a single core.