### PR TITLE
Add KeyedVectors, FastText and CoherenceModel to API reference.

### DIFF
--- a/docs/src/apiref.rst
+++ b/docs/src/apiref.rst
@@ -39,6 +39,7 @@ Modules:
     models/lda_worker
     models/atmodel
     models/word2vec
+    models/keyedvectors
     models/doc2vec
     models/phrases
     models/coherencemodel

--- a/docs/src/apiref.rst
+++ b/docs/src/apiref.rst
@@ -41,11 +41,13 @@ Modules:
     models/word2vec
     models/doc2vec
     models/phrases
+    models/coherencemodel
     models/wrappers/ldamallet
     models/wrappers/dtmmodel
     models/wrappers/ldavowpalwabbit.rst
     models/wrappers/wordrank
     models/wrappers/varembed
+    models/wrappers/fasttext
     similarities/docsim
     similarities/index
     topic_coherence/aggregation

--- a/docs/src/models/keyedvectors.rst
+++ b/docs/src/models/keyedvectors.rst
@@ -1,0 +1,9 @@
+:mod:`models.keyedvectors` -- Store and query word vectors
+==========================================================
+
+.. automodule:: gensim.models.keyedvectors
+    :synopsis: Store and query word vectors
+    :members:
+    :inherited-members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/src/models/wrappers/fasttext.rst
+++ b/docs/src/models/wrappers/fasttext.rst
@@ -1,0 +1,9 @@
+:mod:`models.wrappers.fasttext` -- FastText Word Embeddings
+===========================================================
+
+.. automodule:: gensim.models.wrappers.fasttext
+    :synopsis: FastText Embeddings
+    :members:
+    :inherited-members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/src/topic_coherence/topic_coherence.rst
+++ b/docs/src/topic_coherence/topic_coherence.rst
@@ -1,7 +1,0 @@
-:mod:`topic_coherence` -- Package for the topic coherence pipeline
-==================================================================
-
-.. automodule:: gensim.topic_coherence
-    :synopsis: Package for the topic coherence pipeline
-    :members:
-    :inherited-members:

--- a/gensim/models/coherencemodel.py
+++ b/gensim/models/coherencemodel.py
@@ -6,7 +6,7 @@
 
 """
 Module for calculating topic coherence in python. This is the implementation of
-the four stage topic coherence pipeline from the paper [1].
+the four stage topic coherence pipeline from the paper [1]_.
 The four stage pipeline is basically:
 
 Segmentation -> Probability Estimation -> Confirmation Measure -> Aggregation.
@@ -14,7 +14,7 @@ Segmentation -> Probability Estimation -> Confirmation Measure -> Aggregation.
 Implementation of this pipeline allows for the user to in essence "make" a
 coherence measure of his/her choice by choosing a method in each of the pipelines.
 
-[1] Michael Roeder, Andreas Both and Alexander Hinneburg. Exploring the space of topic
+.. [1] Michael Roeder, Andreas Both and Alexander Hinneburg. Exploring the space of topic
 coherence measures. http://svn.aksw.org/papers/2015/WSDM_Topic_Evaluation/public.pdf.
 """
 
@@ -75,15 +75,17 @@ class CoherenceModel(interfaces.TransformationABC):
     2. the ``get_coherence()`` method, which returns the topic coherence.
 
     One way of using this feature is through providing a trained topic model. A dictionary has to be explicitly
-    provided if the model does not contain a dictionary already.
-    >>> cm = CoherenceModel(model=tm, corpus=corpus, coherence='u_mass')  # tm is the trained topic model
-    >>> cm.get_coherence()
+    provided if the model does not contain a dictionary already::
 
