### PR TITLE
[WIP] Replaced `logger.warn` by `logger.warning`

### DIFF
--- a/gensim/corpora/sharded_corpus.py
+++ b/gensim/corpora/sharded_corpus.py
@@ -264,10 +264,11 @@ class ShardedCorpus(IndexedCorpus):
                 logger.info('Deriving dataset dimension from corpus: '
                              '{0}'.format(proposed_dim))
             else:
-                logger.warning('Dataset dimension derived from input corpus diffe'
-                             'rs from initialization argument, using corpus.'
-                             '(corpus {0}, init arg {1})'.format(proposed_dim,
-                                                                 self.dim))
+                logger.warning(
+                    'Dataset dimension derived from input corpus diffe'
+                    'rs from initialization argument, using corpus.'
+                    '(corpus {0}, init arg {1})'.format(proposed_dim, self.dim)
+                )
 
         self.dim = proposed_dim
         self.offsets = [0]
@@ -311,9 +312,11 @@ class ShardedCorpus(IndexedCorpus):
             if self.dim is None:
                 logger.info('Loaded dataset dimension: {0}'.format(temp.dim))
             else:
-                logger.warning('Loaded dataset dimension differs from init arg '
-                             'dimension, using loaded dim. '
-                             '(loaded {0}, init {1})'.format(temp.dim, self.dim))
+                logger.warning(
+                    'Loaded dataset dimension differs from init arg '
+                    'dimension, using loaded dim. '
+                    '(loaded {0}, init {1})'.format(temp.dim, self.dim)
+                )
 
         self.dim = temp.dim  # To be consistent with the loaded data!
 
@@ -531,14 +534,18 @@ class ShardedCorpus(IndexedCorpus):
                                  'refusing to guess (dimension set to {0},'
                                  'type of corpus: {1}).'.format(self.dim, type(corpus)))
             else:
-                logger.warning('Couldn\'t find number of features, trusting '
-                             'supplied dimension ({0})'.format(self.dim))
+                logger.warning(
+                    'Couldn\'t find number of features, trusting '
+                    'supplied dimension ({0})'.format(self.dim)
+                )
                 n_features = self.dim
 
         if self.dim and n_features != self.dim:
-            logger.warning('Discovered inconsistent dataset dim ({0}) and '
-                         'feature count from corpus ({1}). Coercing to dimension'
-                         ' given by argument.'.format(self.dim, n_features))
+            logger.warning(
+                'Discovered inconsistent dataset dim ({0}) and '
+                'feature count from corpus ({1}). Coercing to dimension'
+                ' given by argument.'.format(self.dim, n_features)
+            )
 
         return n_features
 

--- a/gensim/corpora/sharded_corpus.py
+++ b/gensim/corpora/sharded_corpus.py
@@ -264,7 +264,7 @@ class ShardedCorpus(IndexedCorpus):
                 logger.info('Deriving dataset dimension from corpus: '
                              '{0}'.format(proposed_dim))
             else:
