### PR TITLE
Fix #824 : no corpus in init, but trim_rule in init

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -476,8 +476,9 @@ class Word2Vec(utils.SaveLoad):
             self.train(sentences)
             
         else :
-            logger.warning("The rule, if given, is only used prune vocabulary during build_vocab() and is not stored as part of the model. ")
-            logger.warning("Model initialized without sentences. trim_rule provided, if any, will be ignored." )
+            if trim_rule is not None :
+                logger.warning("The rule, if given, is only used prune vocabulary during build_vocab() and is not stored as part of the model. ")
+                logger.warning("Model initialized without sentences. trim_rule provided, if any, will be ignored." )
 
 
     def initialize_word_vectors(self):

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -474,6 +474,11 @@ class Word2Vec(utils.SaveLoad):
                 raise TypeError("You can't pass a generator as the sentences argument. Try an iterator.")
             self.build_vocab(sentences, trim_rule=trim_rule)
             self.train(sentences)
+            
+        else :
+            logger.warning("The rule, if given, is only used prune vocabulary during build_vocab() and is not stored as part of the model. ")
+            logger.warning("Model initialized without sentences. trim_rule provided, if any, will be ignored." )
+
 
     def initialize_word_vectors(self):
         self.wv = KeyedVectors()


### PR DESCRIPTION
logged warning that trim_rule is being ignored for separate model initialization and vocabulary building. [(#824)](https://github.com/RaRe-Technologies/gensim/issues/824)
