### PR TITLE
Make compatible with numpy 1.12 stricter indexing

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -206,6 +206,9 @@ def sparse2full(doc, length):
 
     """
     result = np.zeros(length, dtype=np.float32)  # fill with zeroes (default value)
+    # convert indices to int as numpy 1.12 no longer indexes by floats
+    doc = ((int(id_), float(val_)) for (id_, val_) in doc)
+
     doc = dict(doc)
     # overwrite some of the zeroes with explicit values
     result[list(doc)] = list(itervalues(doc))

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -862,7 +862,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             for m in top_words[1:]:
                 # m_docs is v_m^(t)
                 m_docs = doc_word_list[m]
-                m_index = np.where(top_words == m)[0]
+                m_index = np.where(top_words == m)[0][0]
 
                 # Sum of top words l=1..m
                 # i.e., all words ranked higher than the current word m


### PR DESCRIPTION

In numpy 1.12:

> DeprecationWarning to error
> Indexing with floats raises IndexError, e.g., a[0, 0.0].
> Indexing with non-integer array_like raises IndexError, e.g., a['1', '2']
