### PR TITLE
Ignoring rst and ipynb file in Travis flake8 validations

### DIFF
--- a/continuous_integration/travis/flake8_diff.sh
+++ b/continuous_integration/travis/flake8_diff.sh
@@ -133,6 +133,6 @@ check_files() {
 if [[ "$MODIFIED_FILES" == "no_match" ]]; then
     echo "No file has been modified"
 else
-    check_files "$(echo "$MODIFIED_FILES" )" "--ignore=E501,E731,E12,W503 --exclude=*.sh,*.md,*.yml"
+    check_files "$(echo "$MODIFIED_FILES" )" "--ignore=E501,E731,E12,W503 --exclude=*.sh,*.md,*.yml,*.rst,*.ipynb"
 fi
 echo -e "No problem detected by flake8\n"


### PR DESCRIPTION
Making travis not check PEP-8 on rst, and ipynb files.