### PR TITLE
Fixed bound computation mistake in author-topic model

### DIFF
--- a/gensim/models/atmodel.py
+++ b/gensim/models/atmodel.py
@@ -838,7 +838,7 @@ class AuthorTopicModel(LdaModel):
             # Computing the bound requires summing over expElogtheta[a, k] * expElogbeta[k, v], which
             # is the same computation as in normalizing phi.
             phinorm = self.compute_phinorm(ids, authors_d, expElogtheta[authors_d, :], expElogbeta[:, ids])
-            word_score += np.log(1.0 / len(authors_d)) + cts.dot(np.log(phinorm))
+            word_score += np.log(1.0 / len(authors_d)) * sum(cts) + cts.dot(np.log(phinorm))
 
         # Compensate likelihood for when `chunk` above is only a sample of the whole corpus. This ensures
         # that the likelihood is always rougly on the same scale.


### PR DESCRIPTION
Noticed a mistake in the `bound` method of the author-topic model (`atmodel`). This is a very simple fix.

Basically, I forgot to multiply the expectation over author assignments (`np.log(1.0 / len(authors_d))`) by the number of words in the document `sum(cts)`, and fixed that in this PR.

This fix changes the bound, only by adding a factor that depends only on the data (constant w.r.t. the model).