### PR TITLE
 RandomState (Fix to issue #113) breaks backwards compatibility with old LDA models

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -1049,11 +1049,10 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         result = super(LdaModel, cls).load(fname, *args, **kwargs)
 
         random_state_fname = utils.smart_extension(fname, '.random_state')
-        random_state_val = utils.get_random_state(random_state_fname)
         try:
-            result.random_state = super(LdaModel, cls).load(random_state_val, *args, **kwargs)
+            result.random_state = super(LdaModel, cls).load(random_state_fname, *args, **kwargs)
         except Exception as e:
-            logging.warning("failed to load random_state from %s: %s", random_state_val, e)
+            logging.warning("failed to load random_state from %s: %s", random_state_fname, e)
         state_fname = utils.smart_extension(fname, '.state')
         try:
             result.state = super(LdaModel, cls).load(state_fname, *args, **kwargs)

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -1047,6 +1047,13 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         """
         kwargs['mmap'] = kwargs.get('mmap', None)
         result = super(LdaModel, cls).load(fname, *args, **kwargs)
+
+        random_state_fname = utils.smart_extension(fname, '.random_state')
+        random_state_val = utils.get_random_state(random_state_fname)
+        try:
+            result.random_state = super(LdaModel, cls).load(random_state_val, *args, **kwargs)
+        except Exception as e:
+            logging.warning("failed to load random_state from %s: %s", random_state_val, e)
         state_fname = utils.smart_extension(fname, '.state')
         try:
             result.state = super(LdaModel, cls).load(state_fname, *args, **kwargs)


### PR DESCRIPTION
LDA models saved before version 0.13.2 can not be used in version 0.13.2 and up because they do not contain random_state variable. (https://github.com/RaRe-Technologies/gensim/issues/1082).