### PR TITLE
Sparse support when num_best not None in interfaces. Fixes #1294

### DIFF
--- a/gensim/interfaces.py
+++ b/gensim/interfaces.py
@@ -224,8 +224,7 @@ class SimilarityABC(utils.SaveLoad):
 
         # if maintain_sparity is True, result is scipy sparse. Sort, clip the
         # topn and return as a scipy sparse matrix.
-        if hasattr(self, 'maintain_sparsity'):
-            if self.maintain_sparsity:
+        if getattr(self, 'maintain_sparsity', False):
                 return matutils.scipy2scipy_clipped(result, self.num_best)
 
         # if the input query was a corpus (=more documents), compute the top-n

--- a/gensim/interfaces.py
+++ b/gensim/interfaces.py
@@ -19,8 +19,6 @@ import itertools
 from gensim import utils, matutils
 from six.moves import xrange
 
-import numpy as np
-import scipy.sparse
 
 logger = logging.getLogger('gensim.interfaces')
 

--- a/gensim/interfaces.py
+++ b/gensim/interfaces.py
@@ -225,10 +225,10 @@ class SimilarityABC(utils.SaveLoad):
         # if the input query was a corpus (=more documents), compute the top-n
         # most similar for each document in turn
         if matutils.ismatrix(result):
-            return [matutils.full2sparse_clipped(v, self.num_best) for v in result]
+            return [matutils.any2sparse_clipped(v, self.num_best) for v in result]
         else:
             # otherwise, return top-n of the single input document
-            return matutils.full2sparse_clipped(result, self.num_best)
+            return matutils.any2sparse_clipped(result, self.num_best)
 
 
     def __iter__(self):

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -185,9 +185,13 @@ def scipy2scipy_clipped(matrix, topn, eps=1e-9):
         matrix_indices = []
         matrix_data = []
         matrix_indptr = [0]
-        for v in matrix:
+        matrix.sort_indices()  # ensure data is stored in row major, sorts inplace
+        # calling abs() on entire matrix once is faster than calling abs() iteratively for each row
+        matrix_abs = abs(matrix.data)
+        for i in range(matrix.shape[0]):
+            v = matrix.getrow(i)
             # Sort and clip each row vector first.
-            biggest = argsort(abs(v.data), topn, reverse=True)
+            biggest = argsort(matrix_abs[matrix.indptr[i]:matrix.indptr[i + 1]], topn, reverse=True)
             indices, data = v.indices.take(biggest), v.data.take(biggest)
             # Store the topn indices and values of each row vector.
             matrix_data.append(data)

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -175,8 +175,14 @@ def any2sparse_clipped(vec, topn, eps=1e-9):
         return []
     if isinstance(vec, np.ndarray):
         return full2sparse_clipped(vec, topn, eps)
-    vec_sparse = any2sparse(vec, eps)
-    return sorted(vec_sparse, key=lambda x: x[1], reverse=True)[:topn]
+    if scipy.sparse.issparse(vec):
+        biggest = argsort(abs(vec).data, topn, reverse=True)
+        return list(zip(vec.indices.take(biggest), vec.data.take(biggest)))
+    else:
+        vec_csr = scipy.sparse.csr_matrix(vec)
+        biggest = argsort(abs(vec_csr).data, topn, reverse=True)
+        return list(zip(vec_csr.indices.take(biggest), vec_csr.data.take(biggest)))
+
 
 
 def scipy2sparse(vec, eps=1e-9):

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -176,7 +176,7 @@ def any2sparse_clipped(vec, topn, eps=1e-9):
     if isinstance(vec, np.ndarray):
         return full2sparse_clipped(vec, topn, eps)
     vec_sparse = any2sparse(vec, eps)
-    return sorted(vec_sparse,key=lambda x: x[1], reverse=True)
+    return sorted(vec_sparse, key=lambda x: x[1], reverse=True)
 
 
 def scipy2sparse(vec, eps=1e-9):

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -185,13 +185,13 @@ def scipy2scipy_clipped(matrix, topn, eps=1e-9):
         matrix_indices = []
         matrix_data = []
         matrix_indptr = [0]