-    Another way of using this feature is through providing tokenized topics such as:
-    >>> topics = [['human', 'computer', 'system', 'interface'],
+        cm = CoherenceModel(model=tm, corpus=corpus, coherence='u_mass')  # tm is the trained topic model
+        cm.get_coherence()
+
+    Another way of using this feature is through providing tokenized topics such as::
+
+        topics = [['human', 'computer', 'system', 'interface'],
                   ['graph', 'minors', 'trees', 'eps']]
-    >>> cm = CoherenceModel(topics=topics, corpus=corpus, dictionary=dictionary, coherence='u_mass') # note that a dictionary has to be provided.
-    >>> cm.get_coherence()
+        cm = CoherenceModel(topics=topics, corpus=corpus, dictionary=dictionary, coherence='u_mass') # note that a dictionary has to be provided.
+        cm.get_coherence()
 
     Model persistency is achieved via its load/save methods.
     """
@@ -94,11 +96,11 @@ class CoherenceModel(interfaces.TransformationABC):
         model : Pre-trained topic model. Should be provided if topics is not provided.
                 Currently supports LdaModel, LdaMallet wrapper and LdaVowpalWabbit wrapper. Use 'topics'
                 parameter to plug in an as yet unsupported model.
-        topics : List of tokenized topics. If this is preferred over model, dictionary should be provided.
-                 eg. topics = [['human', 'machine', 'computer', 'interface'],
+        topics : List of tokenized topics. If this is preferred over model, dictionary should be provided. eg.::
+                 topics = [['human', 'machine', 'computer', 'interface'],
                                ['graph', 'trees', 'binary', 'widths']]
-        texts : Tokenized texts. Needed for coherence models that use sliding window based probability estimator.
-                eg. texts = [['system', 'human', 'system', 'eps'],
+        texts : Tokenized texts. Needed for coherence models that use sliding window based probability estimator, eg::
+                texts = [['system', 'human', 'system', 'eps'],
                              ['user', 'response', 'time'],
                              ['trees'],
                              ['graph', 'trees'],

--- a/gensim/models/coherencemodel.py
+++ b/gensim/models/coherencemodel.py
@@ -96,7 +96,7 @@ class CoherenceModel(interfaces.TransformationABC):
         model : Pre-trained topic model. Should be provided if topics is not provided.
                 Currently supports LdaModel, LdaMallet wrapper and LdaVowpalWabbit wrapper. Use 'topics'
                 parameter to plug in an as yet unsupported model.
-        topics : List of tokenized topics. If this is preferred over model, dictionary should be provided. eg.::
+        topics : List of tokenized topics. If this is preferred over model, dictionary should be provided. eg::
                  topics = [['human', 'machine', 'computer', 'interface'],
                                ['graph', 'trees', 'binary', 'widths']]
         texts : Tokenized texts. Needed for coherence models that use sliding window based probability estimator, eg::

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -606,12 +606,11 @@ class Doc2Vec(Word2Vec):
         doc-vector training; default is 0 (faster training of doc-vectors only).
 
         `trim_rule` = vocabulary trimming rule, specifies whether certain words should remain
-         in the vocabulary, be trimmed away, or handled using the default (discard if word count < min_count).
-         Can be None (min_count will be used), or a callable that accepts parameters (word, count, min_count) and
-         returns either util.RULE_DISCARD, util.RULE_KEEP or util.RULE_DEFAULT.
-         Note: The rule, if given, is only used prune vocabulary during build_vocab() and is not stored as part
-          of the model.
-
+        in the vocabulary, be trimmed away, or handled using the default (discard if word count < min_count).
+        Can be None (min_count will be used), or a callable that accepts parameters (word, count, min_count) and
+        returns either util.RULE_DISCARD, util.RULE_KEEP or util.RULE_DEFAULT.
+        Note: The rule, if given, is only used prune vocabulary during build_vocab() and is not stored as part
+        of the model.
         """
 
         super(Doc2Vec, self).__init__(


### PR DESCRIPTION
And a minor indentation fix in doc2vec doscstring.

Sphinx 1.5.3 still produces 108 warnings when generating the docs. Raised #1192.