### PR TITLE
Duplicate imports and typos in word2vec.py

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -774,7 +774,6 @@ class Word2Vec(utils.SaveLoad):
         if (self.model_trimmed_post_training):
             raise RuntimeError("Parameters for training were discarded using model_trimmed_post_training method")
         if FAST_VERSION < 0:
-            import warnings
             warnings.warn("C extension not loaded for Word2Vec, training will be slow. "
                           "Install a C compiler and reinstall gensim for fast training.")
             self.neg_labels = []
@@ -977,7 +976,6 @@ class Word2Vec(utils.SaveLoad):
 
         """
         if FAST_VERSION < 0:
-            import warnings
             warnings.warn("C extension compilation failed, scoring will be slow. "
                           "Install a C compiler and reinstall gensim for fastness.")
 

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -422,7 +422,7 @@ class Word2Vec(utils.SaveLoad):
         in the vocabulary, be trimmed away, or handled using the default (discard if word count < min_count).
         Can be None (min_count will be used), or a callable that accepts parameters (word, count, min_count) and
         returns either `utils.RULE_DISCARD`, `utils.RULE_KEEP` or `utils.RULE_DEFAULT`.
-        Note: The rule, if given, is only used prune vocabulary during build_vocab() and is not stored as part
+        Note: The rule, if given, is only used to prune vocabulary during build_vocab() and is not stored as part
         of the model.
 
         `sorted_vocab` = if 1 (default), sort the vocabulary by descending frequency before
@@ -477,7 +477,7 @@ class Word2Vec(utils.SaveLoad):
 
         else :
             if trim_rule is not None :
-                logger.warning("The rule, if given, is only used prune vocabulary during build_vocab() and is not stored as part of the model. ")
+                logger.warning("The rule, if given, is only used to prune vocabulary during build_vocab() and is not stored as part of the model. ")
                 logger.warning("Model initialized without sentences. trim_rule provided, if any, will be ignored." )
 
 

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -109,7 +109,6 @@ import itertools
 import warnings
 
 from gensim.utils import keep_vocab_item, call_on_class_only
-from gensim.utils import keep_vocab_item
 from gensim.models.keyedvectors import KeyedVectors, Vocab
 
 try:


### PR DESCRIPTION
This PR fixes a few duplicate imports and typographical errors in the file gensim/models/word2vec.py .