### PR TITLE
Add common terms phrases model

### DIFF
--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -81,7 +81,7 @@ import warnings
 from collections import defaultdict
 import itertools as it
 
-from six import iteritems, string_types, next
+from six import iteritems, iterbytes, string_types, next
 
 from gensim import utils, interfaces
 
@@ -566,7 +566,7 @@ class CommonTermsPhrases(CommonTermsUtils, Phrases):
                 new_s.append(word_a)
                 # common terms in front of b
                 last_stop_index = 0
-                for i, w in enumerate(word_b):
+                for i, w in enumerate(iterbytes(word_b)):
                     if w == odelimiter:
                         new_s.append(word_b[last_stop_index:i])
                         last_stop_index = i + 1
@@ -633,7 +633,7 @@ class CommonTermsPhraser(CommonTermsUtils, Phraser):
                 new_s.append(word_a)
                 # common terms in front of b
                 last_stop_index = 0
-                for i, w in enumerate(word_b):
+                for i, w in enumerate(iterbytes(word_b)):
                     if w == odelimiter:
                         new_s.append(word_b[last_stop_index:i])
                         last_stop_index = i + 1

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -52,6 +52,22 @@ two tokens (e.g. `new_york_times`):
 >>> print(trigram[bigram[sent]])
 [u'the', u'new_york_times', u'is', u'a', u'newspaper']
 
+The CommonTermsPhrases add a way to give special treatment to common terms (aka stop words)
+such that their presence between two words
+won't prevent bigram detection.
+It allows to detect expressions like "bank of america" or "eye of the beholder".
+
+>>> common_terms = ["of", "with", "without", "and", "or", "the", "a"]
+>>> ct_phrases = CommonTermsPhrases(sentence_stream, common_terms=common_terms)
+
+It has its own Phraser:
+
+>>> ct_bigram = CommonTermsPhraser(ct_phrases)
+>>> sent = [u'the', u'mayor', u'shows', u'his', u'lack', u'of', u'interest']
+>>> print(bigram[sent])
+[u'the', u'mayor', u'shows', u'his', u'lack_of_interest']
+
+
 .. [1] Tomas Mikolov, Ilya Sutskever, Kai Chen, Greg Corrado, and Jeffrey Dean.
        Distributed Representations of Words and Phrases and their Compositionality.
        In Proceedings of NIPS, 2013.
@@ -339,7 +355,7 @@ class Phraser(interfaces.TransformationABC):
         self.min_count = phrases_model.min_count
         self.delimiter = phrases_model.delimiter
         self.phrasegrams = {}
-        corpus = pseudocorpus(phrases_model.vocab, phrases_model.delimiter)
+        corpus = self.pseudocorpus(phrases_model)
         logger.info('source_vocab length %i', len(phrases_model.vocab))
         count = 0
         for bigram, score in phrases_model.export_phrases(corpus, self.delimiter, as_tuples=True):
@@ -350,6 +366,9 @@ class Phraser(interfaces.TransformationABC):
             if not count % 50000:
                 logger.info('Phraser added %i phrasegrams', count)
         logger.info('Phraser built with %i %i phrasegrams', count, len(self.phrasegrams))