-                logger.warn('Dataset dimension derived from input corpus diffe'
+                logger.warning('Dataset dimension derived from input corpus diffe'
                              'rs from initialization argument, using corpus.'
                              '(corpus {0}, init arg {1})'.format(proposed_dim,
                                                                  self.dim))
@@ -311,7 +311,7 @@ class ShardedCorpus(IndexedCorpus):
             if self.dim is None:
                 logger.info('Loaded dataset dimension: {0}'.format(temp.dim))
             else:
-                logger.warn('Loaded dataset dimension differs from init arg '
+                logger.warning('Loaded dataset dimension differs from init arg '
                              'dimension, using loaded dim. '
                              '(loaded {0}, init {1})'.format(temp.dim, self.dim))
 
@@ -531,12 +531,12 @@ class ShardedCorpus(IndexedCorpus):
                                  'refusing to guess (dimension set to {0},'
                                  'type of corpus: {1}).'.format(self.dim, type(corpus)))
             else:
-                logger.warn('Couldn\'t find number of features, trusting '
+                logger.warning('Couldn\'t find number of features, trusting '
                              'supplied dimension ({0})'.format(self.dim))
                 n_features = self.dim
 
         if self.dim and n_features != self.dim:
-            logger.warn('Discovered inconsistent dataset dim ({0}) and '
+            logger.warning('Discovered inconsistent dataset dim ({0}) and '
                          'feature count from corpus ({1}). Coercing to dimension'
                          ' given by argument.'.format(self.dim, n_features))
 

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -617,12 +617,12 @@ class Doc2Vec(Word2Vec):
         super(Doc2Vec, self).__init__(
             sg=(1 + dm) % 2,
             null_word=dm_concat, **kwargs)
-        
+
         self.load = call_on_class_only
 
         if dm_mean is not None:
             self.cbow_mean = dm_mean
-        
+
         self.dbow_words = dbow_words
         self.dm_concat = dm_concat
         self.dm_tag_count = dm_tag_count
@@ -672,7 +672,7 @@ class Doc2Vec(Word2Vec):
         for document_no, document in enumerate(documents):
             if not checked_string_types:
                 if isinstance(document.words, string_types):
-                    logger.warn("Each 'words' should be a list of words (usually unicode strings)."
+                    logger.warning("Each 'words' should be a list of words (usually unicode strings)."
                                 "First 'words' here is instead plain %s." % type(document.words))
                 checked_string_types += 1
             if document_no % progress_per == 0:
@@ -845,7 +845,7 @@ class Doc2Vec(Word2Vec):
                         fout.write(utils.to_utf8(doctag) + b" " + row.tostring())
                     else:
                         fout.write(utils.to_utf8("%s %s\n" % (doctag, ' '.join("%f" % val for val in row))))
-        
+
 
 class TaggedBrownCorpus(object):
     """Iterate over documents from the Brown corpus (part of NLTK data), yielding

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -672,8 +672,10 @@ class Doc2Vec(Word2Vec):
         for document_no, document in enumerate(documents):
             if not checked_string_types:
                 if isinstance(document.words, string_types):
-                    logger.warning("Each 'words' should be a list of words (usually unicode strings)."
-                                "First 'words' here is instead plain %s." % type(document.words))
+                    logger.warning(
+                        "Each 'words' should be a list of words (usually unicode strings)."
+                        "First 'words' here is instead plain %s." % type(document.words)
+                    )
                 checked_string_types += 1
             if document_no % progress_per == 0:
                 interval_rate = (total_words - interval_count) / (default_timer() - interval_start)

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -565,8 +565,10 @@ class Word2Vec(utils.SaveLoad):
         for sentence_no, sentence in enumerate(sentences):
             if not checked_string_types:
                 if isinstance(sentence, string_types):
-                    logger.warning("Each 'sentences' item should be a list of words (usually unicode strings)."
-                                "First item here is instead plain %s.", type(sentence))
+                    logger.warning(
+                        "Each 'sentences' item should be a list of words (usually unicode strings)."
+                        "First item here is instead plain %s.", type(sentence)
+                    )
                 checked_string_types += 1
             if sentence_no % progress_per == 0:
                 logger.info("PROGRESS: at sentence #%i, processed %i words, keeping %i word types",
@@ -845,7 +847,9 @@ class Word2Vec(utils.SaveLoad):
             pushed_words, pushed_examples = 0, 0
             next_alpha = start_alpha
             if next_alpha > self.min_alpha_yet_reached:
-                logger.warning("Effective 'alpha' higher than previous training cycles")
+                logger.warning(
+                    "Effective 'alpha' higher than previous training cycles"
+                )
             self.min_alpha_yet_reached = next_alpha
             job_no = 0
 
@@ -953,13 +957,19 @@ class Word2Vec(utils.SaveLoad):
             "training on %i raw words (%i effective words) took %.1fs, %.0f effective words/s",
             raw_word_count, trained_word_count, elapsed, trained_word_count / elapsed)
         if job_tally < 10 * self.workers:
-            logger.warning("under 10 jobs per worker: consider setting a smaller `batch_words' for smoother alpha decay")
+            logger.warning(
+                "under 10 jobs per worker: consider setting a smaller `batch_words' for smoother alpha decay"
+            )
 
         # check that the input corpus hasn't changed during iteration
         if total_examples and total_examples != example_count:
-            logger.warning("supplied example count (%i) did not equal expected count (%i)", example_count, total_examples)
+            logger.warning(
+                "supplied example count (%i) did not equal expected count (%i)", example_count, total_examples
+            )
         if total_words and total_words != raw_word_count:
-            logger.warning("supplied raw word count (%i) did not equal expected count (%i)", raw_word_count, total_words)
+            logger.warning(
+                "supplied raw word count (%i) did not equal expected count (%i)", raw_word_count, total_words
+            )
 
         self.train_count += 1  # number of times train() has been called
         self.total_train_time += elapsed

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -565,7 +565,7 @@ class Word2Vec(utils.SaveLoad):
         for sentence_no, sentence in enumerate(sentences):
             if not checked_string_types:
                 if isinstance(sentence, string_types):
-                    logger.warn("Each 'sentences' item should be a list of words (usually unicode strings)."
+                    logger.warning("Each 'sentences' item should be a list of words (usually unicode strings)."
                                 "First item here is instead plain %s.", type(sentence))
                 checked_string_types += 1
             if sentence_no % progress_per == 0:
@@ -845,7 +845,7 @@ class Word2Vec(utils.SaveLoad):
             pushed_words, pushed_examples = 0, 0
             next_alpha = start_alpha
             if next_alpha > self.min_alpha_yet_reached:
-                logger.warn("Effective 'alpha' higher than previous training cycles")
+                logger.warning("Effective 'alpha' higher than previous training cycles")
             self.min_alpha_yet_reached = next_alpha
             job_no = 0
 
@@ -953,13 +953,13 @@ class Word2Vec(utils.SaveLoad):
             "training on %i raw words (%i effective words) took %.1fs, %.0f effective words/s",
             raw_word_count, trained_word_count, elapsed, trained_word_count / elapsed)
         if job_tally < 10 * self.workers:
-            logger.warn("under 10 jobs per worker: consider setting a smaller `batch_words' for smoother alpha decay")
+            logger.warning("under 10 jobs per worker: consider setting a smaller `batch_words' for smoother alpha decay")
 
         # check that the input corpus hasn't changed during iteration
         if total_examples and total_examples != example_count:
-            logger.warn("supplied example count (%i) did not equal expected count (%i)", example_count, total_examples)
+            logger.warning("supplied example count (%i) did not equal expected count (%i)", example_count, total_examples)
         if total_words and total_words != raw_word_count:
-            logger.warn("supplied raw word count (%i) did not equal expected count (%i)", raw_word_count, total_words)
+            logger.warning("supplied raw word count (%i) did not equal expected count (%i)", raw_word_count, total_words)
 
         self.train_count += 1  # number of times train() has been called
         self.total_train_time += elapsed

--- a/gensim/models/wrappers/ldamallet.py
+++ b/gensim/models/wrappers/ldamallet.py
@@ -242,7 +242,9 @@ class LdaMallet(utils.SaveLoad, basemodel.BaseTopicModel):
 
     def show_topic(self, topicid, num_words=10):
         if self.word_topics is None:
-            logger.warning("Run train or load_word_topics before showing topics.")
+            logger.warning(
+                "Run train or load_word_topics before showing topics."
+            )
         topic = self.word_topics[topicid]
         topic = topic / topic.sum()  # normalize to probability dist
         bestn = matutils.argsort(topic, num_words, reverse=True)

--- a/gensim/models/wrappers/ldamallet.py
+++ b/gensim/models/wrappers/ldamallet.py
@@ -242,7 +242,7 @@ class LdaMallet(utils.SaveLoad, basemodel.BaseTopicModel):
 
     def show_topic(self, topicid, num_words=10):
         if self.word_topics is None:
-            logger.warn("Run train or load_word_topics before showing topics.")
+            logger.warning("Run train or load_word_topics before showing topics.")
         topic = self.word_topics[topicid]
         topic = topic / topic.sum()  # normalize to probability dist
         bestn = matutils.argsort(topic, num_words, reverse=True)


### PR DESCRIPTION
This PR updates `logger.warn` to `logger.warning` in the code since `logging.warn` has been deprecated since Python 3.3 and it is advisable to use `logging.warning` ([Reference](http://stackoverflow.com/questions/15539937/whats-the-difference-between-logging-warn-and-logging-warning-in-python-or-are)).

Relevant Google mailing list discussion [here](https://groups.google.com/forum/#!topic/gensim/xztXxrKix9Q).