-        matrix.sort_indices()  # ensure data is stored in row major, sorts inplace
         # calling abs() on entire matrix once is faster than calling abs() iteratively for each row
-        matrix_abs = abs(matrix.data)
+        matrix_abs = abs(matrix)
         for i in range(matrix.shape[0]):
             v = matrix.getrow(i)
+            v_abs = matrix_abs.getrow(i)
             # Sort and clip each row vector first.
-            biggest = argsort(matrix_abs[matrix.indptr[i]:matrix.indptr[i + 1]], topn, reverse=True)
+            biggest = argsort(v_abs.data, topn, reverse=True)
             indices, data = v.indices.take(biggest), v.data.take(biggest)
             # Store the topn indices and values of each row vector.
             matrix_data.append(data)

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -176,7 +176,7 @@ def any2sparse_clipped(vec, topn, eps=1e-9):
     if isinstance(vec, np.ndarray):
         return full2sparse_clipped(vec, topn, eps)
     vec_sparse = any2sparse(vec, eps)
-    return sorted(vec_sparse, key=lambda x: x[1], reverse=True)
+    return sorted(vec_sparse, key=lambda x: x[1], reverse=True)[:topn]
 
 
 def scipy2sparse(vec, eps=1e-9):

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -168,7 +168,7 @@ def any2sparse(vec, eps=1e-9):
 
 def scipy2scipy_clipped(matrix, topn, eps=1e-9):
     """
-    Return a scipy.sparse vector/matrix consisting of 'topn' elements of greatest magnitude(abs).
+    Return a scipy.sparse vector/matrix consisting of 'topn' elements of the greatest magnitude (absolute value).
     """
     if not scipy.sparse.issparse(matrix):
         raise ValueError("'%s' is not a scipy sparse vector." % matrix)
@@ -177,7 +177,7 @@ def scipy2scipy_clipped(matrix, topn, eps=1e-9):
     # Return clipped sparse vector if input is a sparse vector.
     if matrix.shape[0] == 1:
         # use np.argpartition/argsort and only form tuples that are actually returned.
-        biggest = argsort(abs(matrix).data, topn, reverse=True)
+        biggest = argsort(abs(matrix.data), topn, reverse=True)
         indices, data = matrix.indices.take(biggest), matrix.data.take(biggest)
         return scipy.sparse.csr_matrix((data, indices, [0, len(indices)]))
     # Return clipped sparse matrix if input is a matrix, processing row by row.
@@ -187,7 +187,7 @@ def scipy2scipy_clipped(matrix, topn, eps=1e-9):
         matrix_indptr = [0]
         for v in matrix:
             # Sort and clip each row vector first.
-            biggest = argsort(abs(v).data, topn, reverse=True)
+            biggest = argsort(abs(v.data), topn, reverse=True)
             indices, data = v.indices.take(biggest), v.data.take(biggest)
             # Store the topn indices and values of each row vector.
             matrix_data.append(data)

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -184,6 +184,7 @@ def scipy2scipy_clipped(matrix, topn, eps=1e-9):
     else:
         matrix_indices = []
         matrix_data = []
+        matrix_indptr = [0]
         for v in matrix:
             # Sort and clip each row vector first.
             biggest = argsort(abs(v).data, topn, reverse=True)
@@ -191,7 +192,7 @@ def scipy2scipy_clipped(matrix, topn, eps=1e-9):
             # Store the topn indices and values of each row vector.
             matrix_data.append(data)
             matrix_indices.append(indices)
-        matrix_indptr = np.array([i * topn for i in range(1 + len(matrix_indices))])
+            matrix_indptr.append(matrix_indptr[-1] + min(len(indices), topn))
         matrix_indices = np.concatenate(matrix_indices).ravel()
         matrix_data = np.concatenate(matrix_data).ravel()
         # Instantiate and return a sparse csr_matrix which preserves the order of indices/data.

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -166,6 +166,19 @@ def any2sparse(vec, eps=1e-9):
     return [(int(fid), float(fw)) for fid, fw in vec if np.abs(fw) > eps]
 
 