+
+    def pseudocorpus(self, phrases_model):
+        return pseudocorpus(phrases_model.vocab, phrases_model.delimiter)
 
     def __getitem__(self, sentence):
         """
@@ -382,6 +401,243 @@ class Phraser(interfaces.TransformationABC):
 
             if not last_bigram:
                 new_s.append(word_a)
+            last_bigram = False
+
+        if s:  # add last word skipped by previous loop
+            last_token = s[-1]
+            if not last_bigram:
+                new_s.append(last_token)
+
+        return [utils.to_unicode(w) for w in new_s]
+
+
+class CommonTermsUtils:
+
+    def lrsentence(self, sentence, delimiter, common_terms):
+        # first part does not us stop words
+        lsentence = [w for w in sentence if w not in common_terms]
+        # second sentence join stop words and following word
+        rsentence = []
+        common_terms = []
+        for w in sentence:
+            if w in self.common_terms:
+                common_terms.append(w)
+            else:
+                w = delimiter.join(common_terms +  [w])
+                rsentence.append(w)
+                common_terms = []
+        return lsentence, rsentence
+
+
+
+class CommonTermsPhrases(CommonTermsUtils, Phrases):
+    """
+    This class is a variation of :py:class:`Phrases` capable of handling common grams
+    that appears between words, like *with* in *car with driver*.
+
+    It take inspirations from elastic search `common grams filter`_.
+
+    .. _`common grams filter`:: `common grams filter`
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        see py:class:`Phrase`.
+
+        It has the following required parameters:
+
+        :param common_terms: a list of common terms
+        """
+        if "common_terms" not in kwargs:
+            raise ValueError("common_terms parameter is mandatory")
+        self.common_terms = frozenset(utils.any2utf8(w) for w in kwargs.pop("common_terms"))
+        super(CommonTermsPhrases, self).__init__(*args, **kwargs)
+
+    # no more static, we wan't to access stop words
+    def learn_vocab(self, sentences, max_vocab_size, delimiter=b'_', progress_per=10000):
+        """Collect unigram/bigram counts from the `sentences` iterable."""
+        common_terms = self.common_terms
+        sentence_no = -1
+        total_words = 0
+        #logger.info("collecting all words and their counts")
+        vocab = defaultdict(int)
+        min_reduce = 1
+        for sentence_no, sentence in enumerate(sentences):
+            if sentence_no % progress_per == 0:
+                logger.info("PROGRESS: at sentence #%i, processed %i words and %i word types" %
+                            (sentence_no, total_words, len(vocab)))
+            sentence = [utils.any2utf8(w) for w in sentence]
+            lsentence, rsentence = self.lrsentence(sentence, delimiter, common_terms)
+            for bigram in zip(lsentence, rsentence[1:]):
+                vocab[bigram[0]] += 1
+                vocab[delimiter.join(bigram)] += 1
+                total_words += 1
+
+            if lsentence:  # add last word skipped by previous loop
+                word = lsentence[-1]
+                vocab[word] += 1
+
+            if len(vocab) > max_vocab_size:
+                utils.prune_vocab(vocab, min_reduce)
+                min_reduce += 1
+
+        logger.info("collected %i word types from a corpus of %i words (unigram + bigrams) and %i sentences" %
+                    (len(vocab), total_words, sentence_no + 1))
+        return min_reduce, vocab
+
+    def export_phrases(self, sentences, out_delimiter=b' ', as_tuples=False):
+        """
+        Generate an iterator that contains all phrases in given 'sentences'
+
+        see :py:meth:`Phrases.export_phrases`
+        """
+        vocab = self.vocab
+        threshold = self.threshold
+        delimiter = self.delimiter  # delimiter used for lookup
+        min_count = self.min_count
+        common_terms = self.common_terms
+        for sentence in sentences:
+            s = [utils.any2utf8(w) for w in sentence]
+            last_bigram = False
+            lsentence, rsentence = self.lrsentence(s, delimiter, common_terms)
+            for word_a, word_b, orig_b in zip(lsentence, rsentence[1:], lsentence[1:]):
+                if word_a in vocab and orig_b in vocab:
+                    bigram_word = delimiter.join((word_a, word_b))
+                    if bigram_word in vocab and not last_bigram:
+                        pa = float(vocab[word_a])
+                        pb = float(vocab[orig_b])
+                        pab = float(vocab[bigram_word])
+                        score = (pab - min_count) / pa / pb * len(vocab)
+                        if score > threshold:
+                            if as_tuples:
+                                yield ((word_a, word_b), score)
+                            else:
+                                yield (out_delimiter.join([word_a] + list(word_b.split(delimiter))), score)
+                            last_bigram = True
+                            continue
+                        last_bigram = False
+
+    def __getitem__(self, sentence):
+        """
+        Convert the input tokens `sentence` (=list of unicode strings) into phrase
+        tokens (=list of unicode strings, where detected phrases are joined by u'_').
+
+        see :py:meth:`Phrases.__getitem__`
+        """
+        #FIXME
+        # warnings.warn("For a faster implementation, use the gensim.models.phrases.Phraser class")
+
+        common_terms = self.common_terms
+        is_single, sentence = _is_single(sentence)
+        if not is_single:
+            # if the input is an entire corpus (rather than a single sentence),
+            # return an iterable stream.
+            return self._apply(sentence)
+
+        s, new_s = [utils.any2utf8(w) for w in sentence], []
+        last_bigram = False
+        vocab = self.vocab
+        threshold = self.threshold
+        delimiter = self.delimiter
+        odelimiter = ord(delimiter)
+        min_count = self.min_count
+        lsentence, rsentence = self.lrsentence(s, delimiter, common_terms)
+        for w in s:  # initial common term
+            if w not in common_terms:
+                break
+            new_s.append(w)
+        for word_a, word_b, orig_b in zip(lsentence, rsentence[1:], lsentence[1:]):
+            if word_a in vocab and orig_b in vocab:
+                bigram_word = delimiter.join((word_a, word_b))
+                if bigram_word in vocab and not last_bigram:
+                    pa = float(vocab[word_a])
+                    pb = float(vocab[orig_b])
+                    pab = float(vocab[bigram_word])
+                    score = (pab - min_count) / pa / pb * len(vocab)
+                    # logger.debug("score for %s: (pab=%s - min_count=%s) / pa=%s / pb=%s * vocab_size=%s = %s",
+                    #     bigram_word, pab, self.min_count, pa, pb, len(self.vocab), score)
+                    if score > threshold:
+                        new_s.append(bigram_word)
+                        last_bigram = True
+                        continue
+
+            if not last_bigram:
+                new_s.append(word_a)
+                # common terms in front of b
+                last_stop_index = 0
+                for i, w in enumerate(word_b):
+                    if w == odelimiter:
+                        new_s.append(word_b[last_stop_index:i])
+                        last_stop_index = i + 1
+
+            last_bigram = False
+
+        if s:  # add last word skipped by previous loop
+            last_token = s[-1]
+            if not last_bigram:
+                new_s.append(last_token)
+
+        return [utils.to_unicode(w) for w in new_s]
+
+
+class CommonTermsPhraser(CommonTermsUtils, Phraser):
+    """
+    Minimal state & functionality to apply results of a CommonTermsPhrases model to tokens.
+    """
+
+    def __init__(self, phrases_model):
+        """see :py:meth:`Phraser.__init__`
+        """
+        self.common_terms = phrases_model.common_terms
+        super(CommonTermsPhraser, self).__init__(phrases_model)
+
+    def pseudocorpus(self, phrases_model):
+        """Feeds source_vocab's compound keys back to it, to discover phrases"""
+        sep = phrases_model.delimiter
+        for k in phrases_model.vocab:
+            if sep not in k:
+                continue
+            yield k.split(sep)
+
+    def __getitem__(self, sentence):
+        """
+        """
+        is_single, sentence = _is_single(sentence)
+        if not is_single:
+            # if the input is an entire corpus (rather than a single sentence),
+            # return an iterable stream.
+            return self._apply(sentence)
+
+        s, new_s = [utils.any2utf8(w) for w in sentence], []
+        last_bigram = False
+        phrasegrams = self.phrasegrams
+        threshold = self.threshold
+        delimiter = self.delimiter
+        odelimiter = ord(delimiter)
+        common_terms = self.common_terms
+        lsentence, rsentence = self.lrsentence(s, delimiter, common_terms)
+        for w in s:  # initial common term
+            if w not in common_terms:
+                break
+            new_s.append(w)
+        for word_a, word_b, orig_b in zip(lsentence, rsentence[1:], lsentence[1:]):
+            bigram_tuple = (word_a, word_b)
+            if not last_bigram and phrasegrams.get(bigram_tuple, (-1, -1))[1] > self.threshold:
+                bigram_word = delimiter.join((word_a, word_b))
+                new_s.append(bigram_word)
+                last_bigram = True
+                continue
+
+            if not last_bigram:
+                new_s.append(word_a)
+                # common terms in front of b
+                last_stop_index = 0
+                for i, w in enumerate(word_b):
+                    if w == odelimiter:
+                        new_s.append(word_b[last_stop_index:i])
+                        last_stop_index = i + 1
+
             last_bigram = False
 
         if s:  # add last word skipped by previous loop

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -14,7 +14,7 @@ import os
 import sys
 
 from gensim import utils
