### PR TITLE
Due to scipy 0.19 release need to increase epsilon for comparing in KL tests

### DIFF
--- a/gensim/test/test_similarity_metrics.py
+++ b/gensim/test/test_similarity_metrics.py
@@ -188,7 +188,7 @@ class TestKL(unittest.TestCase):
         vec_2 = [(1, 0.1), (3, 0.8), (4, 0.1)]
         result = matutils.kullback_leibler(vec_2, vec_1, 8)
         expected = 0.55451775
-        self.assertAlmostEqual(expected, result)
+        self.assertAlmostEqual(expected, result, places=5)
 
         # KL is not symetric; vec1 compared with vec2 will contain log of zeros and return infinity
         vec_1 = [(2, 0.1), (3, 0.4), (4, 0.1), (5, 0.1), (1, 0.1), (7, 0.2)]
@@ -201,14 +201,14 @@ class TestKL(unittest.TestCase):
         vec_2 = csr_matrix([[1, 0.4], [0, 0.2], [2, 0.2]])
         result = matutils.kullback_leibler(vec_1, vec_2, 3)
         expected = 0.0894502
-        self.assertAlmostEqual(expected, result)
+        self.assertAlmostEqual(expected, result, places=5)
 
         # checking ndarray, list as inputs
         vec_1 = np.array([0.6, 0.1, 0.1, 0.2])
         vec_2 = [0.2, 0.2, 0.1, 0.5]
         result = matutils.kullback_leibler(vec_1, vec_2)
         expected = 0.40659450877
-        self.assertAlmostEqual(expected, result)
+        self.assertAlmostEqual(expected, result, places=5)
 
         # testing LDA distribution vectors
         np.random.seed(0)
@@ -217,7 +217,7 @@ class TestKL(unittest.TestCase):
         lda_vec2 = model[[(2, 2), (1, 3)]]
         result = matutils.kullback_leibler(lda_vec1, lda_vec2)
         expected = 4.283407e-12
-        self.assertAlmostEqual(expected, result)
+        self.assertAlmostEqual(expected, result, places=5)
 
 class TestJaccard(unittest.TestCase):
     def test_inputs(self):


### PR DESCRIPTION
Fix this [build](https://travis-ci.org/RaRe-Technologies/gensim/jobs/210683284) error
```
======================================================================
FAIL: test_distributions (gensim.test.test_similarity_metrics.TestKL)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/RaRe-Technologies/gensim/gensim/test/test_similarity_metrics.py", line 204, in test_distributions
    self.assertAlmostEqual(expected, result)
AssertionError: 0.0894502 != 0.089450255 within 7 places

```