+def any2sparse_clipped(vec, topn, eps=1e-9):
+    """
+    Like `any2sparse`, but only returns the `topn` elements of greatest magnitude (abs).
+
+    """
+    if topn <= 0:
+        return []
+    if isinstance(vec, np.ndarray):
+        return full2sparse_clipped(vec, topn, eps)
+    vec_sparse = any2sparse(vec, eps)
+    return sorted(vec_sparse,key=lambda x: x[1], reverse=True)
+
+
 def scipy2sparse(vec, eps=1e-9):
     """Convert a scipy.sparse vector into gensim document format (=list of 2-tuples)."""
     vec = vec.tocsr()

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -113,7 +113,7 @@ class _TestSimilarityABC(object):
         expected = [(0, 0.80000000000000004), (1, 0.20000000000000001), (5, -0.14999999999999999)]
         self.assertTrue(matutils.any2sparse_clipped(vec, topn=3), expected)
 
-        vec_scipy = scipy.csr_matrix(vec)
+        vec_scipy = scipy.sparse.csr_matrix(vec)
         self.assertTrue(matutils.any2sparse_clipped(vec_scipy, topn=3), expected)
 
 

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -425,7 +425,7 @@ class TestSparseMatrixSimilarity(unittest.TestCase, _TestSimilarityABC):
         """Tests that sparsity is correctly maintained when maintain_sparsity=True and num_best is not None"""
         num_features = len(dictionary)
 
-        index = self.cls(corpus, num_features=num_features, num_best=3)
+        index = self.cls(corpus, num_features=num_features, maintain_sparsity=False, num_best=3)
         dense_topn_sims = index[corpus]
 
         index = self.cls(corpus, num_features=num_features, maintain_sparsity=True, num_best=3)

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -123,7 +123,7 @@ class _TestSimilarityABC(object):
         matrix_scipy = scipy.sparse.csr_matrix([vec] * 3)
         matrix_scipy_clipped = matutils.scipy2scipy_clipped(matrix_scipy, topn=3)
         self.assertTrue(scipy.sparse.issparse(matrix_scipy_clipped))
-        self.assertTrue([matutils.scipy2sparse(x) for x in matrix_scipy_clipped], [expected]*3)
+        self.assertTrue([matutils.scipy2sparse(x) for x in matrix_scipy_clipped], [expected] * 3)
 
 
     def testChunking(self):

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -108,6 +108,13 @@ class _TestSimilarityABC(object):
         expected = [(0, 0.80000000000000004), (1, 0.20000000000000001), (5, -0.14999999999999999)]
         self.assertTrue(matutils.full2sparse_clipped(vec, topn=3), expected)
 
+    def test_any2sparse_clipped(self):
+        vec = [0.8, 0.2, 0.0, 0.0, -0.1, -0.15]
+        expected = [(0, 0.80000000000000004), (1, 0.20000000000000001), (5, -0.14999999999999999)]
+        self.assertTrue(matutils.any2sparse_clipped(vec, topn=3), expected)
+
+        vec_scipy = scipy.csr_matrix(vec)
+        self.assertTrue(matutils.any2sparse_clipped(vec_scipy, topn=3), expected)
 
 
     def testChunking(self):


### PR DESCRIPTION
Fixes #1294. Added a new function ( any2sparse_clipped() ), in matutils by extending any2sparse() to return the topn elements of greatest magnitude. Also, replaced full2sparse_clipped in interfaces.py to any2sparse_clipped to handle sparse cases when num_best isn't None. 
I am fairly new to contributing to open source and so do not have much idea about testing my commits. I have only tested/verified against the code to reproduce the issue and it seemed to be working. Let me know in case I need to do anything else.