-from gensim.models.phrases import Phrases, Phraser
+from gensim.models.phrases import Phrases, Phraser, CommonTermsPhrases, CommonTermsPhraser
 
 if sys.version_info[0] >= 3:
     unicode = str
@@ -23,32 +23,35 @@ module_path = os.path.dirname(__file__)  # needed because sample data files are 
 datapath = lambda fname: os.path.join(module_path, 'test_data', fname)
 
 
-sentences = [
-    ['human', 'interface', 'computer'],
-    ['survey', 'user', 'computer', 'system', 'response', 'time'],
-    ['eps', 'user', 'interface', 'system'],
-    ['system', 'human', 'system', 'eps'],
-    ['user', 'response', 'time'],
-    ['trees'],
-    ['graph', 'trees'],
-    ['graph', 'minors', 'trees'],
-    ['graph', 'minors', 'survey'],
-    ['graph', 'minors', 'survey','human','interface'] #test bigrams within same sentence
-]
-unicode_sentences = [[utils.to_unicode(w) for w in sentence] for sentence in sentences]
+class PhrasesData:
+
+    sentences = [
+        ['human', 'interface', 'computer'],
+        ['survey', 'user', 'computer', 'system', 'response', 'time'],
+        ['eps', 'user', 'interface', 'system'],
+        ['system', 'human', 'system', 'eps'],
+        ['user', 'response', 'time'],
+        ['trees'],
+        ['graph', 'trees'],
+        ['graph', 'minors', 'trees'],
+        ['graph', 'minors', 'survey'],
+        ['graph', 'minors', 'survey','human','interface'] #test bigrams within same sentence
+    ]
+    unicode_sentences = [[utils.to_unicode(w) for w in sentence] for sentence in sentences]
 
 
-def gen_sentences():
-    return ((w for w in sentence) for sentence in sentences)
 
