### PR TITLE
Added documentation for metadata

### DIFF
--- a/gensim/corpora/indexedcorpus.py
+++ b/gensim/corpora/indexedcorpus.py
@@ -69,6 +69,7 @@ class IndexedCorpus(interfaces.CorpusABC):
            each saved document,
         * the `docbyoffset(offset)` method, which returns a document
           positioned at `offset` bytes within the persistent storage (file).
+        * metadata if set to true will ensure that serialize will write out article titles to a pickle file.
 
         Example:
 

--- a/gensim/corpora/wikicorpus.py
+++ b/gensim/corpora/wikicorpus.py
@@ -266,6 +266,7 @@ class WikiCorpus(TextCorpus):
         If `pattern` package is installed, use fancier shallow parsing to get
         token lemmas. Otherwise, use simple regexp tokenization. You can override
         this automatic logic by forcing the `lemmatize` parameter explicitly.
+        self.metadata if set to true will ensure that serialize will write out article titles to a pickle file.
 
         """
         self.fname = fname


### PR DESCRIPTION
Short metadata documentation added to ```wikicorpus.py``` and ```indexedcorpus.py```.

@#1161