### PR TITLE
Word2vec update before train error message. Fix #1162

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1090,6 +1090,13 @@ class Word2Vec(utils.SaveLoad):
         for i in xrange(len(self.wv.syn0), len(self.wv.vocab)):
             # construct deterministic seed from word AND seed argument
             newsyn0[i-len(self.wv.syn0)] = self.seeded_vector(self.wv.index2word[i] + str(self.seed))
+
+        # Raise an error in an online update is run before initial training on a corpus
+        if not len(self.wv.syn0):
+            raise RuntimeError("You can do an online update of vocabulary on a pre-trained model. " \
+                "Or first build the vocabulary of your model with a corpus and train it " \
+                "before doing an online update.")
+
         self.wv.syn0 = vstack([self.wv.syn0, newsyn0])
 
         if self.hs:

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1091,7 +1091,7 @@ class Word2Vec(utils.SaveLoad):
             # construct deterministic seed from word AND seed argument
             newsyn0[i-len(self.wv.syn0)] = self.seeded_vector(self.wv.index2word[i] + str(self.seed))
 
-        # Raise an error in an online update is run before initial training on a corpus
+        # Raise an error if an online update is run before initial training on a corpus
         if not len(self.wv.syn0):
             raise RuntimeError("You can do an online update of vocabulary on a pre-trained model. " \
                 "Or first build the vocabulary of your model with a corpus and train it " \

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1093,8 +1093,8 @@ class Word2Vec(utils.SaveLoad):
 
         # Raise an error if an online update is run before initial training on a corpus
         if not len(self.wv.syn0):
-            raise RuntimeError("You can do an online update of vocabulary on a pre-trained model. " \
-                "Or first build the vocabulary of your model with a corpus and train it " \
+            raise RuntimeError("You cannot do an online vocabulary-update of a model which has no prior vocabulary. " \
+                "First build the vocabulary of your model with a corpus " \
                 "before doing an online update.")
 
         self.wv.syn0 = vstack([self.wv.syn0, newsyn0])


### PR DESCRIPTION
Using Python 2.7.12 on MAC OSX VERSION 10.11.6 
Used Sublime Text Build 3126 to make changes

Replicated the error by running the following 

```python
import gensim
from nltk.corpus import brown, movie_reviews, treebank
b = gensim.models.Word2Vec()
b_sents = brown.sents()
b.build_vocab(b_sents, keep_raw_vocab=False, trim_rule=None, progress_per=10000, update=True)
b.train(b_sents)
```

**Error displayed:**
```ValueError: all the input array dimensions except for the concatenation axis must match exactly```

Made changes in file ```gensim\models\word2vec.py``` in the function ```update_weights```.
Added the following code which checks if the model weights have been initialized. 
(line 1072 - 1076)
```python
# Raise an error in an online update is run before initial training on a corpus
if not len(self.wv.syn0):
    raise RuntimeError("You can do an online update of vocabulary on a pre-trained model. " \
       "Or first build the vocabulary of your model with a corpus and train it " \
       "before doing an online update.")
```

**Post-change testing:**
I tested using the following  code:

1) New Error message will be displayed instead of a `ValueError`

```python
import gensim
from nltk.corpus import brown, movie_reviews, treebank
b = gensim.models.Word2Vec()
b_sents = brown.sents()
b.build_vocab(b_sents, keep_raw_vocab=False, trim_rule=None, progress_per=10000, update=True)
b.train(b_sents)
```
and 

```python
model = gensim.models.Word2Vec()
sentences = gensim.models.word2vec.Text8Corpus('/path/to/text8')
model.build_vocab(sentences, update=True)
model.train(sentences)
```

2) No Error message will be displayed.

```python
import gensim
from nltk.corpus import brown, movie_reviews, treebank
b = gensim.models.Word2Vec()
b_sents = brown.sents()
b.build_vocab(b_sents, keep_raw_vocab=False, trim_rule=None, progress_per=10000, update=False)
b.train(b_sents)
b.build_vocab(b_sents, keep_raw_vocab=False, trim_rule=None, progress_per=10000, update=True)
b.train(b_sents)
```

```python
model = gensim.models.Word2Vec()
sentences = gensim.models.word2vec.Text8Corpus('/path/to/text8')
model.build_vocab(sentences, update=False)
model.train(sentences)
model.build_vocab(sentences, update=True)
model.train(sentences)
```