-
-class TestPhrasesCommon(unittest.TestCase):
+class TestPhrasesCommon(PhrasesData, unittest.TestCase):
     """ Tests that need to be run for both Prases and Phraser classes."""
+
+    def gen_sentences(self):
+        return ((w for w in sentence) for sentence in self.sentences)
+
     def setUp(self):
-        self.bigram = Phrases(sentences, min_count=1, threshold=1)
-        self.bigram_default = Phrases(sentences)
-        self.bigram_utf8 = Phrases(sentences, min_count=1, threshold=1)
-        self.bigram_unicode = Phrases(unicode_sentences, min_count=1, threshold=1)
+        self.bigram = Phrases(self.sentences, min_count=1, threshold=1)
+        self.bigram_default = Phrases(self.sentences)
+        self.bigram_utf8 = Phrases(self.sentences, min_count=1, threshold=1)
+        self.bigram_unicode = Phrases(self.unicode_sentences, min_count=1, threshold=1)
 
     def testEmptyInputsOnBigramConstruction(self):
         """Test that empty inputs don't throw errors and return the expected result."""
@@ -66,12 +69,12 @@ class TestPhrasesCommon(unittest.TestCase):
     def testSentenceGeneration(self):
         """Test basic bigram using a dummy corpus."""
         # test that we generate the same amount of sentences as the input
-        self.assertEqual(len(sentences), len(list(self.bigram_default[sentences])))
+        self.assertEqual(len(self.sentences), len(list(self.bigram_default[self.sentences])))
 
     def testSentenceGenerationWithGenerator(self):
         """Test basic bigram production when corpus is a generator."""
-        self.assertEqual(len(list(gen_sentences())),
-                         len(list(self.bigram_default[gen_sentences()])))
+        self.assertEqual(len(list(self.gen_sentences())),
+                         len(list(self.bigram_default[self.gen_sentences()])))
 
     def testBigramConstruction(self):
         """Test Phrases bigram construction building."""
@@ -79,7 +82,7 @@ class TestPhrasesCommon(unittest.TestCase):
         bigram1_seen = False
         bigram2_seen = False
 
