### PR TITLE
Allows training if model is not modified by "_minimize_model". Adds deprecation warning.

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -106,6 +106,7 @@ from copy import deepcopy
 from collections import defaultdict
 import threading
 import itertools
+import warnings
 
 from gensim.utils import keep_vocab_item, call_on_class_only
 from gensim.utils import keep_vocab_item
@@ -1245,16 +1246,16 @@ class Word2Vec(utils.SaveLoad):
         return "%s(vocab=%s, size=%s, alpha=%s)" % (self.__class__.__name__, len(self.wv.index2word), self.vector_size, self.alpha)
 
     def _minimize_model(self, save_syn1 = False, save_syn1neg = False, save_syn0_lockf = False):
+        warnings.warn("This method would be deprecated in the future. Keep just_word_vectors = model.wv to retain just the KeyedVectors instance for read-only querying of word vectors.")
+        if save_syn1 and save_syn1neg and save_syn0_lockf:
+            return
         if hasattr(self, 'syn1') and not save_syn1:
             del self.syn1
         if hasattr(self, 'syn1neg') and not save_syn1neg:
             del self.syn1neg
         if hasattr(self, 'syn0_lockf') and not save_syn0_lockf:
             del self.syn0_lockf
-        if not save_syn1 or not save_syn1neg or not save_syn0_lockf:
-            self.model_trimmed_post_training = True
-        import warnings
-        warnings.warn("This method would be deprecated in the future. Use KeyedVectors to retain the previously trained word vectors instead.")
+        self.model_trimmed_post_training = True
 
     def delete_temporary_training_data(self, replace_word_vectors_with_normalized=False):
         """

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1253,7 +1253,8 @@ class Word2Vec(utils.SaveLoad):
             del self.syn0_lockf
         if not save_syn1 or not save_syn1neg or not save_syn0_lockf:
             self.model_trimmed_post_training = True
-        logger.warning("This method would be deprecated in the future. Use KeyedVectors to retain the previously trained word vectors instead.")
+        import warnings
+        warnings.warn("This method would be deprecated in the future. Use KeyedVectors to retain the previously trained word vectors instead.")
 
     def delete_temporary_training_data(self, replace_word_vectors_with_normalized=False):
         """

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1251,7 +1251,8 @@ class Word2Vec(utils.SaveLoad):
             del self.syn1neg
         if hasattr(self, 'syn0_lockf') and not save_syn0_lockf:
             del self.syn0_lockf
-        self.model_trimmed_post_training = True
+        if not save_syn1 or not save_syn1neg or not save_syn0_lockf:
+            self.model_trimmed_post_training = True
 
     def delete_temporary_training_data(self, replace_word_vectors_with_normalized=False):
         """

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1253,6 +1253,7 @@ class Word2Vec(utils.SaveLoad):
             del self.syn0_lockf
         if not save_syn1 or not save_syn1neg or not save_syn0_lockf:
             self.model_trimmed_post_training = True
+        logger.warning("This method would be deprecated in the future. Use KeyedVectors to retain the previously trained word vectors instead.")
 
     def delete_temporary_training_data(self, replace_word_vectors_with_normalized=False):
         """


### PR DESCRIPTION
This PR modifies the function `_minimize_model` in word2vec.py by checking if model was modified at all before setting `model_trimmed_post_training`. Also, a deprecation warning has been added for the function `_minimize_model`. The function would be deprecated in the future as using KeyedVectors is the way to go for word2vec.

Maling list [discussion](https://groups.google.com/d/msg/gensim/PxttBVSLixc/SlLehCJrEgAJ).