### PR TITLE
[WIP] Add support for PySpaRNN (#1224)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,14 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda2/bin:$PATH
   - conda update --yes conda
+  - git clone https://github.com/facebookresearch/pysparnn pysparnn
 install:
   - conda create --yes -n gensim-test python=$TRAVIS_PYTHON_VERSION pip atlas numpy scipy
   - source activate gensim-test
   - pip install pyemd
   - pip install annoy
+  - pip install -r pysparnn/requirements.txt
+  - cd pysparnn; python setup.py install; cd ..
   - pip install testfixtures
   - pip install unittest2
   - pip install Morfessor==2.0.2a4

--- a/docs/notebooks/pysparnn-benchmark.ipynb
+++ b/docs/notebooks/pysparnn-benchmark.ipynb
@@ -1,0 +1,498 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Approximate NN with `PySpaRNN` (for sparse data)\n",
+    "This tutorial will show you how to use the `PySpaRNNIndexer` object for approximate nearest neighbour search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "\n",
+    "import gensim\n",
+    "from gensim.similarities.index import PySpaRNNIndexer\n",
+    "from gensim.models.word2vec import Word2Vec"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How to use `PySpaRNNIndexer`\n",
+    "Let's prepare some data first: For this we will load text data from the Lee Corpus."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# This is adapted from /docs/notebooks/annoytutorial.ipynb\n",
+    "training_file = os.path.join(gensim.__path__[0], 'test', 'test_data', 'lee_background.cor')\n",
+    "\n",
+    "class MyText(object):\n",
+    "    def __iter__(self):\n",
+    "        for line in open(training_file):\n",
+    "            # Assume there's one document per line, tokens separated by whitespace\n",
+    "            yield gensim.utils.simple_preprocess(line)\n",
+    "\n",
+    "sentences = MyText()\n",
+    "model = Word2Vec(sentences, min_count = 1)\n",
+    "model.init_sims()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "pysparnn_index = PySpaRNNIndexer(model, num_clusters = 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "K = len(model.wv.syn0norm)\n",
+    "# Randomly draw a vector...\n",
+    "vector = model.wv.syn0norm[np.random.randint(0, K)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can query for data points in proximity using `pysparnn` as indexer. For example, let's try to find the ten nearest neighbor of our (random) vector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('funds', 1.000000238419),\n",
+       " ('beyond', 0.99431658),\n",
+       " ('top', 0.99428999),\n",
+       " ('continuing', 0.99417728),\n",
+       " ('month', 0.99401522),\n",
+       " ('crash', 0.99400979),\n",
+       " ('plans', 0.99398941),\n",
+       " ('strip', 0.99397492),\n",
+       " ('laws', 0.99395961),\n",
+       " ('peter', 0.9939574)]"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.most_similar([vector], topn = 10, indexer = pysparnn_index)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's compare it with Gensim's default indexer..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('funds', 1.0),\n",
+       " ('beyond', 0.9943166375160217),\n",
+       " ('top', 0.9942900538444519),\n",
+       " ('continuing', 0.9941773414611816),\n",
+       " ('month', 0.9940152168273926),\n",
+       " ('crash', 0.994009792804718),\n",
+       " ('plans', 0.9939892292022705),\n",
+       " ('strip', 0.9939751625061035),\n",
+       " ('laws', 0.9939596056938171),\n",
+       " ('peter', 0.9939572811126709)]"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.most_similar([vector], topn = 10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# A first benchmark\n",
+    "If we benchmark `PySpaRNNIndexer` against the default indexer, we will find out that it is way slower. This is because it is developed primiarly for sparse data. More on this below!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1000 loops, best of 3: 589 µs per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit model.most_similar([vector], topn = 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 32.9 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit model.most_similar([vector], topn = 10, indexer = pysparnn_index)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Benchmarking NN implementations (on artificial data)\n",
+    "We will now benchmark PySpaRNN's performance alongside `Annoy` (another library for aproximate NN) and a brute–force exact nearest neighbour search using `scikit-learn`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "from scipy.sparse import csr_matrix\n",
+    "\n",
+    "from annoy import AnnoyIndex\n",
+    "from pysparnn.cluster_index import MultiClusterIndex\n",
+    "from sklearn.neighbors import NearestNeighbors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate some data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Number of vectors\n",
+    "N = 1000\n",
+    "# Number of features\n",
+    "K = 50000\n",
+    "# Sparsity parameters\n",
+    "f = 0.0005\n",
+    "M = int(np.ceil(f * K))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Hallucinate a corpus\n",
+    "corpus = [[(a, b) for a, b in zip(np.random.randint(0, K, size = M), np.random.normal(size = M))] for i in range(N)]\n",
+    "# Build the feature matrix\n",
+    "vectors, labels = np.zeros((N, K)), np.arange(0, N, 1)\n",
+    "for i, document in enumerate(corpus):\n",
+    "    for j, x in document:\n",
+    "        vectors[i, j] = x\n",
+    "        \n",
+    "# Randomly draw some sample vectors to predict on\n",
+    "indices = np.random.randint(N, size = 100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Benchmarking `Annoy`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Train the Annoy model\n",
+    "a = AnnoyIndex(K)\n",
+    "for i, vector in enumerate(vectors):\n",
+    "    a.add_item(i, vector)\n",
+    "n_trees = 300\n",
+    "a.build(n_trees)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def test_annoy(model, indices, k = 3):\n",
+    "\n",
+    "    for i in indices:\n",
+    "        dense = vectors[i]\n",
+    "        sparse = csr_matrix(dense)\n",
+    "        model.get_nns_by_vector(dense, k)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Benchmarking annoy:\n",
+      "1 loop, best of 3: 5.18 s per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Benchmarking annoy:')\n",
+    "%timeit test_annoy(a, indices)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Benchmarking `PySpaRNN`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Train the PySpaRNN model\n",
+    "b = MultiClusterIndex(csr_matrix(vectors), labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def test_pysparnn(model, indices, k = 3):\n",
+    "\n",
+    "    for i in indices:\n",
+    "        dense = vectors[i]\n",
+    "        sparse = csr_matrix(dense)\n",
+    "        model.search(sparse, k = k, return_distance = False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Benchmarking PySpaRNN:\n",
+      "1 loop, best of 3: 721 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Benchmarking PySpaRNN:')\n",
+    "%timeit test_pysparnn(b, indices)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Benchmarking `scikit-learn`'s brute–force (exact) NN"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "NearestNeighbors(algorithm='brute', leaf_size=30, metric='minkowski',\n",
+       "         metric_params=None, n_jobs=1, n_neighbors=3, p=2, radius=1.0)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Train the (brute force) scitki-learn exact NN search\n",
+    "c = NearestNeighbors(n_neighbors = 3, algorithm = 'brute')\n",
+    "c.fit(vectors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def test_sklearn(model, indices, k = 3):\n",
+    "\n",
+    "    for i in indices:\n",
+    "        dense = vectors[i]\n",
+    "        sparse = csr_matrix(dense)\n",
+    "        model.kneighbors(dense.reshape(1, -1), n_neighbors = k, return_distance = False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Benchmarking sklearn:\n",
+      "1 loop, best of 3: 18.8 s per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Benchmarking sklearn:')\n",
+    "%timeit test_sklearn(c, indices)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This wraps Facebook's [PySpaRNN library](http://github.com/facebookresearch/pysparnn) for approximate NN search on sparse data. The interface allows the `PySpaRNNIndexer` object to be used as indexer within gensim, e.g. something like
```
pysparnn_index = PySpaRNNIndexer(model)
model.most_similar([vector], topn = 3, indexer = pysparnn_index)
```

with some arbitrary `vector`.