### PR TITLE
add test_req

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -226,6 +226,12 @@ Copyright (c) 2009-now Radim Rehurek
 """
 
 
+test_env = ['testfixtures',
+            'unittest2',
+            'Morfessor==2.0.2a4',
+            'scikit-learn',
+            'pyemd']
+
 setup(
     name='gensim',
     version='2.1.0',
@@ -282,23 +288,11 @@ setup(
         'six >= 1.5.0',
         'smart_open >= 1.2.1',
     ],
-    tests_require=[
-        'testfixtures',
-        'unittest2',
-        'Morfessor==2.0.2a4',
-        'scikit-learn',
-        'pyemd'
-    ],
+    tests_require=test_env,
     extras_require={
         'distributed': ['Pyro4 >= 4.27'],
         'wmd': ['pyemd >= 0.2.0'],
-        'test': [
-            'testfixtures',
-            'unittest2',
-            'Morfessor==2.0.2a4',
-            'scikit-learn',
-            'pyemd'
-        ],
+        'test': test_env,
     },
 
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -282,6 +282,13 @@ setup(
         'six >= 1.5.0',
         'smart_open >= 1.2.1',
     ],
+    tests_require=[
+        'testfixtures',
+        'unittest2',
+        'Morfessor==2.0.2a4',
+        'scikit-learn',
+        'pyemd'
+    ],
     extras_require={
         'distributed': ['Pyro4 >= 4.27'],
         'wmd': ['pyemd >= 0.2.0'],
@@ -289,7 +296,8 @@ setup(
             'testfixtures',
             'unittest2',
             'Morfessor==2.0.2a4',
-            'scikit-learn'
+            'scikit-learn',
+            'pyemd'
         ],
     },
 


### PR DESCRIPTION
Add `tests_require` to setup.py
The reason is `python setup.py test` don't install test dependencies if `test_require` not presented