### PR TITLE
Updated the error message for the case when build_vocab() is triggered more than once without update parameter

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -721,7 +721,7 @@ class Word2Vec(utils.SaveLoad):
     def sort_vocab(self):
         """Sort the vocabulary so the most frequent words have the lowest indexes."""
         if len(self.wv.syn0):
-            raise RuntimeError("must sort before initializing vectors/weights")
+            raise RuntimeError("cannot sort vocabulary after model weights already initialized.")
         self.wv.index2word.sort(key=lambda word: self.wv.vocab[word].count, reverse=True)
         for i, word in enumerate(self.wv.index2word):
             self.wv.vocab[word].index = i


### PR DESCRIPTION
Updated the error message for the case when build_vocab() is triggered more than once without **update** parameter, according to the discussion in [(issue #1187 )](https://github.com/RaRe-Technologies/gensim/issues/1187)

```python
model = gensim.models.Word2Vec(sentences,min_count=3,trim_rule=my_rule)
model.build_vocab(sentences) #throws error
model.build_vocab(sentences, update = True) #works as expected
```