### PR TITLE
Fix #1230. Fix word2vec reset_from bug in v1.0.1 and added unittest

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -738,8 +738,8 @@ class Word2Vec(utils.SaveLoad):
         Borrow shareable pre-built structures (like vocab) from the other_model. Useful
         if testing multiple models in parallel on the same corpus.
         """
-        self.wv.vocab = other_model.vw.vocab
-        self.wv.index2word = other_model.vw.index2word
+        self.wv.vocab = other_model.wv.vocab
+        self.wv.index2word = other_model.wv.index2word
         self.cum_table = other_model.cum_table
         self.corpus_count = other_model.corpus_count
         self.reset_weights()

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -738,8 +738,8 @@ class Word2Vec(utils.SaveLoad):
         Borrow shareable pre-built structures (like vocab) from the other_model. Useful
         if testing multiple models in parallel on the same corpus.
         """
-        self.wv.vocab = other_model.vocab
-        self.wv.index2word = other_model.index2word
+        self.wv.vocab = other_model.vw.vocab
+        self.wv.index2word = other_model.vw.index2word
         self.cum_table = other_model.cum_table
         self.corpus_count = other_model.corpus_count
         self.reset_weights()

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -678,6 +678,13 @@ class TestWord2VecModel(unittest.TestCase):
     def testLoadOnClassError(self):
         """Test if exception is raised when loading word2vec model on instance"""
         self.assertRaises(AttributeError, load_on_instance)
+
+    def test_reset_from(self):
+        """Test if exception is raised when reset_from is used"""
+        model = word2vec.Word2Vec(sentences, min_count=1)
+        model2 = word2vec.Word2Vec(new_sentences, min_count=1)
+        self.assertRaises(AttributeError, model.reset_from(model2))
+
 #endclass TestWord2VecModel
 
 class TestWMD(unittest.TestCase):

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -683,7 +683,10 @@ class TestWord2VecModel(unittest.TestCase):
         """Test if exception is raised when reset_from is used"""
         model = word2vec.Word2Vec(sentences, min_count=1)
         model2 = word2vec.Word2Vec(new_sentences, min_count=1)
-        self.assertRaises(AttributeError, model.reset_from(model2))
+        try:
+            model.reset_from(model2)
+        except AttributeError:
+            self.fail('AttributeError in reset_from()')
 
 #endclass TestWord2VecModel
 

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -680,13 +680,13 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertRaises(AttributeError, load_on_instance)
 
     def test_reset_from(self):
-        """Test if exception is raised when reset_from is used"""
+        """Test if reset_from() uses pre-built structures from other model"""
         model = word2vec.Word2Vec(sentences, min_count=1)
-        model2 = word2vec.Word2Vec(new_sentences, min_count=1)
-        try:
-            model.reset_from(model2)
-        except AttributeError:
-            self.fail('AttributeError in reset_from()')
+        other_model = word2vec.Word2Vec(new_sentences, min_count=1) 
+	other_vocab = other_model.wv.vocab        
+        model.reset_from(other_model)
+        self.assertEqual(model.wv.vocab, other_vocab)
+        
 
 #endclass TestWord2VecModel
 

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -683,7 +683,7 @@ class TestWord2VecModel(unittest.TestCase):
         """Test if reset_from() uses pre-built structures from other model"""
         model = word2vec.Word2Vec(sentences, min_count=1)
         other_model = word2vec.Word2Vec(new_sentences, min_count=1) 
-	other_vocab = other_model.wv.vocab        
+        other_vocab = other_model.wv.vocab
         model.reset_from(other_model)
         self.assertEqual(model.wv.vocab, other_vocab)
         


### PR DESCRIPTION
Fixed reset_from attribute bug in gensim 1.0.1 version. 