### PR TITLE
Fixes import statement in keyedvectors.py

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -21,7 +21,7 @@ Persist the word vectors to disk with::
 
 The vectors can also be instantiated from an existing file on disk in the original Google's word2vec C format as a KeyedVectors instance::
 
-  >>> from gensim.keyedvectors import KeyedVectors
+  >>> from gensim.models.keyedvectors import KeyedVectors
   >>> word_vectors = KeyedVectors.load_word2vec_format('/tmp/vectors.txt', binary=False)  # C text format
   >>> word_vectors = KeyedVectors.load_word2vec_format('/tmp/vectors.bin', binary=True)  # C binary format
 


### PR DESCRIPTION
This PR fixes an import statement in `gensim.models.keyedvectors.py` as pointed out [here](https://github.com/RaRe-Technologies/gensim/issues/1335#issuecomment-302445444).