-        for s in self.bigram[sentences]:
+        for s in self.bigram[self.sentences]:
             if not bigram1_seen and u'response_time' in s:
                 bigram1_seen = True
             if not bigram2_seen and u'graph_minors' in s:
@@ -91,18 +94,18 @@ class TestPhrasesCommon(unittest.TestCase):
 
         # check the same thing, this time using single doc transformation
         # last sentence should contain both graph_minors and human_interface
-        self.assertTrue(u'response_time' in self.bigram[sentences[1]])
-        self.assertTrue(u'response_time' in self.bigram[sentences[4]])
-        self.assertTrue(u'graph_minors' in self.bigram[sentences[-2]])
-        self.assertTrue(u'graph_minors' in self.bigram[sentences[-1]])
-        self.assertTrue(u'human_interface' in self.bigram[sentences[-1]])
+        self.assertTrue(u'response_time' in self.bigram[self.sentences[1]])
+        self.assertTrue(u'response_time' in self.bigram[self.sentences[4]])
+        self.assertTrue(u'graph_minors' in self.bigram[self.sentences[-2]])
+        self.assertTrue(u'graph_minors' in self.bigram[self.sentences[-1]])
+        self.assertTrue(u'human_interface' in self.bigram[self.sentences[-1]])
 
     def testBigramConstructionFromGenerator(self):
         """Test Phrases bigram construction building when corpus is a generator"""
         bigram1_seen = False
         bigram2_seen = False
 
-        for s in self.bigram[gen_sentences()]:
+        for s in self.bigram[self.gen_sentences()]:
             if not bigram1_seen and 'response_time' in s:
                 bigram1_seen = True
             if not bigram2_seen and 'graph_minors' in s:
@@ -115,23 +118,23 @@ class TestPhrasesCommon(unittest.TestCase):
         """Test that both utf8 and unicode input work; output must be unicode."""
         expected = [u'survey', u'user', u'computer', u'system', u'response_time']
 
-        self.assertEqual(self.bigram_utf8[sentences[1]], expected)
-        self.assertEqual(self.bigram_unicode[sentences[1]], expected)
+        self.assertEqual(self.bigram_utf8[self.sentences[1]], expected)
+        self.assertEqual(self.bigram_unicode[self.sentences[1]], expected)
 
-        transformed = ' '.join(self.bigram_utf8[sentences[1]])
+        transformed = ' '.join(self.bigram_utf8[self.sentences[1]])
         self.assertTrue(isinstance(transformed, unicode))
 
 
-class TestPhrasesModel(unittest.TestCase):
+class TestPhrasesModel(PhrasesData, unittest.TestCase):
     def testExportPhrases(self):
         """Test Phrases bigram export_phrases functionality."""
-        bigram = Phrases(sentences, min_count=1, threshold=1)
+        bigram = Phrases(self.sentences, min_count=1, threshold=1)
 
         # with this setting we should get response_time and graph_minors
         bigram1_seen = False
         bigram2_seen = False
 
-        for phrase, score in bigram.export_phrases(sentences):
+        for phrase, score in bigram.export_phrases(self.sentences):
             if not bigram1_seen and b'response time' == phrase:
                 bigram1_seen = True
             elif not bigram2_seen and b'graph minors' == phrase:
@@ -145,14 +148,14 @@ class TestPhrasesModel(unittest.TestCase):
     def testBadParameters(self):
         """Test the phrases module with bad parameters."""
         # should fail with something less or equal than 0
-        self.assertRaises(ValueError, Phrases, sentences, min_count=0)
+        self.assertRaises(ValueError, Phrases, self.sentences, min_count=0)
 
         # threshold should be positive
-        self.assertRaises(ValueError, Phrases, sentences, threshold=-1)
+        self.assertRaises(ValueError, Phrases, self.sentences, threshold=-1)
 
     def testPruning(self):
         """Test that max_vocab_size parameter is respected."""
-        bigram = Phrases(sentences, max_vocab_size=5)
+        bigram = Phrases(self.sentences, max_vocab_size=5)
         self.assertTrue(len(bigram.vocab) <= 5)
 #endclass TestPhrasesModel
 
