### PR TITLE
most_similar_among functionality added with tests

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -343,39 +343,46 @@ class KeyedVectors(utils.SaveLoad):
         result = [(self.index2word[sim], float(dists[sim])) for sim in best if sim not in all_words]
         return result[:topn]
 
-    def most_similar_among(self, positive=[], negative=[], topn=10, words_list=None, indexer=None,
+    def most_similar_among(self, positive=[], negative=[],
+                            topn=10, words_list=None, indexer=None,
                             suppress_warnings=False):
         """
-        Find the top-N most similar words among words_list to given words. Positive words
-        contribute positively towards the similarity, negative words negatively.
+        Find the top-N most similar words among words_list to given words.
+
+        Positive words contribute positively towards the similarity,
+        negative words negatively.
 
         Please refer to docs of most_similar function.
 
-        If topn is False, most_similar returns the vector of similarity scores for all words
-        in vocabulary of model, restriced by the supplied words_list.
+        If topn is False, most_similar returns the vector of similarity scores
+        for all words in vocabulary of model, restriced by the supplied words_list.
 
-        'words_list' should be a list/set of words. The returned word similarities will only
-        contain similarity scores for those words that are in words_list (and in trained vocabulary).
+        'words_list' should be a list/set of words. The returned word similarities
+        will only contain similarity scores for those words that are in words_list
+        (and in trained vocabulary).
 
-        If some words in words_list are not in vocabulary then a warning is issued to the user.
+        If some words in words_list are not in vocabulary then a warning is
+        issued to the user.
 
         Warnings can be supressed by setting the suppress_warnings flag.
 
         Example::
 
-          >>> trained_model.most_similar_among(positive=['man'], topn=1, words_list=['woman','random_word'])
+          >>> trained_model.most_similar_among(positive=['man'], topn=1,
+                                                words_list=['woman','random_word'])
           [('woman', 0.75882536)]
 
         """
 
         if isinstance(words_list, int):
-            raise ValueError("words_list must be a set/list of words. Maybe you wanted the \
-                                most_similar function.")
+            raise ValueError("words_list must be a set/list of words. \
+                                Maybe you wanted the most_similar function.")
         elif isinstance(words_list, list) or isinstance(words_list, set):
             pass
         else:  # This is triggered for empty words_list parameter
-            raise ValueError("words_list must be set/list of words. Maybe you wanted the \
-                                most_similar function. Please read doc string")
+            raise ValueError("words_list must be set/list of words. \
+                                Maybe you wanted the most_similar function. \
+                                Please read doc string")
 
         if type(topn) is not int:
             if topn is False:
@@ -383,16 +390,19 @@ class KeyedVectors(utils.SaveLoad):
             else:
                 if suppress_warnings is False:
                     logger.warning("topn needs to either be a number or False. \
-                                    Please read docstring. Displaying all similarities!")
+                                    Please read docstring. \
+                                    Displaying all similarities!")
             topn = len(self.index2word)
 
         self.init_sims()
 
         if isinstance(positive, string_types) and negative is False:
-            # allow calls like most_similar('dog'), as a shorthand for most_similar(['dog'])
+            # allow calls like most_similar('dog'),
+            # as a shorthand for most_similar(['dog'])
             positive = [positive]
 
-        # add weights for each word, if not already present; default to 1.0 for positive and -1.0 for negative words
+        # add weights for each word, if not already present;
+        # default to 1.0 for positive and -1.0 for negative words
         positive = [
             (word, 1.0) if isinstance(word, string_types + (ndarray,)) else word
             for word in positive
@@ -424,20 +434,24 @@ class KeyedVectors(utils.SaveLoad):
         words_to_use = vocabulary_words.intersection(words_list)
 
         if not words_to_use:
-            raise ValueError("None of the words in words_list exist in current vocabulary")
+            raise ValueError("None of the words in words_list \
+                                exist in current vocabulary")
 
         if suppress_warnings is False:
             missing_words = words_list.difference(vocabulary_words)
             if not missing_words:  # missing_words is empty
                 pass
             else:
-                logger.warning("The following words are not in trained vocabulary : %s", str(missing_words))
-                logger.info("This warning is expensive to calculate, especially for largs words_list. \
-                                If you would rather not remove the missing_words from words_list \
-                                please set the suppress_warnings flag.")
+                logger.warning("The following words are not in \
+                                trained vocabulary : %s", str(missing_words))
+                logger.info("This warning is expensive to calculate, \
+                                especially for largs words_list. \
+                                If you would rather not remove the missing_words \
+                                from words_list please set the \
+                                suppress_warnings flag.")
 
         words_list_indices = [self.vocab[word].index for word in words_to_use]
-        # limited = self.syn0norm[words_list_indices] #syn0norm is an ndarray so this indexing works
+        # limited = self.syn0norm[words_list_indices]
         # Storing 'limited' might add a huge memory overhead so we avoid doing that
 
         dists = dot(self.syn0norm[words_list_indices], mean)

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1180,6 +1180,13 @@ class Word2Vec(utils.SaveLoad):
                         self.wv.syn0[self.wv.vocab[word].index] = weights
         logger.info("merged %d vectors into %s matrix from %s" % (overlap_count, self.wv.syn0.shape, fname))
 
+    def get_words_from_vocab(self):
+        """
+        Returns the words in the currently trained vocabulary as a list.
+        If the model is not trained yet then an empty list is returned.
+        """
+        return self.wv.get_ordered_keys()
+
     def most_similar(self, positive=[], negative=[], topn=10, restrict_vocab=None, indexer=None):
         return self.wv.most_similar(positive, negative, topn, restrict_vocab, indexer)
 

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -16,6 +16,7 @@ import tempfile
 import itertools
 import bz2
 import sys
+import warnings
 
 import numpy as np
 
@@ -370,6 +371,7 @@ class TestWord2VecModel(unittest.TestCase):
         # test querying for "most similar" by vector
         graph_vector = model.wv.syn0norm[model.wv.vocab['graph'].index]
         sims2 = model.most_similar(positive=[graph_vector], topn=11)
+        # topn is 11 because the first answer will be 'graph' itself
         sims2 = [(w, sim) for w, sim in sims2 if w != 'graph']  # ignore 'graph' itself
         self.assertEqual(sims, sims2)
 
@@ -460,6 +462,57 @@ class TestWord2VecModel(unittest.TestCase):
         model = word2vec.Word2Vec(sg=0, cbow_mean=1, alpha=0.05, window=5, hs=0, negative=15,
                                   min_count=5, iter=10, workers=2, sample=0)
         self.model_sanity(model)
+
+    @log_capture
+    def test_most_similar_among(self, l):
+        """
+        Testing most_similar_among method of KeyedVectors Class.
+        CBOW model is used here.
+        """
+
+        model = word2vec.Word2Vec(sentences, size=2, sg=0, min_count=1, hs=1, negative=0)
+
+        # Testing Error in case of absent words_list
+        self.assertRaises(ValueError, model.wv.most_similar_among, positive=['graph'])
+
+        words_in_voc = model.wv.index2word[:5]
+
+        # Testing logs for warnings
+        model.wv.most_similar_among('graph', \
+                                        words_list=words_in_voc+['random_word'], \
+                                        topn="some_gibberish_not_number_or_False")
+        self.assertIn("topn needs to either be a number or False", str(l))
+        self.assertIn("The following words are not in trained vocabulary", str(l))
+        self.assertIn("This warning is expensive to calculate", str(l))
+
+        l.clear()
+
+        # Check if warnings are suppressed upon setting suppress_warnings flag
+        model.wv.most_similar_among('graph', \
+                                        words_list=words_in_voc+['random_word'], \
+                                        topn="some_gibberish_not_number_or_False", \
+                                        suppress_warnings=True)
+        self.assertIn("No logging captured", str(l))
+
+        # Check functionality
+        sims = model.wv.most_similar_among('graph', words_list=words_in_voc)
+        sims2 = model.wv.most_similar_among('graph', words_list=words_in_voc+['random_word'], \
+                                                suppress_warnings=True)
+        self.assertEqual(sims, sims2)
+
+        # Results by vector
+        graph_vector = model.wv.syn0norm[model.wv.vocab['graph'].index]
+        sims3 = model.wv.most_similar_among(positive = [graph_vector], words_list=words_in_voc)
+        sims3 = [(w, sim) for w, sim in sims3 if w != 'graph']  # ignore 'graph' itself
+        self.assertEqual(sims, sims3)
+
+        sims4 = model.wv.most_similar_among('graph', words_list=model.wv.index2word, \
+                                                topn=False)  # Returns all possible similarities
+        sims5 = model.wv.most_similar_among('graph', words_list=model.wv.index2word, \
+                                                topn=len(model.wv.vocab))
+        self.assertEqual(sims4, sims5)
+        self.assertEqual(len(sims4), len(model.wv.vocab)-1)
+        # Subtracting one as the word itself is not returned in most_similar calculation
 
     def test_cosmul(self):
         model = word2vec.Word2Vec(sentences, size=2, min_count=1, hs=1, negative=0)

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -16,7 +16,6 @@ import tempfile
 import itertools
 import bz2
 import sys
-import warnings
 
 import numpy as np
 
@@ -470,17 +469,20 @@ class TestWord2VecModel(unittest.TestCase):
         CBOW model is used here.
         """
 
-        model = word2vec.Word2Vec(sentences, size=2, sg=0, min_count=1, hs=1, negative=0)
+        model = word2vec.Word2Vec(sentences, size=2, sg=0, min_count=1,
+                                    hs=1, negative=0)
 
         # Testing Error in case of absent words_list
-        self.assertRaises(ValueError, model.wv.most_similar_among, positive=['graph'])
+        self.assertRaises(ValueError, model.wv.most_similar_among,
+                            positive=['graph'])
 
         words_in_voc = model.wv.index2word[:5]
 
         # Testing logs for warnings
-        model.wv.most_similar_among('graph', \
-                                        words_list=words_in_voc+['random_word'], \
-                                        topn="some_gibberish_not_number_or_False")
+        model.wv.most_similar_among('graph',
+                                    words_list=words_in_voc+['random_word'],
+                                    topn="some_gibberish_not_number_or_False")
+
         self.assertIn("topn needs to either be a number or False", str(l))
         self.assertIn("The following words are not in trained vocabulary", str(l))
         self.assertIn("This warning is expensive to calculate", str(l))
@@ -488,31 +490,36 @@ class TestWord2VecModel(unittest.TestCase):
         l.clear()
 
         # Check if warnings are suppressed upon setting suppress_warnings flag
-        model.wv.most_similar_among('graph', \
-                                        words_list=words_in_voc+['random_word'], \
-                                        topn="some_gibberish_not_number_or_False", \
-                                        suppress_warnings=True)
+        model.wv.most_similar_among('graph',
+                                    words_list=words_in_voc+['random_word'],
+                                    topn="some_gibberish_not_number_or_False",
+                                    suppress_warnings=True)
         self.assertIn("No logging captured", str(l))
 
         # Check functionality
         sims = model.wv.most_similar_among('graph', words_list=words_in_voc)
-        sims2 = model.wv.most_similar_among('graph', words_list=words_in_voc+['random_word'], \
-                                                suppress_warnings=True)
+        sims2 = model.wv.most_similar_among('graph',
+                                            words_list=words_in_voc+['random_word'],
+                                            suppress_warnings=True)
         self.assertEqual(sims, sims2)
 
         # Results by vector
         graph_vector = model.wv.syn0norm[model.wv.vocab['graph'].index]
-        sims3 = model.wv.most_similar_among(positive = [graph_vector], words_list=words_in_voc)
+        sims3 = model.wv.most_similar_among(positive = [graph_vector],
+                                            words_list=words_in_voc)
         sims3 = [(w, sim) for w, sim in sims3 if w != 'graph']  # ignore 'graph' itself
         self.assertEqual(sims, sims3)
 
-        sims4 = model.wv.most_similar_among('graph', words_list=model.wv.index2word, \
-                                                topn=False)  # Returns all possible similarities
-        sims5 = model.wv.most_similar_among('graph', words_list=model.wv.index2word, \
-                                                topn=len(model.wv.vocab))
+        sims4 = model.wv.most_similar_among('graph',
+                                            words_list=model.wv.index2word,
+                                            topn=False)  # Returns all possible similarities
+        sims5 = model.wv.most_similar_among('graph',
+                                            words_list=model.wv.index2word,
+                                            topn=len(model.wv.vocab))
         self.assertEqual(sims4, sims5)
         self.assertEqual(len(sims4), len(model.wv.vocab)-1)
-        # Subtracting one as the word itself is not returned in most_similar calculation
+        # Subtracting one as the word itself is not returned
+        # in most_similar calculation
 
     def test_cosmul(self):
         model = word2vec.Word2Vec(sentences, size=2, min_count=1, hs=1, negative=0)


### PR DESCRIPTION
Fix #148. After @gojomo's comprehensive review from #1229

I have split PR's for all drive-by bug fixes as suggested. Some follow ups from previous comments :

>Since people might not find index2word, I can see the benefit of an accessor method. However, given that this is now a generic KeyedVectors class, the name shouldn't be 'words'-centric. I'd suggest ordered_keys.

Done. I have also added a method to class `Word2Vec` in order to solve the original "people might not find index2word" problem.

>I think suppress_warnings adds extra complication for little benefit.

Actually, calculating difference in sets (which is needed to generate this warning) can be an unnecessary overhead for people using this code in production environment. I have added a `logging.info` call to inform users of the same.
Sometimes it is not possible to remove all non-vocabulary words from the `words-list`, for example, if `words-list` is generated during runtime. Here using `suppress_warnings` would be ideal. 

>Seems more like something to log than use warnings.

Done. Yes, you're right. The module uses logging throughout, unnecessary import and use of warnings was not a good choice.

>Because most_similar_among() functionality is merely on a set of vectors, it's not dependent on the mode-of-training – so there's no need for multiple models built different ways.

Ok sure, removing extra tests.


>In fact, it'd ultimately make even more sense to be inside a set of KeyedVectors tests, rather than Word2Vec tests, but since its sibling methods are tested here it's not necessary to make that big change yet.

Quoted here to keep track.