@@ -161,17 +164,161 @@ class TestPhraserModel(TestPhrasesCommon):
     """ Test Phraser models."""
     def setUp(self):
         """Set up Phraser models for the tests."""
-        bigram_phrases = Phrases(sentences, min_count=1, threshold=1)
+        bigram_phrases = Phrases(self.sentences, min_count=1, threshold=1)
         self.bigram = Phraser(bigram_phrases)
 
-        bigram_default_phrases = Phrases(sentences)
+        bigram_default_phrases = Phrases(self.sentences)
         self.bigram_default = Phraser(bigram_default_phrases)
 
-        bigram_utf8_phrases = Phrases(sentences, min_count=1, threshold=1)
+        bigram_utf8_phrases = Phrases(self.sentences, min_count=1, threshold=1)
         self.bigram_utf8 = Phraser(bigram_utf8_phrases)
 
-        bigram_unicode_phrases = Phrases(unicode_sentences, min_count=1, threshold=1)
+        bigram_unicode_phrases = Phrases(self.unicode_sentences, min_count=1, threshold=1)
         self.bigram_unicode = Phraser(bigram_unicode_phrases)
+
+
+class CommonTermsPhrasesData:
+
+    sentences = [
+        ['human', 'interface', 'with', 'computer'],
+        ['survey', 'of', 'user', 'computer', 'system', 'lack', 'of', 'interest'],
+        ['eps', 'user', 'interface', 'system'],
+        ['system', 'and', 'human', 'system', 'eps'],
+        ['user', 'lack', 'of', 'interest'],
+        ['trees'],
+        ['graph', 'of', 'trees'],
+        ['data', 'and', 'graph', 'of', 'trees'],
+        ['data', 'and', 'graph', 'survey'],
+        ['data', 'and', 'graph', 'survey', 'for', 'human','interface'] #test bigrams within same sentence
+    ]
+    unicode_sentences = [[utils.to_unicode(w) for w in sentence] for sentence in sentences]
+    common_terms = ['of', 'and', 'for']
+
+
+class TestCommonTermsPhrasesCommon(CommonTermsPhrasesData, TestPhrasesCommon):
+    """ Test CommonTermsPhrases models."""
+    def setUp(self):
+        """Set up Phraser models for the tests."""
+        self.bigram = CommonTermsPhrases(
+            self.sentences, min_count=1, threshold=1, common_terms=self.common_terms)
+        self.bigram_default = CommonTermsPhrases(self.sentences, common_terms=self.common_terms)
+        self.bigram_utf8 = CommonTermsPhrases(
+            self.sentences, min_count=1, threshold=1, common_terms=self.common_terms)
+        self.bigram_unicode = CommonTermsPhrases(
+            self.unicode_sentences, min_count=1, threshold=1, common_terms=self.common_terms)
+
+    def testBigramConstruction(self):
+        """Test Phrases bigram construction building."""
+        # with this setting we should get response_time and graph_minors
+        bigram1_seen = False
+        bigram2_seen = False
+
+        for s in self.bigram[self.sentences]:
+            if not bigram1_seen and u'lack_of_interest' in s:
+                bigram1_seen = True
+            if not bigram2_seen and u'data_and_graph' in s:
+                bigram2_seen = True
+            if bigram1_seen and bigram2_seen:
+                break
+
+        self.assertTrue(bigram1_seen and bigram2_seen)
+
+        # check the same thing, this time using single doc transformation
+        # last sentence should contain both graph_minors and human_interface
+        self.assertTrue(u'lack_of_interest' in self.bigram[self.sentences[1]])
+        self.assertTrue(u'lack_of_interest' in self.bigram[self.sentences[4]])
+        self.assertTrue(u'data_and_graph' in self.bigram[self.sentences[-2]])
+        self.assertTrue(u'data_and_graph' in self.bigram[self.sentences[-1]])
+        self.assertTrue(u'human_interface' in self.bigram[self.sentences[-1]])
+
+    def testBigramConstructionFromGenerator(self):
+        """Test Phrases bigram construction building when corpus is a generator"""
+        bigram1_seen = False
+        bigram2_seen = False
+
+        for s in self.bigram[self.gen_sentences()]:
+            if not bigram1_seen and 'lack_of_interest' in s:
+                bigram1_seen = True
+            if not bigram2_seen and 'data_and_graph' in s:
+                bigram2_seen = True
+            if bigram1_seen and bigram2_seen:
+                break
+        self.assertTrue(bigram1_seen and bigram2_seen)
+
+    def testEncoding(self):
+        """Test that both utf8 and unicode input work; output must be unicode."""
+        expected = [u'survey', u'of', u'user', u'computer', u'system', u'lack_of_interest']
+
+        self.assertEqual(self.bigram_utf8[self.sentences[1]], expected)
+        self.assertEqual(self.bigram_unicode[self.sentences[1]], expected)
+
+        transformed = ' '.join(self.bigram_utf8[self.sentences[1]])
+        self.assertTrue(isinstance(transformed, unicode))
+
+
+
+
+class TestCommonTermsPhrasesModel(CommonTermsPhrasesData, unittest.TestCase):
+    def testExportPhrases(self):
+        """Test Phrases bigram export_phrases functionality."""
+        bigram = CommonTermsPhrases(
+            self.sentences, min_count=1, threshold=1, common_terms=self.common_terms)
+
+        # with this setting we should get response_time and graph_minors
+        bigram1_seen = False
+        bigram2_seen = False
+
+        for phrase, score in bigram.export_phrases(self.sentences):
+            if not bigram1_seen and b'lack of interest' == phrase:
+                bigram1_seen = True
+            elif not bigram2_seen and b'data and graph' == phrase:
+                bigram2_seen = True
+            if bigram1_seen and bigram2_seen:
+                break
+
+        self.assertTrue(bigram1_seen)
+        self.assertTrue(bigram2_seen)
+
+    def testBadParameters(self):
+        """Test the phrases module with bad parameters."""
+        # should fail with something less or equal than 0
+        self.assertRaises(
+            ValueError, CommonTermsPhrases, self.sentences, min_count=0, common_terms=self.common_terms)
+
+        # threshold should be positive
+        self.assertRaises(
+            ValueError, CommonTermsPhrases, self.sentences, threshold=-1, common_terms=self.common_terms)
+
+        # common_terms is a mandatory keyword parameter
+        self.assertRaises(
+            ValueError, CommonTermsPhrases, self.sentences)
+
+    def testPruning(self):
+        """Test that max_vocab_size parameter is respected."""
+        bigram = CommonTermsPhrases(
+            self.sentences, max_vocab_size=5, common_terms=self.common_terms)
+        self.assertTrue(len(bigram.vocab) <= 5)
+
+
+class TestCommonTermsPhraserModel(TestCommonTermsPhrasesCommon):
+    """ Test Phraser models."""
+    def setUp(self):
+        """Set up Phraser models for the tests."""
+        bigram_phrases = CommonTermsPhrases(
+            self.sentences, min_count=1, threshold=1, common_terms=self.common_terms)
+        self.bigram = CommonTermsPhraser(bigram_phrases)
+
+        bigram_default_phrases = CommonTermsPhrases(
+            self.sentences, common_terms=self.common_terms)
+        self.bigram_default = CommonTermsPhraser(bigram_default_phrases)
+
+        bigram_utf8_phrases = CommonTermsPhrases(
+            self.sentences, min_count=1, threshold=1, common_terms=self.common_terms)
+        self.bigram_utf8 = CommonTermsPhraser(bigram_utf8_phrases)
+
+        bigram_unicode_phrases = CommonTermsPhrases(
+            self.unicode_sentences, min_count=1, threshold=1, common_terms=self.common_terms)
+        self.bigram_unicode = CommonTermsPhraser(bigram_unicode_phrases)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This follows feature request #1258.

This add a new model CommonTermsPhrases and it's companion CommonTermsPhraser.
Theses class enable taking into account common terms (aka stop words) when searching for bigrams. Common terms are not taken into account in frequency computation but kept along in the final bigram.

It may allow to catch expressions like "eye of the beholder" or "lack of interest" (in language like french it is quite frequent to have common terms).