### PR TITLE
Updated Annoy Tutorial with Text8

### DIFF
--- a/docs/notebooks/annoytutorial-text8.ipynb
+++ b/docs/notebooks/annoytutorial-text8.ipynb
@@ -1,0 +1,743 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Similarity Queries using Annoy Tutorial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This tutorial is about using the ([Annoy Approximate Nearest Neighbors Oh Yeah](https://github.com/spotify/annoy \"Link to annoy repo\")) library for similarity queries with a Word2Vec model built with gensim.\n",
+    "\n",
+    "## Why use Annoy?\n",
+    "The current implementation for finding k nearest neighbors in a vector space in gensim has linear complexity via brute force in the number of indexed documents, although with extremely low constant factors. The retrieved results are exact, which is an overkill in many applications: approximate results retrieved in sub-linear time may be enough. Annoy can find approximate nearest neighbors much faster.\n",
+    "\n",
+    "\n",
+    "## Prerequisites\n",
+    "Additional libraries needed for this tutorial:\n",
+    "- annoy\n",
+    "- psutil\n",
+    "- matplotlib\n",
+    "\n",
+    "## Outline\n",
+    "1. Download Text8 Corpus\n",
+    "2. Build Word2Vec Model\n",
+    "3. Construct AnnoyIndex with model & make a similarity query\n",
+    "4. Verify & Evaluate performance\n",
+    "5. Evaluate relationship of `num_trees` to initialization time and accuracy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPython 3.6.1\n",
+      "IPython 6.0.0\n",
+      "\n",
+      "gensim 2.1.0\n",
+      "numpy 1.12.1\n",
+      "scipy 0.19.0\n",
+      "psutil 5.2.2\n",
+      "matplotlib 2.0.2\n",
+      "\n",
+      "compiler   : GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)\n",
+      "system     : Darwin\n",
+      "release    : 14.5.0\n",
+      "machine    : x86_64\n",
+      "processor  : i386\n",
+      "CPU cores  : 8\n",
+      "interpreter: 64bit\n"
+     ]
+    }
+   ],
+   "source": [
+    "# pip install watermark\n",
+    "%reload_ext watermark\n",
+    "%watermark -v -m -p gensim,numpy,scipy,psutil,matplotlib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Download Text8 Corpus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os.path\n",
+    "if not os.path.isfile('text8'):\n",
+    "    !wget -c http://mattmahoney.net/dc/text8.zip\n",
+    "    !unzip text8.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Import & Set up Logging\n",
+    "I'm not going to set up logging due to the verbose input displaying in notebooks, but if you want that, uncomment the lines in the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "LOGS = False\n",
+    "\n",
+    "if LOGS:\n",
+    "    import logging\n",
+    "    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Build Word2Vec Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Word2Vec(vocab=71290, size=100, alpha=0.05)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from gensim.models import Word2Vec, KeyedVectors\n",
+    "from gensim.models.word2vec import Text8Corpus\n",
+    "\n",
+    "# using params from Word2Vec_FastText_Comparison\n",
+    "\n",
+    "lr = 0.05\n",
+    "dim = 100\n",
+    "ws = 5\n",
+    "epoch = 5\n",
+    "minCount = 5\n",
+    "neg = 5\n",
+    "loss = 'ns'\n",
+    "t = 1e-4\n",
+    "\n",
+    "# Same values as used for fastText training above\n",
+    "params = {\n",
+    "    'alpha': lr,\n",
+    "    'size': dim,\n",
+    "    'window': ws,\n",
+    "    'iter': epoch,\n",
+    "    'min_count': minCount,\n",
+    "    'sample': t,\n",
+    "    'sg': 1,\n",
+    "    'hs': 0,\n",
+    "    'negative': neg\n",
+    "}\n",
+    "\n",
+    "model = Word2Vec(Text8Corpus('text8'), **params)\n",
+    "print(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See the [Word2Vec tutorial](https://github.com/RaRe-Technologies/gensim/blob/develop/docs/notebooks/word2vec.ipynb) for how to initialize and save this model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Comparing the traditional implementation and the Annoy approximation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Set up the model and vector that we are using in the comparison\n",
+    "try:\n",
+    "    from gensim.similarities.index import AnnoyIndexer\n",
+    "except ImportError:\n",
+    "    raise ValueError(\"SKIP: Please install the annoy indexer\")\n",
+    "\n",
+    "model.init_sims()\n",
+    "annoy_index = AnnoyIndexer(model, 100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('the', 0.9999998807907104),\n",
+       " ('of', 0.8208043575286865),\n",
+       " ('in', 0.8024208545684814),\n",
+       " ('a', 0.7661813497543335),\n",
+       " ('and', 0.7392199039459229)]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Dry run to make sure both indices are fully in RAM\n",
+    "vector = model.wv.syn0norm[0]\n",
+    "model.most_similar([vector], topn=5, indexer=annoy_index)\n",
+    "model.most_similar([vector], topn=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def avg_query_time(annoy_index=None, queries=1000):\n",
+    "    \"\"\"\n",
+    "    Average query time of a most_similar method over 1000 random queries,\n",
+    "    uses annoy if given an indexer\n",
+    "    \"\"\"\n",
+    "    total_time = 0\n",
+    "    for _ in range(queries):\n",
+    "        rand_vec = model.wv.syn0norm[np.random.randint(0, len(model.wv.vocab))]\n",
+    "        start_time = time.clock()\n",
+    "        model.most_similar([rand_vec], topn=5, indexer=annoy_index)\n",
+    "        total_time += time.clock() - start_time\n",
+    "    return total_time / queries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gensim (s/query):\t0.00571\n",
+      "Annoy (s/query):\t0.00028\n",
+      "\n",
+      "Annoy is 20.67 times faster on average on this particular run\n"
+     ]
+    }
+   ],
+   "source": [
+    "queries = 10000\n",
+    "\n",
+    "gensim_time = avg_query_time(queries=queries)\n",
+    "annoy_time = avg_query_time(annoy_index, queries=queries)\n",
+    "print(\"Gensim (s/query):\\t{0:.5f}\".format(gensim_time))\n",
+    "print(\"Annoy (s/query):\\t{0:.5f}\".format(annoy_time))\n",
+    "speed_improvement = gensim_time / annoy_time\n",
+    "print (\"\\nAnnoy is {0:.2f} times faster on average on this particular run\".format(speed_improvement))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "**This speedup factor is by no means constant** and will vary greatly from run to run and is particular to this data set, BLAS setup, Annoy parameters(as tree size increases speedup factor decreases), machine specifications, among other factors.\n",
+    "\n",
+    ">**Note**: Initialization time for the annoy indexer was not included in the times. The optimal knn algorithm for you to use will depend on how many queries you need to make and the size of the corpus. If you are making very few similarity queries, the time taken to initialize the annoy indexer will be longer than the time it would take the brute force method to retrieve results. If you are making many queries however, the time it takes to initialize the annoy indexer will be made up for by the incredibly fast retrieval times for queries once the indexer has been initialized\n",
+    "\n",
+    ">**Note** : Gensim's 'most_similar' method is using numpy operations in the form of dot product whereas Annoy's method isnt. If 'numpy' on your machine is using one of the BLAS libraries like ATLAS or LAPACK, it'll run on multiple cores(only if your machine has multicore support ). Check [SciPy Cookbook](http://scipy-cookbook.readthedocs.io/items/ParallelProgramming.html) for more details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Construct AnnoyIndex with model & make a similarity query"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating an indexer\n",
+    "An instance of `AnnoyIndexer` needs to be created in order to use Annoy in gensim. The `AnnoyIndexer` class is located in `gensim.similarities.index`\n",
+    "\n",
+    "`AnnoyIndexer()` takes two parameters:\n",
+    "\n",
+    "**`model`**: A `Word2Vec` or `Doc2Vec` model\n",
+    "\n",
+    "**`num_trees`**: A positive integer. `num_trees` effects the build time and the index size. **A larger value will give more accurate results, but larger indexes**. More information on what trees in Annoy do can be found [here](https://github.com/spotify/annoy#how-does-it-work). The relationship between `num_trees`, build time, and accuracy will be investigated later in the tutorial. \n",
+    "\n",
+    "Now that we are ready to make a query, lets find the top 5 most similar words to \"science\" in the Text8 corpus. To make a similarity query we call `Word2Vec.most_similar` like we would traditionally, but with an added parameter, `indexer`. The only supported indexer in gensim as of now is Annoy. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Approximate Neighbors\n",
+      "('science', 1.0)\n",
+      "('interdisciplinary', 0.6099119782447815)\n",
+      "('astrobiology', 0.5975957810878754)\n",
+      "('actuarial', 0.596003383398056)\n",
+      "('robotics', 0.5942946970462799)\n",
+      "('sciences', 0.59312504529953)\n",
+      "('scientific', 0.5900688469409943)\n",
+      "('psychohistory', 0.5890524089336395)\n",
+      "('bioethics', 0.5867903232574463)\n",
+      "('cryobiology', 0.5854728817939758)\n",
+      "('xenobiology', 0.5836742520332336)\n",
+      "\n",
+      "Normal (not Annoy-indexed) Neighbors\n",
+      "('science', 1.0)\n",
+      "('fiction', 0.7495021224021912)\n",
+      "('interdisciplinary', 0.6956626772880554)\n",
+      "('astrobiology', 0.6761417388916016)\n",
+      "('actuarial', 0.6735734343528748)\n",
+      "('robotics', 0.6708062887191772)\n",
+      "('sciences', 0.6689055562019348)\n",
+      "('scientific', 0.6639128923416138)\n",
+      "('psychohistory', 0.6622439622879028)\n",
+      "('bioethics', 0.6585155129432678)\n",
+      "('vernor', 0.6571990251541138)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 100 trees are being used in this example\n",
+    "annoy_index = AnnoyIndexer(model, 100)\n",
+    "# Derive the vector for the word \"science\" in our model\n",
+    "vector = model[\"science\"]\n",
+    "# The instance of AnnoyIndexer we just created is passed \n",
+    "approximate_neighbors = model.most_similar([vector], topn=11, indexer=annoy_index)\n",
+    "# Neatly print the approximate_neighbors and their corresponding cosine similarity values\n",
+    "print(\"Approximate Neighbors\")\n",
+    "for neighbor in approximate_neighbors:\n",
+    "    print(neighbor)\n",
+    "\n",
+    "normal_neighbors = model.most_similar([vector], topn=11)\n",
+    "print(\"\\nNormal (not Annoy-indexed) Neighbors\")\n",
+    "for neighbor in normal_neighbors:\n",
+    "    print(neighbor)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Analyzing the results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The closer the cosine similarity of a vector is to 1, the more similar that word is to our query, which was the vector for \"science\". There are some differences in the ranking of similar words and the set of words included within the 10 most similar words."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. Verify & Evaluate performance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Persisting Indexes\n",
+    "You can save and load your indexes from/to disk to prevent having to construct them each time. This will create two files on disk, _fname_ and _fname.d_. Both files are needed to correctly restore all attributes. Before loading an index, you will have to create an empty AnnoyIndexer object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "fname = 'index'\n",
+    "\n",
+    "# Persist index to disk\n",
+    "annoy_index.save(fname)\n",
+    "\n",
+    "# Load index back\n",
+    "if os.path.exists(fname):\n",
+    "    annoy_index2 = AnnoyIndexer()\n",
+    "    annoy_index2.load(fname)\n",
+    "    annoy_index2.model = model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('science', 1.0)\n",
+      "('interdisciplinary', 0.6099119782447815)\n",
+      "('astrobiology', 0.5975957810878754)\n",
+      "('actuarial', 0.596003383398056)\n",
+      "('robotics', 0.5942946970462799)\n",
+      "('sciences', 0.59312504529953)\n",
+      "('scientific', 0.5900688469409943)\n",
+      "('psychohistory', 0.5890524089336395)\n",
+      "('bioethics', 0.5867903232574463)\n",
+      "('cryobiology', 0.5854728817939758)\n",
+      "('xenobiology', 0.5836742520332336)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Results should be identical to above\n",
+    "vector = model[\"science\"]\n",
+    "approximate_neighbors2 = model.most_similar([vector], topn=11, indexer=annoy_index2)\n",
+    "for neighbor in approximate_neighbors2:\n",
+    "    print(neighbor)\n",
+    "    \n",
+    "assert approximate_neighbors == approximate_neighbors2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Be sure to use the same model at load that was used originally, otherwise you will get unexpected behaviors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Save memory by memory-mapping indices saved to disk\n",
+    "\n",
+    "Annoy library has a useful feature that indices can be memory-mapped from disk. It saves memory when the same index is used by several processes.\n",
+    "\n",
+    "Below are two snippets of code. First one has a separate index for each process. The second snipped shares the index between two processes via memory-mapping. The second example uses less total RAM as it is shared."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Remove verbosity from code below (if logging active)\n",
+    "\n",
+    "if LOGS:\n",
+    "    logging.disable(logging.CRITICAL)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from multiprocessing import Process\n",
+    "import os\n",
+    "import psutil"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Bad Example: Two processes load the Word2vec model from disk and create there own Annoy indices from that model. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Process Id:  6452\n",
+      "\n",
+      "Memory used by process 6452:  pmem(rss=425226240, vms=3491692544, pfaults=149035, pageins=0) \n",
+      "---\n",
+      "Process Id:  6460\n",
+      "\n",
+      "Memory used by process 6460:  pmem(rss=425136128, vms=3491692544, pfaults=149020, pageins=0) \n",
+      "---\n",
+      "CPU times: user 489 ms, sys: 204 ms, total: 693 ms\n",
+      "Wall time: 29.3 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "model.save('/tmp/mymodel')\n",
+    "\n",
+    "def f(process_id):\n",
+    "    print ('Process Id: ', os.getpid())\n",
+    "    process = psutil.Process(os.getpid())\n",
+    "    new_model = Word2Vec.load('/tmp/mymodel')\n",
+    "    vector = new_model[\"science\"]\n",
+    "    annoy_index = AnnoyIndexer(new_model,100)\n",
+    "    approximate_neighbors = new_model.most_similar([vector], topn=5, indexer=annoy_index)\n",
+    "    print('\\nMemory used by process {}: '.format(os.getpid()), process.memory_info(), \"\\n---\")\n",
+    "\n",
+    "# Creating and running two parallel process to share the same index file.\n",
+    "p1 = Process(target=f, args=('1',))\n",
+    "p1.start()\n",
+    "p1.join()\n",
+    "p2 = Process(target=f, args=('2',))\n",
+    "p2.start()\n",
+    "p2.join()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Good example. Two processes load both the Word2vec model and index from disk and memory-map the index\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Process Id:  6461\n",
+      "\n",
+      "Memory used by process 6461:  pmem(rss=357363712, vms=3576012800, pfaults=105041, pageins=0) \n",
+      "---\n",
+      "Process Id:  6462\n",
+      "\n",
+      "Memory used by process 6462:  pmem(rss=357097472, vms=3576012800, pfaults=104995, pageins=0) \n",
+      "---\n",
+      "CPU times: user 509 ms, sys: 181 ms, total: 690 ms\n",
+      "Wall time: 2.61 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "model.save('/tmp/mymodel')\n",
+    "\n",
+    "def f(process_id):\n",
+    "    print('Process Id: ', os.getpid())\n",
+    "    process = psutil.Process(os.getpid())\n",
+    "    new_model = Word2Vec.load('/tmp/mymodel')\n",
+    "    vector = new_model[\"science\"]\n",
+    "    annoy_index = AnnoyIndexer()\n",
+    "    annoy_index.load('index')\n",
+    "    annoy_index.model = new_model\n",
+    "    approximate_neighbors = new_model.most_similar([vector], topn=5, indexer=annoy_index)\n",
+    "    print('\\nMemory used by process {}: '.format(os.getpid()), process.memory_info(), \"\\n---\")\n",
+    "\n",
+    "# Creating and running two parallel process to share the same index file.\n",
+    "p1 = Process(target=f, args=('1',))\n",
+    "p1.start()\n",
+    "p1.join()\n",
+    "p2 = Process(target=f, args=('2',))\n",
+    "p2.start()\n",
+    "p2.join()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5. Evaluate relationship of `num_trees` to initialization time and accuracy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Build dataset of Initialization times and accuracy measures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "exact_results = [element[0] for element in model.most_similar([model.wv.syn0norm[0]], topn=100)]\n",
+    "\n",
+    "x_values = []\n",
+    "y_values_init = []\n",
+    "y_values_accuracy = []\n",
+    "\n",
+    "for x in range(1, 300, 10):\n",
+    "    x_values.append(x)\n",
+    "    start_time = time.time()\n",
+    "    annoy_index = AnnoyIndexer(model, x)\n",
+    "    y_values_init.append(time.time() - start_time)\n",
+    "    approximate_results = model.most_similar([model.wv.syn0norm[0]], topn=100, indexer=annoy_index)\n",
+    "    top_words = [result[0] for result in approximate_results]\n",
+    "    y_values_accuracy.append(len(set(top_words).intersection(exact_results)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plot results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1gAAAGoCAYAAABbkkSYAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xd8VfX9x/HXJxAIe8geYcsmoAyti1atE7UOLHUvrP21\n1lW1auturXV3O+oWQdEq4sI9C4KSsJEdSIAwAmFkf35/nEMbaSAJ5Obk3ryfj8d95N4z37lJ7snn\nnO/5fs3dERERERERkf2XFHUAERERERGRRKECS0REREREpJqowBIREREREakmKrBERERERESqiQos\nERERERGRaqICS0REREREpJqowBIREREREakmKrBEImJmb5nZBdW9bDnrdjczN7P6+7utCvYzz8xG\nV/d297CvbWbWsyb2JSJSW5jZCjM7JuocIrJ3poGGJV6Y2QrgUnd/L+osUTKzCwneh8MruXx3YDmQ\n7O7F1ZThKWC1u99SHdurYF8fAc+5++Ox3peISG1W0XHQzOpX1+d8XWBm9dy9JOocknh0BUsSxq4r\nNCIiItUtvHp0nZllmNkWM5toZinhvAvN7LPdlncz6x0+f8rM/hq2INhmZp+bWQcze8jMNpvZQjMb\nVsH+nwVSgSnhNq4v00LhEjNbBXwQLnuImX1hZrlmll62dYGZtTCzJ8ws28zWmNldZlYvnNfbzD4O\nv78NZjZxD1neMrOf7zYt3cxOt8CDZrbezLaa2RwzG7SH7VxkZgvMLM/MlpnZ5bvNP9XMZofbWWpm\nx4fTW5vZk2aWFb5//6rCz+FvZvammW0Hvm9mJ5nZN+E+Ms3stt3WP7zMe5kZ7mOEma3b9b6Fy51u\nZul7/glKneLueuhR4QNYAVwHZABbgIlASjjvQuCz3ZZ3oHf4/Cngr8BbwDbgc6AD8BCwGVgIDKtg\n/88CpcDOcBvXA93D/VwCrAI+CZc9BPgCyAXSgdFlttMCeALIBtYAdwH1wnm9gY/D728DMHEPWd4C\nfr7btHTgdMCAB4H1wFZgDjBoD9v5iOBM5H/eQ+C+8D1ZDpyw+7JAfyAfKAnfh9xw/knAN+E+M4Hb\nyqy7632qX85+08Pt7Hr4rvcLeAlYG74fnwADw+njgSKgMFxnSpnfkWPC5w3Dn29W+HgIaBjOGw2s\nBq4N36ds4KI9vEd3h99rfrivP+/v7xfQCZgM5ITv85VR/33poYcetf8RfsbNCD9DWgMLgJ+G8y6k\n4uPgBuBgIIWgEFoOnA/UIzgWfVjJDMeUeb3r8/0ZoAnQCOgMbAROJDiRfmz4um24zqvAP8Ll24Xf\n0+XhvAnAzeF6KcDhe8hxPvB5mdcDCI65DYHjgFlAS4JjYn+g4x62cxLQK1zuKGAHcFA4byTB8efY\nME9noF84byrB/yGtgGTgqCr8HLYAh5X5HkcDg8PXQ4B1wGnh8t2APGBcuJ8DgKHhvPl89zj9KnBt\n1L+netSOh65gSVWMBY4HehB8CF1YxXVvAdoABcCXwNfh65eBB/a2srufR1BEjXH3pu5+b5nZRxF8\ngB9nZp0JPnjvIjgAXgdMNrO24bJPAcUExdQw4IcEhQvAncC7BB/YXYA/7SHOBIIPWwDMbADBh/DU\ncHtHAgcSFHNjCQ5slTEKWETwntwLPGFmttv7sAD4KfBl+D60DGdtJzjgtSQ4YF1hZqdVtEN3Twu3\n0xS4Jtz/1+Hst4A+BAfgr4Hnw3UeDZ/fG647ppxN30xQ6A4F0ggOlGWbE3YgeH86ExTIfzGzVuXk\nuxn4lKCgberuP999mVClfr/MLAmYQlBYdgaOBq4ys+P28jaJiOzyiLtnufsmgs+SoVVY91V3n+Xu\n+QT/jOe7+zMeNFGbSHBM2le3uft2d98JnAu86e5vunupu08DZgInmll7gsLrqnD59QQnBX8cbqeI\n4HjWyd3z3f2zcvZFmH+omXULX58DvOLuBeE2mgH9CG5FWeDu2eVtxN2nuvtSD3xMcAw+Ipx9CfBP\nd58Wfh9r3H2hmXUETiAobje7e1G4bmW95u6fh9vMd/eP3H1O+DqD4Bh/VLjsT4D33H1CuJ+N7j47\nnPc0wXuNmbUmKCxfqEIOSWAqsKQqdGAJvxeq4cBSjpXu/lj4njwNdATaV2bFCg4QFTKzwwmK0lPc\nfWu4zX+6e174fd0GpJlZi0pu8hzgDndf7+45wO3AeWXmF4Xzi9z9TYIrT30rm7cclf39GkFwFvcO\ndy9092XAY/z3d0BEZG/Wlnm+A2hahXXXlXm+s5zXVdnW7jLLPO8GnBU2acs1s1zgcIJjSjeCKzHZ\nZeb9g+BEGgStQwyYYUHHRReXtzN3zyM4qbjrs3Mc/z0J9wHwZ+AvwHoze9TMmpe3HTM7wcz+bWab\nwiwnEpwYA+gKLC1nta7AJnffXMF7sidl3yvMbJSZfWhmOWa2heAkZkUZAJ4DxphZE4KTfJ9W4Xgv\nCU4FllSFDixU34GlHP95f919R/i0Uu9LBQeIitbtCkwCLnD3xeG0emZ2T9jmfStBsxQqu02CJjQr\ny7xeGU7bZaN/90bsqv4+7a6yv1/dgE67/X7cRCULWRGRPdgONN71wsw6xGg/e+qZrOz0TOBZd29Z\n5tHE3e8J5xUAbcrMa+7uAwHcfa27X+bunYDLgb/uun+pHBOAcWZ2KEFTuw//E8b9EXc/mKDp4IHA\nr3Zf2cwaEjTXvg9oH7bIeJPgOLzr++hVzn4zgdZm1rKceZX5Oez+Hr4AvA50dfcWwN8rkQF3X0PQ\nWuJ0ghOIz5a3nNRNKrCkOujAUsUDy34q733Y2wFij8ysEfAv4CF3f6vMrJ8ApwLHEDTl675rlb1k\nKCuLoJjZJTWcti+qs6vTTGD5br8fzdz9xGrch4jUPenAQDMbakHHF7fFaD/rgIqGqNh1ZeW48GRZ\nipmNNrMu4RWWd4H7zay5mSWZWS8zOwrAzM4ysy7hdjYTfP6W7mE/bxJ8zt9BcM9yabiNEeFJv2SC\n/w/y97CNBgT3bOUAxWZ2AkEz+12eAC4ys6PDnJ3NrF/4PbxFcIxuZWbJZnZkuM6+/ByaEVwRyzez\nkQTHv12eB44xs7FmVt/MDjCzsq13niE4OTsYeKUS+5I6QgWWVAcdWKp+YNkf64AuZtagzLS9HSD2\n5p/AQv/uPW27tldAcP9YY+B35WTY289iAnCLmbU1szbAbwl+NvuiMj/3ypoB5JnZDWbWKPwdGWRm\nI6pp+yJSB4VX/+8A3gO+Jei0KBZ+T/DZmmtm1+0hSybBCbKbCIqXTIITfbv+5zufoLiZT3Cse5mg\nlQcEzainm9k2gpN2vwybUpe3nwKCouIYvnvvUXOCptebCVovbAT+WM76ecCVBC0oNhMct14vM38G\ncBFBU/4tBJ1Q7Tpxdx5BU/OFBJ0lXRWusy8/h58Bd5hZHsGxalKZDKsImi1eC2wCZhPcV7zLq2Gm\nV8u0PBFRL4J6VO7B//ZcdBvB2ES7Xt9M0ENSJsF9ULv32nNXmWUvBT4q87o3UFyJDKcSdHSRS9B5\nRXfK9I5XZrlRBB/EmwgOLlOB1HBeC+BvBL3YbSHoee/H4bx7CXoW3EbQ5np8BXmeCPc/osy0owl6\nWtwWvh/PA033sP5H7NaL4G7zy76HZZdtEH5Pm4AN4bQzCQ5kecAbBM0Unwvnfed92m1bTtA8r2xP\ngkcQNKl7LdzeSoIDctk8fQgONLnAv3b/HSG4qvcIQQ+B2eHzXb1OjiYYQ2uPv1+7zTsUWExwAH6k\nnPfmKarw+0XQVHECQZPMzcC/97RvPfTQQw899NjbI/x/QccQPb7z0EDDIiIiIiJVZGZnAH8ADvSw\nJYsIgAZmFREREakFzCyVoOleeQZ40GRNagEz+4jgXuvzVFzJ7nQFS2oNHVhEREREJN6pwBIRERER\nEakmcdFEsE2bNt69e/eoY4iISIzMmjVrg7u3jTrHvtJxSkQksVXlOBUXBVb37t2ZOXNm1DFERCRG\nzGxlxUvFZL+/BC4jGOPtMXd/yMxaAxMJeuBcAYx19817246OUyIiia0qxymNgyUiInWSmQ0iKK5G\nEoxtc3I4uPiNwPvu3gd4P3wtIiJSKSqwRESkruoPTHf3He5eTDB+3ukEY+49HS7zNHBaRPlERCQO\nqcASEZG6ai5whJkdYGaNgROBrkB7d88Ol1kLtI8qoIiIxJ+4uAdLRESkurn7AjP7A/AusB2YDZTs\ntoybWbnd7ZrZeGA8QGpqaozTiohIvNAVLBERqbPc/Ql3P9jdjwQ2A4uBdWbWESD8un4P6z7q7sPd\nfXjbtnHbAaKIiFQzFVgiIlJnmVm78Gsqwf1XLwCvAxeEi1wAvBZNOhERiUdqIigiInXZZDM7ACgC\n/s/dc83sHmCSmV0CrATGRppQRETiigosERGps9z9iHKmbQSOjiCOiIgkADURFBERERERqSYqsERE\nRERERKqJCiwREREREZFqogJLRERERESkmqjAEhERERERqSYqsEREZJ8VFJdEHUFERKRWUTftIiKy\nT7Jyd3LxU19x3qHdOGdUt6jjiIhIAistdb7J3MyU9Gw+X7KB4lKv0vpvXnkEjRrUi1G671KBJSIi\nVTY/aysXPTWDHQUldD+gSdRxREQkAbk787K2MiU9izcyslmTu5OG9ZM4rHcbmjasWhljFqOQ5VCB\nJSIiVfLJ4hx+9vzXNEupz0tXHEq/Ds2jjiQiIgnk23V5TEnPYkpGNss3bKd+knHkgW351XF9OWZA\n+yoXVzWtdqcTEZFaZdJXmfz61Tn0adeUpy4aSYcWKVFHEhGRBLBy43beyMhmSnoWC9fmkWTwvV5t\nuPzInhw/qAMtGzeIOmKlqcASEZEKuTsPvvctj7z/LUf0acNfzzmIZinJUccSEZE4lr1lJ1PDoip9\n9RYAhndrxe2nDOSEwR1o1yw+T+KpwBIRkb0qLC7lxlcyeOXrNZx1cBd+d/pgkuupE1oREam6DdsK\neGtONlPSs5mxYhMAgzo356YT+3HSkE50btko4oT7TwWWiIjs0db8Iq54bhafL9nINcceyC9+0Bur\nyTuFRUQk7m3ZUcQ789YyJSOLz5dsoNShT7umXHvsgZyc1okebRKrsyQVWCIiUq6s3J1c9ORXLM3Z\nxn1npXHmwV2ijiQiInFie0Ex7y1Yx5T0LD5enENRidPtgMb8bHRvxqR1om+HZlFHjBkVWCIi8j/K\ndsP+1EUjObxPm6gjiYhIOXb1uDc3a2vUUf6jsLiUmSs3kV9USscWKVz4ve6MSevE4M4t6kQrCBVY\nIiLyHeqGXUSkdiuvx70D2zerNffHmsHY4V0Zk9aJg1NbkZSU+EVVWSqwREQECHoKnDAjk9++Npfe\n6oZdRKRWSdQe9xKRCiwREWH91nxuenUO7y1Yr27YRURqiQ3bCnhr7lqmzM76T497gzu3SKge9xKR\nCiwRkTrM3Xltdha3vj6P/KISbjmpPxcd1oN6daw5h4hIbTJr5WYeem8xXyzdSEmpJ3SPe4lIBZaI\nSB21Pi+fm1+dy7T56zgotSV/PCuNXm2bRh1LRKTOKiwu5eH3F/O3j5bSrlkKVxzVK+F73EtEMSuw\nzCwF+ARoGO7nZXe/1cyeAo4CtoSLXujus2OVQ0REvsvdeT09uGq1o7CEm0/sz8WH66qViEiUFq7d\nytUT01mQvZWzh3fllpP7q6l2nIrlFawC4Afuvs3MkoHPzOytcN6v3P3lGO5bRETKsWFbAbe8Ope3\n561laNeW3HdWGr3b6aqViEhUSkqdxz5dxgPvLqZ5o/o8dv5wjh3QPupYsh9iVmC5uwPbwpfJ4cNj\ntT8REdm7NzKy+M2/5rK9sIQbT+jHZUf01FUrEZEIrdq4g2tfms1XKzZz/MAO3P2jQRzQtGHUsWQ/\nxfQeLDOrB8wCegN/cffpZnYFcLeZ/RZ4H7jR3QvKWXc8MB4gNTU1ljFFRBLaxm0F/Oa1ubw5Zy1p\nXVpw31lp9Gmv9vwiIlFxd178KpM735hPvSTjwbPTOG1o5zoxCG9dENMCy91LgKFm1hJ41cwGAb8G\n1gINgEeBG4A7yln30XA+w4cP15UvEZF9MG3+Om6cnEFefjHXH9+X8Uf0pH4tGYhSRKQuWr81nxsm\nZ/DhohwO630AfzwzjU7qbj2h1Egvgu6ea2YfAse7+33h5AIzexK4riYyiIjUJaWlzsPvf8vD73/L\noM7NeeGsoeqFSkQkYlMzsrn5X3PYWVjCbWMGcP6h3UlSU+2EE8teBNsCRWFx1Qg4FviDmXV092wL\nroGeBsyNVQYRkbooL7+IayalM23+Os46uAt3njaIlOR6UccSEamT3J0F2Xn8/eOlvJ6eRVqXFtw/\ndqg6GEpgsbyC1RF4OrwPKwmY5O5vmNkHYfFlwGzgpzHMICJSpyzfsJ3LnpnJ8g3buW3MAC74Xne1\n6RcRicDSnG1MSc9iSnoWS3O2Uz/JuObYA/nZ6F5qqp3gYtmLYAYwrJzpP4jVPkVE6rKPFq3nFxO+\noX6S8ewlI/lerzZRRxIRqVMyN+3gjYxspqRnMT97K2YwsntrLjqsBycM6qAeAuuIGrkHS0REYsfd\n+fvHy7j3nYX069CcR887mK6tG0cdS0SkTli3NZ+pGdlMycjim1W5AAzt2pLfnDyAkwZ3pEOLlIgT\nSk1TgSUiEsd2FpZw/eQMpqRncfKQjtx75hAaN9BHu4gklpJS56sVm1iyflvFC9eQnYUlfLBwPf9e\nvhF36N+xOdcf35cxQzrpJFcdp6OwiEicyty0g8ufncWCtVu54fh+/PSonrrfSkQShrszOzOXKenZ\nTJ2Txbqt/zNsauR6tmnClT/ow5i0jvRup55aJaACS0QkDn25dCP/98LXFJWU8s8LRvD9fu2ijhS3\nzOxq4FLAgTnARQQdNb0IHADMAs5z98LIQorUEbt63JuSEXQOsXrzThrUS2J037aMSevEiO6tSaol\n/UMkmXFAkwY6sSX/QwWWiEgccXee+XIld7wxn+4HNOax84fTs626+t1XZtYZuBIY4O47zWwS8GPg\nROBBd3/RzP4OXAL8LcKoIglt9x736iUZh/duw1XHHMixA9rTolFy1BFFKk0FlohInHB37pq6gCc+\nW84x/dvx4NlDaZaifzqqQX2gkZkVAY2BbOAHwE/C+U8Dt6ECS6Rabd5eyItfZf5Pj3sXH96D4weq\nxz2JXyqwRETixP3vLuaJz5Zz4fe689uTB5CUpGYp+8vd15jZfcAqYCfwLkGTwFx3Lw4XWw103n1d\nMxsPjAdITU2tmcAiCeKDheu4YfIccvIK1OOeJBwVWCIiceAvHy7hzx8uYdzIVG4dM0Bt/quJmbUC\nTgV6ALnAS8DxlVnX3R8FHgUYPny4xyqjSCLZVlDM3VPnM2FGJv06NOPJC0cwqHOLqGOJVCsVWCIi\ntdyTny/nj+8s4rShnbjrtEEqrqrXMcByd88BMLNXgMOAlmZWP7yK1QVYE2FGkYQwY/kmrn1pNqs3\n7+SnR/Xi6mP70LB+vahjiVQ7FVgiIrXYxK9WcfuU+Rw3sD33nZVGPTULrG6rgEPMrDFBE8GjgZnA\nh8CZBD0JXgC8FllCkTiXX1TCg9MW8+iny+jaqjGTLj+UEd1bRx1LJGZUYImI1FKvzV7Dja/M4agD\n2/LIuGHUr1dL+iZOIO4+3cxeBr4GioFvCJr9TQVeNLO7wmlPRJdSJH7Ny9rCNRPTWbQuj5+MSuXm\nE/vTpKH+/ZTEpt9wEZFa6J15a7lmUjoju7fm7+cerGY0MeTutwK37jZ5GTAygjgiCaG4pJR/fLKM\nh95bTKvGDXjyohF8v6/G65O6QQWWiEgt8/HiHH7xwjcM7tyCJy4cQaMGKq5EJH4s37CdayfN5utV\nuZw8pCN3njqIVk0aRB1LpMaowBIRqUWmL9vI5c/OpFe7pjx90UiaqimNiMQJd+e56av43dQFNKif\nxCPjhnFKWqeoY4nUOB25RURqidmZuVz81Fd0btmIZy8ZSYvGGkRYROLD2i35XD85g08W53DkgW25\n94whGtNK6iwVWCIitcD8rK2c/8R0DmjakOcvPYQ2TRtGHUlEpELuzuvpWfzmX3MpKnHuPG0Q545K\n1XASUqepwBIRidiS9ds474npNGlYn+cvHaWzviISFzZvL+SW1+YyNSObg1Jb8sDYoXRv0yTqWCKR\nU4ElIhKR/KISPl6cw62vzcMMnrt0FF1bN446lohIhT5cuJ7rJ2eQu6OQ64/vy+VH9tI4fSIhFVgi\nIjWooLiETxdvYOqcbKbNX8e2gmLaNWvIc5eOolfbplHHExHZq+0Fxdw1dQETZqyiX4dmPH3RSAZ0\nah51LJFaRQWWiEiMFRaX8vmSDbyRkc2789eSl19Mi0bJnDi4AycP6cShvQ4gWYMIi0gt99WKTVw7\nKZ3MzTu4/KieXHPsgRqjT6QcKrBERGKgqKSUL5du5I2MLN6Zt44tO4tollKfHw7owMlpHTmsVxsa\n1FdRJSK1X0FxCQ9MW8yjnyyjS6tGTLr8UEZ0bx11LJFaSwWWiEg12rKziHvfXsibc7LZvKOIpg3r\nc+yA9pw8pCOH92mjs70iElfmZW3hmonpLFqXx7iRqdx8Un+NzydSAf2FiIhUk20FxVz45AzmrtnC\nCYM6cvKQjhx5YFtSklVUiUj82LKziHfnrWVKRjafL9lA6yYNePLCEXy/X7uoo4nEBRVYIiLVIL+o\nhEuf/oqM1Vv42zkH8cOBHaKOJCJSaTsKi3lvwXqmpGfx8aIcCktK6dq6EZcf2ZPLjuhJqyYNoo4o\nEjdUYImI7KeC4hIuf3YW05dv4qGzh6q4EpG4sGuoiCnpWby/YD07i0po37wh5x3ajTFpnUjr0kID\nBovsAxVYIiL7oaiklF+88A0fL87h3jOGcOrQzlFHEhHZo6KSoFfTKenZvDtvLXkFxbRu0oAzDu7M\nmCGdGNG9NUkaz0pkv6jAEhHZRyWlzrWT0nl3/jpuP2UgY0d0jTqSiMgevTd/HTe9Oof1eQU0S6nP\n8YM6MCatE9/rdQD1NVSESLVRgSUisg9KS52bXpnD6+lZ3HB8Py74XveoI4mIlCsvv4i73ljAxJmZ\n9OvQjLtOG8RRfduqV1ORGFGBJSJSRe7OHW/MZ+LMTK78QW+uGN0r6kgiIuWavmwj176UTlbuTn42\nuhe/PKaPCiuRGFOBJSJSBe7Ove8s4qkvVnDp4T24+tgDo44kIvI/8otKuP/dRTz+2XJSWzdm0uWH\nMlyDA4vUCBVYIiJV8OcPlvC3j5ZyzqhgwE31sCUitc3cNVu4euJsvl2/jXNGpXLTif1posGBRWqM\n/tpERCrp8U+Xcf+0xZx+UGfuPHWQiisRqVWKS0r520dLefj9b2ndpAFPXTSC0X01OLBITVOBJSJS\nCc/9eyV3TV3ASYM7cu8ZQ9SNsYjUKstytnHNpHRmZ+YyJq0Td546kJaNNTiwSBRUYImIVGDyrNXc\n8q+5/KBfOx48e6i6MxaRWqO01Hlu+kp+9+YCGtavxyPjhnFKWqeoY4nUaSqwRET2YtbKzVw/OYPD\neh/AX885iAb1VVyJSPRydxTy9ty1TJqZyderchndty1/OGMI7ZunRB1NpM5TgSUisgfbCoq5euJs\nOrZI4e/nHkxKsro2FpHo5OUX8d6CdUxJz+aTxTkUlzo92jThdz8azLiRXXVfqEgtoQJLRGQP7pwy\nn9Wbd/Di+ENplpIcdRwRqYN2Fpbw4aL1TEnP4oOF6ykoLqVzy0ZcckQPxgzpxMBOzVVYidQyMSuw\nzCwF+ARoGO7nZXe/1cx6AC8CBwCzgPPcvTBWOURE9sU789YycWYmPxvdi5E9NHaMiNScwuJSPv02\nhynpWUybv47thSW0bdaQcSNTGZPWiWFdW6qjHZFaLJZXsAqAH7j7NjNLBj4zs7eAa4AH3f1FM/s7\ncAnwtxjmEBGpkvV5+fz6lTkM6tycq47RQMIiUjPcnT9/sITHPl3G1vxiWjZO5pShnRmT1pFRPQ6g\nnooqkbgQswLL3R3YFr5MDh8O/AD4STj9aeA2VGCJSC3h7lz/cgbbC4p56Oyh6tRCRGrM/e8u5s8f\nLuGY/u05Z1Qqh/dpQ7J6LRWJOzG9B8vM6hE0A+wN/AVYCuS6e3G4yGqg8x7WHQ+MB0hNTY1lTBGR\n/3hu+io+WpTD7acMpHe7ZlHHEZE64k/vf8ufP1zCuJFdufu0wWoCKBLHYnpaxN1L3H0o0AUYCfSr\nwrqPuvtwdx/etm3bmGUUEdllac427p46nyMPbMv5h3aLOo6I1BH/+Hgp909bzOnDOqu4EkkANXLd\n2d1zgQ+BQ4GWZrbrylkXYE1NZBAR2ZuiklKunjibRsn1+OOZQ9Qrl4jUiKc+X87v31rIyUM6cu+Z\nQ1RciSSAmBVYZtbWzFqGzxsBxwILCAqtM8PFLgBei1UGEZHKeuT9b8lYvYXfnz5YA3WKSI14Yfoq\nbpsynx8OaM+DZw+lvu63EkkIsfxL7gh8aGYZwFfANHd/A7gBuMbMlhB01f5EDDOIiFRo1spN/OXD\nJZx1cBeOH9Qx6jhSg8ysr5nNLvPYamZXmVlrM5tmZt+GX1tFnVUSy8uzVnPzv+bw/b5t+dNPhqkz\nC5EEEsteBDOAYeVMX0ZwP5aISOS2FRRz9cR0OrdqxK2nDIw6jtQwd18EDIX/dMy0BngVuBF4393v\nMbMbw9c3RBZUEsrr6Vlc/3I6h/Vqw9/OPZiG9etFHUlEqpFOl4hInXbHlHms3ryDB8cOpWnDmHas\nKrXf0cBSd18JnEowlAjh19MiSyUJ5e252Vw9cTbDu7fmsfOHk5Ks4kok0ajAEpE66515a5k0czU/\nG92b4d1bRx1HovdjYEL4vL27Z4fP1wLtd1/YzMab2Uwzm5mTk1NTGSWOvb9gHb+Y8A1pXVrwzwtH\n0KiBiiuRRKQCS0TqpPVb87lxcgaDO7fgl8f0iTqORMzMGgCnAC/tPs/dHfBypms4Eam0TxbncMVz\nX9O/Y3OeunikrpiLJDAVWCJS57g710/OYGdRCQ+ePVQ3lwvACcDX7r4ufL3OzDoChF/XR5ZM4t6X\nSzcy/tk60H++AAAgAElEQVSZ9GzbhGcuHknzlOSoI4lIDOm/ChGpc57790o+WpTDzSf2p3e7plHH\nkdphHP9tHgjwOsFQIqAhRWQf7Sws4dVvVnPJ01/RtVVjnr90FC0bN4g6lojEmK5Pi0idsixnG3e/\nuYDRfdty7iHdoo4jtYCZNSEYq/HyMpPvASaZ2SXASmBsFNkk/hQUl/DJ4g1MSc/ivQXr2FFYQp92\nTXn+0lEc0LRh1PFEpAaowBKROqOk1Ln2pXQa1q/HH84YgplFHUlqAXffTjAuY9lpGwl6FRSpUHFJ\nKV8s3ciU9CzenreWvPxiWjVO5rRhnRkzpBMje7SmXpI+b0TqChVYIlJn/OOTpXyzKpdHxg2jffOU\nqOOISBwrLXW+WrGJKRlZvDVnLRu3F9KsYX1+OLADY9I6cljvNrq/U6SOUoElInXCwrVbeXDaYk4a\n3JExQzpGHUdE4pC7k756C1PSs5iakc3arfmkJCdxTP/2jEnrxFEHttW4ViKiAktEEl9hcSlXT0yn\nRaMG3HnaIDUNFJFKc3cWrs1jSnoWUzKyyNy0kwb1kjiqb1tuSuvP0f3a0URdrotIGfpEEJGE96cP\nvmVB9lYeO384rZuoBy8RqdiynG1MSc9mSkYWS9Zvo16ScVjvNlz5gz78cGAHWjRSV+siUj4VWCKS\n0GZn5vLXj5Zy5sFdOHZA+6jjiEgttnrzDt7IyGZKehbzsrZiBiO7t+bC0wZxwqAO6gVQRCpFBZaI\nJKz8ohKumTSb9s0a8tsxA6KOIyK1UFFJKRNmrOK12VnMWrkZgKFdW/Kbkwdw0uCOdGihDnFEpGpU\nYIlIwvrjO4tYlrOd5y8dRfMUNecRkf91z1sLeeKz5fTv2Jzrj+/LyYM7kXpA46hjiUgcU4ElIgnp\n38s28s/Pl3PBod04rHebqOOISC304cL1PPHZcs4/tBt3nDoo6jgikiA0QIOIJJxtBcVc91I63Vo3\n5oYT+kUdR0RqofVb87nupXT6dWjGTSf2jzqOiCQQXcESkYRz99T5ZOXu5KWfHkrjBvqYE5HvKi11\nrp40m+2FxUz8ySEau0pEqpWuYIlIQvlw0XomzMhk/JG9OLhb66jjiEgt9I9PlvH5ko3cNmYgvds1\nizqOiCQYFVgikjBydxRyw8sZ9G3fjKuP7RN1HBGphb5ZtZn7313ESYM7cvaIrlHHEZEEpLYzIpIw\nbn19Hpu2F/LPC0fQsL6a/IjId23NL+LKF7+hffMUfnf6YMws6kgikoB0BUtEEsKbc7J5bXYWVx7d\nh0GdW0QdR0RqGXfnllfnkpWbzyPjhtKikYZuEJHYUIElInEvJ6+Am1+dw5AuLbhidK+o44hILTT5\n6zW8np7FVUf30f2ZIhJTaiIoIrVOQXEJGau3sC2/mLyCYvLyi9iWX8y2gmLy8oPHtoKi/7zO3pLP\n9sISHhibRnI9nTcSke9alrON3742l0N6tuZn3+8ddRwRSXAqsESkVikuKeWcx6Yzc+Xm/5mXZNC0\nYX2apSSHX+vTukkDUls35tShndUbmIj8j4LiEn4x4Rsa1E/iobOHUS9J912JSGypwBKRWuWR979l\n5srN3HJSfw7u1opmKck0S6lP04b1adygnm5KF5EqufftRczL2spj5w+nQ4uUqOOISB2gAktEao3p\nyzby5w+XcMZBXbj0iJ5RxxGROPfhwvU88dlyLji0G8cOaB91HBGpI3SzgojUClt2FHH1xNmktm7M\n7acOjDqOiMS59Vvzue6ldPp1aMavT+wfdRwRqUN0BUtEIufu/PrVDNbnFTD5iu/RtKE+mkRk35WW\nOtdMSmd7YTEvjjuElGSNiyciNUdXsEQkchO/yuTNOWu57ri+pHVtGXUcEYlz//hkGZ8t2cCtYwbS\np706vxGRmqXTxCISqSXrt3H7lPkc1vsAxuu+KxHZD8Ulpfzjk2U8MG0xJw3uyI9HdI06kojUQSqw\nRCQyBcUlXDnhG1KSk3hg7FCS1H2yiOyjFRu2c82k2Xy9KpeThnTkntMHq9dREYmECiwRicy9by9i\nfvZWHj9/OO2bq/tkEak6d+e56av43dQFJNczHhk3jFPSOkUdS0TqMBVYIhKJjxYF3Seff2g3jlH3\nySKyD9Zuyef6yRl8sjiHI/q04Y9npmmsKxGJnAosEalxOXkFXPdSOn3bN+MmdZ8sIvvgtdlr+M2/\n5lJU4tx52iDOHZWqJoEiUiuowBKRGlVa6lz3Ujp5+cU8f6m6TxaRqtm8vZDfvDaXNzKyOSi1JfeP\nHUqPNk2ijiUi8h8qsESkRj35xQo+XpzDnacOpG8HdZ8sIpX34aL13PByBpt3FPKr4/py+ZE9qV9P\nI86ISO2iAktEasy8rC384a2FHNO/Pece0i3qOCISJ7YXFHPX1AVMmLGKvu2b8eRFIxjYqUXUsURE\nyhWzAsvMugLPAO0BBx5194fN7DbgMiAnXPQmd38zVjlEpHbYUVjMlRO+oVWTZO49c4julRCRSpm5\nYhPXTEonc/MOLj+qJ9cceyAN66tpsYjUXrG8glUMXOvuX5tZM2CWmU0L5z3o7vfFcN8iUsvc+cZ8\nlm3YznOXjKJ1kwZRxxGRWq6guIQHp33LPz5ZSpdWjZg4/lBG9mgddSwRkQrFrMBy92wgO3yeZ2YL\ngM6x2p+I1E4FxSU89skyJszI5KdH9eKw3m2ijiTyHWbWEngcGETQ4uJiYBEwEegOrADGuvvmiCLW\nOfOztnLNpNksXJvHuJGp3HxSf5o21F0NIhIfauTOUDPrDgwDpoeTfm5mGWb2TzNrtYd1xpvZTDOb\nmZOTU94iIlKLuTtvz13LsQ98wn3vLua4ge259ocHRh1LpDwPA2+7ez8gDVgA3Ai87+59gPfD1xJj\nJaXOXz9awql/+YyN2wt58sIR/P70wSquRCSuxPwTy8yaApOBq9x9q5n9DbiT4CzhncD9BGcLv8Pd\nHwUeBRg+fLjHOqeIVJ+5a7Zw5xvzmb58Ewe2b8ozF4/kyAPbRh1L5H+YWQvgSOBCAHcvBArN7FRg\ndLjY08BHwA01n7DuWLFhO9e+lM6slZs5aXBH7jptEK3UnFhE4lBMCywzSyYorp5391cA3H1dmfmP\nAW/EMoOI1Jz1efnc984iXpq1mpaNkrnztEGMG9FV3ShLbdaDoNOlJ80sDZgF/BJoHzZ1B1hL0GHT\nd5jZeGA8QGpqas2kTUDuzvPTV3H31AUk1zMe/vFQTknrpI5wRCRuxbIXQQOeABa4+wNlpncsc9D6\nETA3VhlEpGbkF5XwxGfL+euHSygsKeXSw3vw8x/0oUWj5KijiVSkPnAQ8At3n25mD7Nbc0B3dzP7\nn5YUammx/9Zuyef6yRl8sjiHI/q04Y9nptGhRUrUsURE9kssr2AdBpwHzDGz2eG0m4BxZjaUoIng\nCuDyGGYQkRhyd6bOyeb3by5kTe5Ojh3QnptO7E+PNk2ijiZSWauB1e6+6x7hlwkKrHW7TgiaWUdg\nfWQJE9Tr6Vn85l9zKSgu4c5TB3LuId101UpEEkIsexH8DCjvk1JjXokkgIzVudwxZT4zV26mX4dm\nvHDpKL6nHgIlzrj7WjPLNLO+7r4IOBqYHz4uAO4Jv74WYcyE4u7c9OocJszIZFhqSx4YO1QnZUQk\noahbHhGpstdmr+GXL86mTdMG/P70wYwd3pV6STrzLHHrF8DzZtYAWAZcRNDL7iQzuwRYCYyNMF9C\nmTAjkwkzMhl/ZE+uP66v7tEUkYRTpQLLzJoA+e5eEqM8IlLLrdy4nZtemcPwbq148qIRNEvRfVYS\n39x9NjC8nFlH13SWRLd4XR63T5nHEX3acOPx/UjSiRkRSUB7PW1kZklm9hMzm2pm64GFQLaZzTez\nP5pZ75qJKSK1QWFxKVdO+IZ6ScbD44apuBKRSssvKuHKCd/QLKU+949NU3ElIgmrouvyHwK9gF8D\nHdy9q7u3Aw4H/g38wczOjXFGEaklHpi2mPTVW/jDGUPo3LJR1HFEJI787s0FLFybx31npdGumXoK\nFJHEVVETwWPcvWj3ie6+iWB8q8nhWFcikuA+/TaHv3+8lHEjUzlhcMeo44hIHHln3lqe+XIllx3R\ng9F920UdR0QkpvZ6BWtXcWVmvcysYfh8tJldaWYtyy4jIolrw7YCrpmUTu92TfntyQOijiMicSQr\ndyfXv5zB4M4t+NVx/aKOIyISc5XtumcyUBLec/Uo0BV4IWapRKTWKC11rnspnS07i/jTuGE0alAv\n6kgiEidKSp2rJs6muKSUR8YNo0F99RgoIomvsp90pe5eDPwI+JO7/wpQGyGROuDJL1bw0aIcbjmp\nP/07No86jojEkb98uIQZyzdx52mDNNaViNQZlS2wisxsHMFgi2+E03TvlUiCm7tmC394ayHH9G/P\neYd0izqOiMSRmSs28dB7i/nRsM6cflCXqOOIiNSYyhZYFwGHAne7+3Iz6wE8G7tYIhK17QXFXDnh\nG1o3acAfzxyCmbpUFpHK2bKjiF++OJuurRtzx6kDo44jIlKjKjXQsLvPB64s83o58IdYhRKR6N0+\nZR7LN27n+UtH0apJg6jjiEiccHdufCWDdVvzmXzF9zRenojUORUNNDzFzMaU1xW7mfU0szvM7OLY\nxRORKLyensWkmav5v9G9+V6vNlHHEZE4MmFGJm/NXcuvjutLWteWUccREalxFV3Bugy4BnjIzDYB\nOUAK0B1YCvzZ3V+LaUIRqVGZm3Zw8ytzOCi1Jb88pk/UcUQkjixel8ftU+ZxRJ82XHZEz6jjiIhE\nYq8FlruvBa4Hrjez7gQ9B+4EFrv7jpinE5EaVVRSypUvfgPAwz8eRnI9daksIpWTX1TClRO+oVlK\nfe4fm0ZSku7bFJG6qVL3YAG4+wpgRcySiEjkHn7vW75Zlcufxg2ja+vGUccRkTjyuzcXsHBtHk9d\nNIJ2zVKijiMiEhmdnhYRAL5YuoG/fLSEs4d3ZUxap6jjiEgceXfeWp75ciWXHdGD0X3bRR1HRCRS\nKrBEhFkrN3P1xNn0aNOEW08ZEHUcEYkj7s49by2kX4dm/Oq4flHHERGJXKULLDNrZGZ9YxlGRGpW\n5qYd/N8LX3PG377AHf487iAaN6h0y2EREb5YupFlG7Yz/sieNKiv87YiIpX6T8rMxgD3AQ2AHmY2\nFLjD3U+JZTgRiY0tO4v464dLePLzFSQlwS+P7sP4I3vSpKGKKxGpmme+XEHrJg04cXDHqKOIiNQK\nlf1v6jZgJPARgLvPNrMeMcokIjFSVFLKhBmreOi9b9m8o5AzDurCdT/sS4cWuiFdRKoue8tOps1f\nx/gje5GSXC/qOCIitUJlC6wid99i9p0uVz0GeUQkBtydDxau53dvLmBpznYO7XkAN5/Un0GdW0Qd\nTUTi2ITpq3DgnFGpUUcREak1KltgzTOznwD1zKwPcCXwRexiiUh1mZ+1lbvfnM/nSzbSs00THjt/\nOMf0b8duJ0xERKqksLiUF2Zk8v2+7TSsg4hIGZUtsH4B3AwUABOAd4A7YxVKRPbfuq353P/uIl6a\ntZoWjZK5bcwAzjmkmwYPFpFq8c68tWzYVsB5h3aLOoqISK1SqQLL3XcQFFg3xzaOiFSHjNW5nPP4\ndPKLSrj08B78/Pt9aNE4OepYIpJAnv33SlJbN+aoPm2jjiIiUqtUthfB4cBNQPey67j7kNjEEpF9\ntXDtVs7/5wxaNk7mmYsPp0ebJlFHEok5Mxvs7nOizlFXLFy7lRnLN3HTif1ISlJzYxGRsirbRPB5\n4FfAHKA0dnFEZH8sy9nGuY/PIKV+PV649BDdFyF1yV/NrCHwFPC8u2+JOE9Ce+7fK2lQP4mzDu4a\ndRQRkVqnsgVWjru/HtMkIrJfMjft4JzHpwPO85epuJK6xd2PCDthuhiYZWYzgCfdfVrE0RJOXn4R\nr369hjFDOtGqSYOo44iI1DqVLbBuNbPHgfcJOroAwN1fiUkqEamS7C07+cnj/2ZHYQkvjj+EXm2b\nRh1JpMa5+7dmdgswE3gEGGZBd5k36XhVfV79Zg3bC0s4X51biIiUq7IF1kVAPyCZ/zYRdEAHLJGI\n5eQVcM7j09m8vYjnLx1F/47No44kUuPMbAjBseokYBowxt2/NrNOwJfoeFUt3J1nv1zJkC4tSOva\nMuo4IiK1UmULrBHu3jemSUSkynJ3FHLeE9PJyt3JMxeP0j88Upf9CXic4GrVzl0T3T0rvKol1WD6\n8k18u34b956pPq5ERPaksgXWF2Y2wN3nxzSNiFRaXn4RF/xzBstytvPEhcMZ2aN11JFEonQSsNPd\nSwDMLAlIcfcd7v5stNESx7NfrqRFo2ROSesUdRQRkVqrsiOOHgLMNrNFZpZhZnPMLCOWwURkz3YU\nFnPxU18xL2srfz3nII7QODQi7wGNyrxuHE6TarJuaz7vzFvL2OFdSEmuF3UcEZFaq7JXsI6PaQoR\nqbT8ohLGPzOLWSs388i4YRwzoH3UkURqgxR337brhbtvMzN1pVmNXpyRSXGpc84odW4hIrI3ey2w\nzKy5u28F8mooj4jsRVFJKT9/4Ws+W7KB+85K4+QhaqYjEtpuZge5+9cAZnYwsLOCdQiXXUFwnCsB\nit19uJm1BiYC3YEVwFh33xyD3HGhqKSUF2as5KgD29Jdg5eLiOxVRVewXgBOBmYR9BpYdrh2B3rG\nKJeI7Kak1Llq4mzeW7CeO08dyJkHd4k6kkhtchXwkpllERyrOgBnV2H977v7hjKvbwTed/d7zOzG\n8PUN1ZY2zrw3fx3rthZw92m6eiUiUpG9FljufnL4tUfNxBGR8mzZWcQt/5rL1IxsbjqxH+cd2j3q\nSCK1irt/ZWb9gF093i5y96L92OSpwOjw+dPAR9ThAuuZL1fSuWUjvt+vXdRRRERqvUp1cmFm71dm\nmohUL3dnSnoWxzzwMVMzsvjVcX0Zf2SvqGOJ1FZ9gQHAQcA4Mzu/kus58K6ZzTKz8eG09u6eHT5f\nC9TZmx2XrM/jy2UbOeeQVOolWcUriIjUcRXdg5VC0BNTGzNrxX+bCDYHOlewblfgGYKDkgOPuvvD\natcuUjmrNu7gltfm8sniHAZ3bsGTF45gUOcWUccSqZXM7FaCK04DgDeBE4DPCI5DFTnc3deYWTtg\nmpktLDvT3d3MvJx9jgfGA6Smpu7fN1CLPffvVTSol8TY4V2jjiIiEhcqugfrcoJ27Z0I7sPaVWBt\nBf5cwbrFwLXu/rWZNQNmmdk04ELUrl1kj4pKSnns02U8/N631E8ybhszgPMO7a4zxyJ7dyaQBnzj\n7heZWXvgucqs6O5rwq/rzexVYCSwzsw6unu2mXUE1pez3qPAowDDhw//nwIsEWwvKGbyrNWcOLgD\nbZo2jDqOiEhcqOgerIeBh83sF+7+p6psOGxakR0+zzOzBQRXvdSuXWQPZq7YxE2vzmHxum0cP7AD\nt54ygI4tGlW8oojsdPdSMys2s+YEBVGFl1zMrAmQFB6nmgA/BO4AXgcuAO4Jv74Wu+i1179mryGv\noFj3fYqIVEGlxsGqanG1OzPrDgwDplPJdu11pemFCEDujkL+8PZCJszIpHPLRjx+/nCNbyVSNTPN\nrCXwGEGLi23Al5VYrz3wqplBcEx8wd3fNrOvgElmdgmwEhgbm9i1l7vz7JcrGdCxOQeltow6johI\n3KjsQMP7zMyaApOBq9x9a3gQA/bcrj2cl/BNL0TcnddmZ3HnG/PJ3VnE+CN78suj+9CkYcz/NEUS\nhgUHlt+7ey7wdzN7G2ju7hkVrevuywiaFu4+fSNwdLWHjSMzV25m4do8fn/6YMoeu0VEZO9i+l+c\nmSUTFFfPu/sr4eQK27WL1AWrNu7gplfn8NmSDaR1bckzPxrEwE7qxEKkqsKTdW8Cg8PXK6JNlBie\n/XIlzVLqc+pQDWguIlIVlS6wzKwz0K3sOu7+yV6WN+AJYIG7P1Bmltq1S523s7CEc5+Yzubthdx5\n6kB+MqqbOrEQ2T9fm9kId/8q6iCJICevgLfmZnPuId1o3EBX1EVEqqJSn5pm9gfgbGA+UBJOdmCP\nBRZwGHAeMMfMZofTbiIorOp0u3aRB99bzKpNO3hx/CEc0vOAqOOIJIJRwDlmthLYTtDrrbv7kGhj\nxafJX6+mqMQ595BuUUcREYk7lT0tdRrQ190LKrthd/+M/3brvrs63a5d6raM1bk8/ukyxo1MVXEl\nUn2OizpAIpmxfBO92zWlV9umUUcREYk7SZVcbhmQHMsgInVBUUkpN0yeQ5umDbnxhH5RxxFJJL6H\nh1SRu5OxOpchXXRPqIjIvqjsFawdwGwzex/4z1Usd78yJqlEEtRjny5jQfZW/n7uwbRopHMWItVo\nKkFBZUAK0ANYBAyMMlQ8ytqSz4ZthQztqq7ZRUT2RWULrNfDh4jso+UbtvPQe99y/MAOHD+oQ9Rx\nRBKKuw8u+9rMDgJ+FlGcuJaemQvAkC4qsERE9kVlBxp+2swaAAeGkxa5e1HsYokkltJS58bJGTSs\nn8Ttp+qEukisufvXZjYq6hzxKH11Lsn1jP4dm0UdRUQkLlW2F8HRwNPACoLmF13N7IK9ddMuIv81\naWYm05dv4venD6Z985So44gkHDO7pszLJOAgICuiOHEtI3ML/To0p2H9elFHERGJS5VtIng/8EN3\nXwRgZgcCE4CDYxVMJFGs35rP3W8uYFSP1pw9vGvUcUQSVdnLLcUE92RNjihL3Cotdeau2cIpGlxY\nRGSfVbbASt5VXAG4+2Iz0x36IpVw6+vzKCgu5Z4zhpCkwYRFYsLdb486QyJYtmE7eQXFpKmDCxGR\nfVbZbtpnmtnjZjY6fDwGzIxlMJFE8Pbctbw1dy1XHdOHHm2aRB1HJGGZ2TQza1nmdSszeyfKTPEo\nY3XQwUWaOrgQEdlnlb2CdQXwf8Cubtk/Bf4ak0QiCWLLziJ++9pc+ndszmVH9Iw6jkiia+vuubte\nuPtmM2sXZaB4lJ6ZS+MG9ejdTgMMi4jsq8r2IlgAPBA+RKQS7nlrIRu2FfD4BcNJrlfZi8Uiso9K\nzCzV3VcBmFk3NNBwlaWv3sKgTi2op+bMIiL7bK8FlplNcvexZjaHcg5U7j4kZslE4ti/l21kwoxV\nXHZED40lI1IzbgY+M7OPCXq7PQIYH22k+FJYXMr87K2cf0i3qKOIiMS1iq5g/TL8enKsg4gkivyi\nEn79yhy6tm7E1cceWPEKIrLf3P3tcHDhQ8JJV7n7higzxZvF6/IoLC5VBxciIvtpr+2W3D07fPoz\nd19Z9gH8LPbxROLPnz74luUbtvO7Hw2mcYPK3uYoIvvDzH4EFLn7G+7+BlBsZqdFnSuepKuDCxGR\nalHZG0OOLWfaCdUZRCQRzM/ayj8+XsYZB3XhiD5to44jUpfc6u5bdr0IO7y4NcI8cScjcwutGifT\ntXWjqKOIiMS1iu7BuoLgSlVPM8soM6sZ8Hksg4nEm5JS58ZXMmjRKJlbTuofdRyRuqa8E4a6hFwF\n6atzGdylJWbq4EJEZH9UdPB5AXgL+D1wY5npee6+KWapROJIflEJn327gUkzM8lYvYVHxg2jVZMG\nUccSqWtmmtkDwF/C1/8HzIowT1zZUVjM4nV5HDugfdRRRETi3l4LrLC5xRZgHEA4pkgK0NTMmu7q\nDlekrskvKuGjRTm8NTeb9xesZ1tBMS0aJXPF6F6MGdIx6ngiddEvgN8AE8PX0wiKLKmEeVlbKXXd\nfyUiUh0q1XzCzMYQjIHVCVgPdAMWAANjF02kdtlRWMxHi3J4c042Hyxcz47CElo1TubkIR05YXBH\nvtfrAI13JRIRd9/Od1taSBWkZwYdXAzp2iLiJCIi8a+y7dPvIuj69j13H2Zm3wfOjV0skdphe0Ex\n/9/encdHVd59H//+CAlhRyCyK0FxYQcjuHRzrWgVUGtdqiAqtXe12mpbbZ+7tXft82hr61Zbq7Jp\ncd9LW5UKauvdCmELi8iWAEkRkkACJAGy/J4/5tCmFEICM3Nm+bxfr7xm5sz2vThhrvzmXOe65q7a\nqj8t36x5q0pVU1uvbu2zNH5kH104pJdOG9BVrSmqgNCZWY6k7yryxV/2vu3ufnZooZJIQXGlenXO\n1tEdsw/9YABAk5pbYNW6e7mZtTKzVu4+z8weimkyIGQvLyzWD15bpj11DereoY0uP6Wvxg7tqTG5\n3ZTRipPAgQQzS5HhgV+SdLOkiZJKQ02URAqKKzSsL0evACAamltgVZhZB0kfSJplZlslVcUuFhCu\nOSu36LsvL9WY3G66/dyByuvflaIKSGzd3H2qmd3m7u9Let/MFoQdKhlUVO9VUXm1vpzXL+woAJAS\nmltgjZNUI+lbkq6R1FnS/8QqFBCm/KJtuuXZRRrat4uempin9m2Y6RlIArXB5WYzu0jSPyR1DTFP\n0igojiwfxgQXABAdzT155NuS+rh7nbvPdPdHJF0Ww1xAKFZv2anJMxaoT5e2mj7pVIorIHnca2ad\nJd0h6U5JTynypSAOoaA4MsHFUIYIAkBUNLfAulXSW8HkFvvcHIM8QGhKKmp03dT5ys7M0MzJo9WV\ntayApOHus9290t2Xu/tZ7n6Ku78Zdq5ksLS4UgO6t1fntplhRwGAlNDcAqtE0lhJ95nZd4JtnJCC\nlLG9aq8mTpuvqr11mjl5tPp1bRd2JACICya4AIDoavb80sGiwp+XNMjMXpLUNmapgDiq3lunyTMX\naOO2aj11XZ5O7tUp7EgAEBefVu7Wlh17NIzzrwAgappbYOVLkrvvdvfrJb0nifFTSHq19Q265dnF\nWrqpQo9cOUJjBnQLOxIAxM3S4Pyr4SwwDABR06wCy91v2u/2Y+4+IDaRgPhwd9396jLNXbVVPxk/\nRBcM6RV2JABHyMxOM7O3zOw9Mxsfdp5EV1BcoYxWpsG9KbAAIFqanCLNzF509yvMbJkk3/9+dx8W\ns+vxU58AACAASURBVGRAjP3s7U/08sJifevcE3TNmGPDjgPgMJhZT3f/tNGmb0uaoMh5wh9Jer0Z\nr5GhyEiNEnf/kpnlSnpeUjdJCyVd6+57ox4+ARQUV+rEHh2VnZkRdhQASBmHmoP6tuDyS7EOAsTT\n1L8W6jfvrdM1Y47RN885Puw4AA7f42a2SNLP3H23pApJl0tqkLSjma9xm6SPJe07AfN+SQ+6+/Nm\n9rikGyT9Jrqxw+fuKiiu1IVDe4YdBQBSSpNDBN19c3C54UA/8YkIRNcbS0r0k9krdcHgnvqfcUNk\nxoSYQLJy9/GSFkuabWbXSbpdUhtFjj4dcoigmfWVdJEi62bJIh8IZ0t6OXjIzOa8TjLaUF6typpa\nJrgAgChrssAys51mtuMAPzvNrLnfDAIJ4y9rSnXnS0s1JrerHrpyhDJaUVwByc7dfy/pi5I6S3pN\n0mp3f8TdS5vx9IckfVeRI15SpDCrcPe64HaxpD4HeqKZTTGzfDPLLy1tzlslln0TXDBFOwBE16GO\nYHV0904H+Ono7sxljaSyestO3fzMQh2X00FPTszjnAMgBZjZJWY2T9JbkpZL+oqkcWb2vJkdd4jn\nfknSVndfeDjv7e5PuHueu+fl5OQczkuEaummSmVnttIJPTqGHQUAUsqhzsH6N2Z2tKTsfbeDtbGA\nhFdb36A7Xlyq7MwMzZw8Wp2yM8OOBCA67pU0WpG1Gd9299GS7jCzgZJ+KunKJp57pqRLzOxCRfq2\nTpIeltTFzFoHR7H6SiqJZQPCUlBcocG9Oyszo9lLYgIAmqFZn6rBN4RrJBVKel9SkaQ/xTAXEFW/\nfX+dlpVU6t7xQ9SjU/ahnwAgWVRKulTSZZK27tvo7mvcvaniSu5+t7v3dff+ihRic939GknzFJko\nQ5ImSnojFsHDVFffoOX/qGR4IADEQHO/tvqJpNMUGdeeK+kcSX+PWSogij7evEMPv7tGFw/vrbFD\nWesKSDETFDlvqrWkq6P0mt+T9G0zWxu89tQovW7CWLN1l3bXNmg4E1wAQNQ1d4hgrbuXm1krM2vl\n7vPM7KGmnmBm0xSZ3n2ruw8Jtt0j6SZJ+84G/r67//EwswOHVFvfoDtfWqrObTP140sGhx0HQJS5\ne5mkR6PwOu9Jei+4vl6RYYcpq4AJLgAgZppbYFWYWQdJH0iaZWZbJVUd4jkzJP1K0tP7bX/Q3R9o\nUUrgMP163jqt+McOPf7VU9S1fVbYcQAgISzZVKlO2a3Vv1v7sKMAQMpp7hDBcZJqJH1LkZma1km6\nuKknuPsHkrYdUTrgCKz4R6UenbtG40b01gVDWEgTAPYpKK7QsL5d1IqlKgAg6ppVYLl7lbvXu3ud\nu88M1hcpP8z3vMXMCsxsmpkddZivATRpb12D7nypQEe1z9I9FzM0EAD22V1br08+3cnwQACIkUMt\nNPzX4HL/BYcPd6Hh30g6TtIISZsl/aKJ907qBRwRrl/NW6uPN+/Q/50wVEcxNBAA/mnl5h2qa3AN\nY4ILAIiJQy00/Jngcv8Fhw9roWF33xIcCWuQ9KSaOIk42RdwRHiWl1Tq1/PW6tKRfXTeoB5hxwGA\nhFKwKTLBxfB+HMECgFho7jpYzzRnWzNep/Ec2RMkLW/pawBNiQwNXKqu7bP0I4YGAsB/KCiuVE7H\nNurJmoAAEBPNnUXw3/5SNbPWkk5p6glm9pykL0jqbmbFkn4k6QtmNkKSK7JY8ddamBdo0qNz12jV\npzs1dWKeOrfLDDsOACScJcUVGt63i8yY4AIAYqHJAsvM7pb0fUltG51zZZL2Snqiqee6+1UH2Jxy\nizUicRQUV+jX763TZaP66pyTGRoIAPvbsbtW60urNGFEn7CjAEDKOtQ5WP/P3TtK+vl+5191c/e7\n45QROKQ9dfW686Wl6t4hSz+8eFDYcQAgIS0vrpQkDevHBBcAECuHOoJ1kruvkvSSmY3a/353XxSz\nZEALPPznNVq9ZZemX3+qOrdlaCAAHMjSfQVWHya4AIBYOdQ5WN+WNEUHnk7dJZ0d9URACy3ZVKHH\n31+nK/L66qwTjw47DgAkrILiCh3TtR3LVwBADDVZYLn7lODyrPjEAVpmd21kaGCPTtn6P19iaCAA\nNKWguFKjjj0q7BgAkNKaO4ugzOwMSf0bP8fdn45BJqDZHvzzaq3dukszJ49Wp2yGBgLAwZTu3KOS\nihpdf2b/sKMAQEprVoEVrHl1nKQlkuqDzS6JAguhmfXRBj35wXpdeWo/ff4EFqMGgKYUFEcWGB7W\nlwkuACCWmnsEK0/SIHf3WIYBmqOhwXX/26v02/fX66wTc5g1EACaYWlxpVqZNKRPp7CjAEBKa26B\ntVxST0mbY5gFOKR951zNLtisa8Ycox9fMlitM5pcbQAAoMgRrIFHd1S7rGafHQAAOAzN/ZTtLmml\nmc2XtGffRne/JCapgAPYXrVXU57J14Ki7bpr7En62ucGyMzCjgUACc/dVVBcqXNPZqZVAIi15hZY\n98QyBHAoG8urNWn6fBVX1OhXV4/Ul4b1DjsSACSN4u012la1l/OvACAOmlVgufv7sQ4CHMzijdt1\n48x81btr1o1jdGr/rmFHAoCksmjjdknScAosAIi5JgssM9upyGyB/3GXJHd3zpRFTL21/FPd/sJi\nHd0xWzOuP1UDcjqEHQkAks4fl21W9w5tdHKvjmFHAYCUd6iFhvkkRmim/rVQ9/5hpYb37aKnJuap\ne4c2YUcCgKRTUb1Xc1dt1XWn92dSIACIA6YSQsKpb3Dd+4eVmv5hkb44uIce+spItc3KCDsWACSl\n2QWbVVvvmjCyT9hRACAtUGAhodTsrdftLyzW2yu2aPKZufrBRScroxUzBQLA4XptcYlO6NFBg3sz\nqh8A4oECCwmjak+drp36kRZvqtCPLh6k68/MDTsSACS1DeVVWrhhu753wUksawEAcUKBhYRQV9+g\nW55dpCWbKvTrq0dp7NBeYUcCgKT36qISmUnjR7K0BQDECwUWQufu+u83VmjeJ6X66YQhFFcAEAXu\nrteXlOiM47qpV+e2YccBgLTBdEII3a/fW6fn5m/U179wnK4Zc2zYcQAgJSzauF0byqs1YWTfsKMA\nQFqhwEKoXl9cop+//YkuGd5b3zn/xLDjAEDKeHVRibIzW+mCIT3DjgIAaYUCC6H533Vl+s7LSzUm\nt6t+/uVhasVsgQAQFXvq6jW7YLO+OLinOrThbAAAiCcKLIRi9Zad+tozC3Vst/Z64to8tWnNOlcA\nEC3zVpWqsqaWta8AIAQUWIi7LTt2a9K0+crOzNCM609V53aZYUcCgJTy2uJide/QRp85vnvYUQAg\n7VBgIa527anT5BkLVFFTq+mTTlXfo9qFHQkAUkpF9V7NXbVV40b0VusMunkAiDc+eRE3tfUN+sas\nRVr16U49ds0oDenTOexIANKcmWWb2XwzW2pmK8zsx8H2XDP7yMzWmtkLZpYVdtbmml2wWbX1zvBA\nAAgJBRbiwt31368v1/urS3Xv+CE668Sjw44EAJK0R9LZ7j5c0ghJF5jZaZLul/Sgux8vabukG0LM\n2CKvLS7RCT06aHDvTmFHAYC0RIGFuHhs3lo9v2CTbjnreF01+piw4wCAJMkjdgU3M4Mfl3S2pJeD\n7TMljQ8hXottKK/Swg3bNWFkX5kxMysAhIECCzH32uJiPfDOak0Y2Ud3nH9C2HEA4N+YWYaZLZG0\nVdIcSeskVbh7XfCQYkn/Md7OzKaYWb6Z5ZeWlsYvcBNeXVQiM2n8yN5hRwGAtEWBhZj637Vl+u7L\nBTp9QDfdf9kwvlEFkHDcvd7dR0jqK2m0pJOa+bwn3D3P3fNycnJimrGZefT6khKdPqCbenVuG3Yc\nAEhbFFiImRcWbNSkGQuU2729Hr/2FGW15tcNQOJy9wpJ8ySdLqmLme1bobevpJLQgjXToo3btaG8\nmsktACBk/MWLqNtdW6/vvVyg772yTKP7d9VzN52mzm1Z6wpA4jGzHDPrElxvK+k8SR8rUmhdHjxs\noqQ3wknYfK8uKlF2ZiuNHdor7CgAkNZaH/ohQPNt2latr89aqOUlO3TLWcfrW+edoIxWDAsEkLB6\nSZppZhmKfOn4orvPNrOVkp43s3slLZY0NcyQh7Knrl6zCzbr/EE91aENXTsAhIlPYUTNvE+26vbn\nl6jBXU9dl6dzB/UIOxIANMndCySNPMD29Yqcj5UU5q0qVWVNrSaMYnggAISNAgtHrKHB9fC7a/TI\n3DU6qWcnPf7VUTq2W/uwYwFA2nhtcbG6d2ijzx7fPewoAJD2KLBwRLZX7dXtLyzR+6tLddmovrp3\n/BC1zcoIOxYApI2K6r2au2qrrj2tv1pncGo1AISNAguHbVlxpW7+3UKV7tyjn04YoqtHH8M07AAQ\nZ7MLNqu23nUpwwMBICFQYOGwPD9/o3745gp1b5+lF28+XSP6dQk7EgCkpdcWl+iEHh00uHensKMA\nABTDadrNbJqZbTWz5Y22dTWzOWa2Jrg8Klbvj9jYXVuv7768VHe9ukxjcrtq9jc/S3EFACHZUF6l\nhRu2a8LIvowgAIAEEcvB2jMkXbDftrskvevuAyW9G9xGkqirb9BNT+frxfxi3Xr28Zpx/Wh1bZ8V\ndiwASFuvLiqRmTR+ZO+wowAAAjErsNz9A0nb9ts8TtLM4PpMSeNj9f6IvgfeWa2/rCnTfZcO1R3n\nn8j6VgAQInfX60tKdPqAburVuW3YcQAAgXhPN9TD3TcH1z+VdNCFksxsipnlm1l+aWlpfNLhoN5a\nvlmPv79OV485RleOPibsOACQ9hZt3K4N5dWaMJLJLQAgkYQ2n6u7uyRv4v4n3D3P3fNycnLimAz7\nW7t1l+54calG9OuiH108KOw4AABFhgdmZ7bS2KG9wo4CAGgk3gXWFjPrJUnB5dY4vz9aaNeeOn3t\nmXxlZ2boN18dpTatWeMKAMK2p65esws26/xBPdWhDRMCA0AiiXeB9aakicH1iZLeiPP7owXcXd95\naakKy6r06NUjGeMPAAli8cYKVdbU6uLhTG4BAIkmltO0Pyfpb5JONLNiM7tB0n2SzjOzNZLODW4j\nQf32g/X60/JPdffYk3XGcd3DjgMACKwvrZIkDWLtKwBIODEbV+DuVx3krnNi9Z6Ing/Xlulnb63S\nRcN66cbP5oYdBwDQSGHZLrVp3Uq9OmWHHQUAsJ/QJrlA4iqpqNGtzy3WcTkd9LPLhrF4JQAkmMKy\nah3brZ1asVwGACQcCiz8m9219fqv3y3U3roGPX7tKWrPydMAkHCKyqvUv1v7sGMAAA6AAgv/5se/\nX6GlxZX6xRXDdVxOh7DjAAD2U9/g2lherdwcCiwASEQUWPinFxZs1HPzN+m/vnCcvji4Z9hxAAAH\n8I+KGu2tb1AuR7AAICFRYEGSVFBcof9+Y4U+O7C77jj/xLDjAAAOorAsMoNg/+4UWACQiCiwoG1V\ne/X13y1SToc2evjKkcrgpGkASFhF5ZECK5cCCwASEjMYpLm6+gbd+twile7ao1duPkNd22eFHQkA\n0ITCsiq1y8rQ0R3bhB0FAHAAHMFKY7X1Dbr71WX6cG257h0/REP7dg47EgDgEIrKIjMIsoQGACQm\njmClqR27a/WNWYv0lzVluu2cgboir1/YkQAAzVBYVqXBvflCDAASFQVWGiqpqNHk6Qu0rnSXfn75\nMH2Z4goAkkJtfYM2ba/RRcN6hR0FAHAQFFhpZllxpSbPXKDdtfWaOXm0zjy+e9iRAADNVLy9RvUN\nziLDAJDAKLDSyJ9XbtGtzy1W1/ZZevbGMRrYo2PYkQAALVAUTNE+gEWGASBhUWCliRkfFup/Zq/U\nkD6d9dTEPB3dMTvsSACAFlq/bw0sjmABQMKiwEpx9Q2ue/+wUtM/LNJ5g3ro4StHqF0Wux0AklFR\nWZU6ZrdmSQ0ASGD8pZ3CqvfW6bbnl2jOyi2afGaufnDRySwiDABJrKi8SrndmaIdABIZBVaK2rpz\nt26cma/lJZX68SWDNfGM/mFHAgAcocKyKp1y7FFhxwAANIGFhlPQ6i07NeGx/9WaLbv0xLV5FFcA\nkAL21NWrpKKG868AIMFxBCvFLNywXZOmz1d2ZoZe/NrpGtqXxSgBIBVsLK+Wu5TbnQILABIZBVYK\nWbt1pybPWKBu7bM066bT1KdL27AjAQCipHDfDIIUWACQ0BgimCI2V9bouqnzldW6lZ65YQzFFQA0\ng5n1M7N5ZrbSzFaY2W3B9q5mNsfM1gSXoZ/4VFQeKbByGSIIAAmNAisFVFbXatK0Bdqxu07TJ52q\nfl3bhR0JAJJFnaQ73H2QpNMkfcPMBkm6S9K77j5Q0rvB7VAVllWra/ssdW6XGXYUAEATKLCS3O7a\net30dL7Wl+3SE9eeoiF9OOcKAJrL3Te7+6Lg+k5JH0vqI2mcpJnBw2ZKGh9Own8pLNul/t34Ag0A\nEh0FVhKrb3Dd9vxizS/apl9eMUJnHN897EgAkLTMrL+kkZI+ktTD3TcHd30qqccBHj/FzPLNLL+0\ntDTm+YrKqjn/CgCSAAVWknJ3/fCN5Xp7xRb98EuDdPHw3mFHAoCkZWYdJL0i6XZ339H4Pnd3Sb7/\nc9z9CXfPc/e8nJycmOar2VuvT3fs5vwrAEgCFFhJ6tG5azXro426+fPHafJncsOOAwBJy8wyFSmu\nZrn7q8HmLWbWK7i/l6StYeWTGk1wkUOBBQCJjgIrCT03f6N+OWe1Lh3VR9+74MSw4wBA0jIzkzRV\n0sfu/stGd70paWJwfaKkN+KdrbF/TtHOESwASHisg5Vk5qzcoh+8tkyfPyFH9182TJG/DQAAh+lM\nSddKWmZmS4Jt35d0n6QXzewGSRskXRFSPkmsgQUAyYQCK4nkF23TLc8u0tA+nfXra0YpM4MDkABw\nJNz9r5IO9k3VOfHM0pSisirldGyjDm3otgEg0fEXepJYs2WnbpiZr95d2mrapFPVnk4WANJGUXkV\nE1wAQJKgwEoCmytrdN20+cpq3UpPTx6tbh3ahB0JABBHhWXVymV4IAAkBQqsBLetaq8mTpuvnbvr\nNOP6U9WvK4tMAkA62bm7VmW79nD+FQAkCcaZJbBPK3frq1M/0qZt1Zo+6VQN7t057EgAgDgrKquW\nJOV25ws2AEgGFFgJqqisStc89ZEqa2o1c/JonTagW9iRAAAhKCxnBkEASCYUWAno4807dO3U+apv\naNCzN43RsL5dwo4EAAhJEWtgAUBSocBKMAs3bNf10+erXVZrPT/ldB1/dMewIwEAQlRYVqXenbOV\nnZkRdhQAQDNQYCWQv6wp1ZSnF6pHpzZ65oYxTGgBAFBhWRXDAwEgiTCLYIL407LNmjxjgY7t1k4v\n3nw6xRUAQFJkDSwKLABIHqEcwTKzIkk7JdVLqnP3vDByJIoX8zfprlcKNKJfF02fNFqd22WGHQkA\nkAC2V+1VRXUtiwwDQBIJc4jgWe5eFuL7J4Sn/rJe9/7hY312YHf99tpT1C6LUZsAgIh9MwiyyDAA\nJA/+mg+Ju+uXc1br0blrNXZITz105Qi1ac0JzACAf/nnDIIUWACQNMI6B8slvWNmC81syoEeYGZT\nzCzfzPJLS0vjHC+2Ghpc97y5Qo/OXasr8vrq0atGUlwBAP5DUVmVWpl0DOflAkDSCOsI1mfcvcTM\njpY0x8xWufsHjR/g7k9IekKS8vLyPIyQsVDf4PrOS0v16uIS3fTZXH3/wpNlZmHHAgAkoMLyavU5\nqq2yWjMnFQAki1A+sd29JLjcKuk1SaPDyBFvDQ2u771SoFcXl+iO806guAIANKmorEq53TuEHQMA\n0AJxL7DMrL2Zddx3XdL5kpbHO0e8ubt+9OYKvbywWLefO1C3njOQ4goAcFDursKyKuV2Y3ggACST\nMIYI9pD0WlBctJb0rLu/FUKOuHF33fenVXrm7xs05XMDdNs5A8OOBABIcGW79mrXnjomuACAJBP3\nAsvd10saHu/3DdMj767Vbz9Yr2tPO1Z3jz2JI1cAgEMqKmcGQQBIRpw1G2NPfrBeD/55tS4b1Vc/\nvmQwxRUAoFkKgynaB1BgAUBSocCKoWf+vkE//ePHumhoL91/2VC1akVxBQBonsKyKrVuZerTpW3Y\nUQAALUCBFSOvLCzWf7++XOecdLQe/MoItc7gnxoA0HxFZVU6pms7+g8ASDJ8asfAH5dt1ndeXqoz\nj++mx64ZxfolAIAWKyyr4vwrAEhC/OUfZXNXbdE3n1usUcccpSevy1N2ZkbYkQAAScbdtaG8Wv27\nUWABQLKhwIqiD9eW6ebfLdLJvTpp2vWnql1WGLPgAwCS3ZYde1RTW6/cHAosAEg2FFhRkl+0TTfO\nzFdut/Z6evJodcrODDsSACBJrS/bJUnK5QgWACQdCqwoWFZcqeunL1DPztl65sbROqp9VtiRAABJ\nrKisWpLUv3u7kJMAAFqKAusIrd6yU9dN+0id2mZq1o1jdHTH7LAjAQCSXFF5lbJat1LvzkzRDgDJ\nhgLrCGwsr9ZXn/pImRmt9OxNY9SbtUoAAFFQWFal/t3asX4iACQhCqzD9Gnlbl391N+1t75Bv7tx\njI5lnDwAIEoiBRb9CgAkIwqsw1C+a4+ueervqqiu1dOTR+uEHh3DjgQASBH1Da6N5dXKZQ0sAEhK\nFFgttGN3ra6bNl/F22s0dWKehvXtEnYkAEAK+UdFjfbWN7DIMAAkKQqsFqjeW6fJ0xdo9Zad+u21\np2jMgG5hRwIAHAEzm2ZmW81seaNtXc1sjpmtCS6PimemovIqSWKIIAAkKQqsZtpTV6+vPbNQizZu\n18NXjtQXTjw67EgAgCM3Q9IF+227S9K77j5Q0rvB7bgpLIsUWANYZBgAkhIFVjPU1Tfom88t1l/W\nlOm+y4bpwqG9wo4EAIgCd/9A0rb9No+TNDO4PlPS+HhmKiyrUrusDB3dsU083xYAECUUWIfQ0OD6\n7isFenvFFv3o4kG6Iq9f2JEAALHVw903B9c/ldQjnm9eVFalY7u1lxlTtANAMqLAaoK7657fr9Cr\ni0p0x3kn6Pozc8OOBACII3d3SX6g+8xsipnlm1l+aWlp1N6zqLxaud3bRe31AADxRYHVhAfe+URP\n/22DpnxugG45+/iw4wAA4mOLmfWSpOBy64Ee5O5PuHueu+fl5ORE5Y1r6xu0aRtTtANAMqPAOojf\nvLdOj81bp6tGH6O7x57EUA0ASB9vSpoYXJ8o6Y14vXHx9hrVNTgzCAJAEqPAOoBn/lak+99apXEj\neuve8UMorgAgRZnZc5L+JulEMys2sxsk3SfpPDNbI+nc4HZcFAUzCHIECwCSV+uwAySap/9WpB++\nsULnntxDD3x5uDJaUVwBQKpy96sOctc5cQ0S2DdFO4sMA0DyosBqZMaHhbrn9yt17sk99Ng1I5WZ\nwQE+AED8FJVXqWOb1urWPivsKACAw0SBFZj610L9ZPZKfXFwDz161Shltaa4AgDEV2FZlXJzmKId\nAJIZVYSkJz9Yr5/MXqmxQ3rqV1dTXAEAwlFYVsUEFwCQ5NK+knj8/XX66R8/1kVDe+mRqxgWCAAI\nx566ev2joobzrwAgyaX1EMHH5q3Vz9/+RBcP760Hrxiu1hRXAICQbNpWrQYXiwwDQJJL2wLr0XfX\n6BdzVmv8iN564MsUVwCAcBWWVUuScrt3CDkJAOBIpGWB9dCfV+uhP6/RpaP66OeXMxU7ACB8hWW7\nJEm5nIMFAEktrQosd9eDc1brkblrdfkpfXX/ZcMorgAACaGwrFpHtctU53aZYUcBAByBtCmw3F0P\nvPOJHpu3Tl/J66f/d+lQtaK4AgAkiKKyKia4AIAUkBYnHrm77n8rUlxdNfoYiisAQMIpKq9SLgUW\nACS9tCiwfvb2J3r8/XX66mnH6Kfjh1BcAQASSs3eem2u3M35VwCQAtJiiOCgXp006Yz++tHFg2RG\ncQUASCw1tfW6bFRfjTr2qLCjAACOUFoUWBcP762Lh/cOOwYAAAfUtX2WfnHF8LBjAACiIC2GCAIA\nAABAPFBgAQAAAECUhFJgmdkFZvaJma01s7vCyAAAAAAA0Rb3AsvMMiQ9JmmspEGSrjKzQfHOAQAA\nAADRFsYRrNGS1rr7enffK+l5SeNCyAEAAAAAURVGgdVH0qZGt4uDbf/GzKaYWb6Z5ZeWlsYtHAAA\nAAAcroSd5MLdn3D3PHfPy8nJCTsOAAAAABxSGAVWiaR+jW73DbYBAAAAQFILo8BaIGmgmeWaWZak\nKyW9GUIOAAAAAIiq1vF+Q3evM7NbJL0tKUPSNHdfEe8cAAAAABBtcS+wJMnd/yjpj2G8NwAAAADE\nSsJOcgEAAAAAyYYCCwAAAACihAILAAAAAKLE3D3sDIdkZqWSNhzBS3SXVBalOImOtqaudGovbU1N\nTbX1WHdP2kUP6adaLJ3aS1tTUzq1VUqv9h6src3up5KiwDpSZpbv7nlh54gH2pq60qm9tDU1pVNb\nWyrd/m3Sqb20NTWlU1ul9GpvNNrKEEEAAAAAiBIKLAAAAACIknQpsJ4IO0Ac0dbUlU7tpa2pKZ3a\n2lLp9m+TTu2lrakpndoqpVd7j7itaXEOFgAAAADEQ7ocwQIAAACAmKPAAgAAAIAoSekCy8wuMLNP\nzGytmd0Vdp5YMLMiM1tmZkvMLD/Y1tXM5pjZmuDyqLBzHg4zm2ZmW81seaNtB2ybRTwS7OsCMxsV\nXvKWO0hb7zGzkmDfLjGzCxvdd3fQ1k/M7IvhpD48ZtbPzOaZ2UozW2FmtwXbU27fNtHWVN232WY2\n38yWBu39cbA918w+Ctr1gpllBdvbBLfXBvf3DzN/WFK9r0rlfkqir0rhzzP6qhTct3Hrp9w9JX8k\nZUhaJ2mApCxJSyUNCjtXDNpZJKn7ftt+Jumu4Ppdku4PO+dhtu1zkkZJWn6otkm6UNKfJJmkC/4e\nlwAABp5JREFU0yR9FHb+KLT1Hkl3HuCxg4Lf5zaScoPf84yw29CCtvaSNCq43lHS6qBNKbdvm2hr\nqu5bk9QhuJ4p6aNgn70o6cpg++OSvh5c/y9JjwfXr5T0QthtCOHfLOX7qlTup4L89FWp+XlGX5WC\n+zZe/VQqH8EaLWmtu693972Snpc0LuRM8TJO0szg+kxJ40PMctjc/QNJ2/bbfLC2jZP0tEf8XVIX\nM+sVn6RH7iBtPZhxkp539z3uXihprSK/70nB3Te7+6Lg+k5JH0vqoxTct0209WCSfd+6u+8KbmYG\nPy7pbEkvB9v337f79vnLks4xM4tT3ESRrn1VSvRTEn1VE5L984y+6uCSdt/Gq59K5QKrj6RNjW4X\nq+lflmTlkt4xs4VmNiXY1sPdNwfXP5XUI5xoMXGwtqXq/r4lGGowrdEQmpRpa3CofaQi3yCl9L7d\nr61Siu5bM8swsyWStkqao8g3mxXuXhc8pHGb/tne4P5KSd3imzh0Sb/PmyHd+ikpxT/PDiAlP8/2\noa9KrX0bj34qlQusdPEZdx8laaykb5jZ5xrf6ZFjmik5F38qty3wG0nHSRohabOkX4QbJ7rMrIOk\nVyTd7u47Gt+Xavv2AG1N2X3r7vXuPkJSX0W+0Twp5EgIX9r2U1Lqt08p/Hkm0VcpBfdtPPqpVC6w\nSiT1a3S7b7Atpbh7SXC5VdJrivyibNl3WDq43Bpewqg7WNtSbn+7+5bgQ6BB0pP61+H3pG+rmWUq\n8iE+y91fDTan5L49UFtTed/u4+4VkuZJOl2RoTKtg7sat+mf7Q3u7yypPM5Rw5Yy+/xg0rCfklL0\n8+xAUvnzjL4qdfetFNt+KpULrAWSBgazgmQpcmLamyFniioza29mHfddl3S+pOWKtHNi8LCJkt4I\nJ2FMHKxtb0q6LpjF5zRJlY0O4Sel/cZuT1Bk30qRtl4ZzGyTK2mgpPnxzne4grHLUyV97O6/bHRX\nyu3bg7U1hfdtjpl1Ca63lXSeImP550m6PHjY/vt23z6/XNLc4BvhdJLSfVWa9lNSCn6eHUwKf57R\nV6Xgvo1bP7X/rBep9KPIjC6rFRlb+YOw88SgfQMUmcVlqaQV+9qoyNjQdyWtkfRnSV3DznqY7XtO\nkUPStYqMh73hYG1TZFaYx4J9vUxSXtj5o9DWZ4K2FAT/wXs1evwPgrZ+Imls2Plb2NbPKDKkokDS\nkuDnwlTct020NVX37TBJi4N2LZf0w2D7AEU637WSXpLUJtieHdxeG9w/IOw2hPTvlrJ9Var3U0Fb\n6KtS8/OMvioF9228+ikLngwAAAAAOEKpPEQQAAAAAOKKAgsAAAAAooQCCwAAAACihAILAAAAAKKE\nAgsAAAAAooQCC0hQZjbJzHqHnQMAgIOhrwL+EwUWkLgmSTpgp2VmGfGNAgDAAU0SfRXwbyiwgBYw\ns/5m9rGZPWlmK8zsHTNra2bvmVle8JjuZlYUXJ9kZq+b2RwzKzKzW8zs22a22Mz+bmZdD/I+l0vK\nkzTLzJYE71FkZveb2SJJXzaz48zsLTNbaGZ/MbOTgufmmNkrZrYg+Dkz2P754LWWBO/fMR7/ZgCA\n+KKvAsJFgQW03EBJj7n7YEkVki47xOOHSLpU0qmSfiqp2t1HSvqbpOsO9AR3f1lSvqRr3H2Eu9cE\nd5W7+yh3f17SE5JudfdTJN0p6dfBYx6W9KC7nxpkeyrYfqekb7j7CEmflbTvNQEAqYe+CghJ67AD\nAEmo0N2XBNcXSup/iMfPc/edknaaWaWk3wfbl0ka1sL3fkGSzKyDpDMkvWRm++5rE1yeK2lQo+2d\ngsd/KOmXZjZL0qvuXtzC9wYAJA/6KiAkFFhAy+1pdL1eUltJdfrXEeHsJh7f0Oh2g1r+f7AquGwl\nqSL4hm9/rSSd5u6799t+n5n9QdKFkj40sy+6+6oWvj8AIDnQVwEhYYggEB1Fkk4Jrl8epdfcKemA\nY8/dfYekQjP7siRZxPDg7nck3brvsWY2Irg8zt2Xufv9khZIOilKOQEAyaFI9FVAzFFgAdHxgKSv\nm9liSd2j9JozJD2+78ThA9x/jaQbzGyppBWSxgXbvykpz8wKzGylpJuD7beb2XIzK5BUK+lPUcoJ\nAEgO9FVAHJi7h50BAAAAAFICR7AAAAAAIEqY5AIImZk9JunM/TY/7O7Tw8gDAMD+6KuA5mOIIAAA\nAABECUMEAQAAACBKKLAAAAAAIEoosAAAAAAgSiiwAAAAACBKKLAAAAAAIEr+PynyxZtf4OScAAAA\nAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11e53e470>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(1, figsize=(12, 6))\n",
+    "plt.subplot(121)\n",
+    "plt.plot(x_values, y_values_init)\n",
+    "plt.title(\"num_trees vs initalization time\")\n",
+    "plt.ylabel(\"Initialization time (s)\")\n",
+    "plt.xlabel(\"num_trees\")\n",
+    "plt.subplot(122)\n",
+    "plt.plot(x_values, y_values_accuracy)\n",
+    "plt.title(\"num_trees vs accuracy\")\n",
+    "plt.ylabel(\"% accuracy\")\n",
+    "plt.xlabel(\"num_trees\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Initialization:\n",
+    "Initialization time of the annoy indexer increases in a linear fashion with num_trees. Initialization time will vary from corpus to corpus, in the graph above the lee corpus was used\n",
+    "\n",
+    "##### Accuracy:\n",
+    "In this dataset, the accuracy seems logarithmically related to the number of trees. We see an improvement in accuracy with more trees, but the relationship is nonlinear. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Recap\n",
+    "In this notebook we used the Annoy module to build an indexed approximation of our word embeddings. To do so, we did the following steps:\n",
+    "1. Download Text8 Corpus\n",
+    "2. Build Word2Vec Model\n",
+    "3. Construct AnnoyIndex with model & make a similarity query\n",
+    "4. Verify & Evaluate performance\n",
+    "5. Evaluate relationship of `num_trees` to initialization time and accuracy"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/docs/notebooks/annoytutorial.ipynb
+++ b/docs/notebooks/annoytutorial.ipynb
@@ -11,58 +11,153 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This tutorial is about using the [Annoy(Approximate Nearest Neighbors Oh Yeah)]((https://github.com/spotify/annoy \"Link to annoy repo\") library for similarity queries in gensim"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Why use Annoy?\n",
-    "The current implementation for finding k nearest neighbors in a vector space in gensim has linear complexity via brute force in the number of indexed documents, although with extremely low constant factors. The retrieved results are exact, which is an overkill in many applications: approximate results retrieved in sub-linear time may be enough. Annoy can find approximate nearest neighbors much faster."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For the following examples, we'll use the Lee Corpus (which you already have if you've installed gensim)\n",
+    "This tutorial is about using the ([Annoy Approximate Nearest Neighbors Oh Yeah](https://github.com/spotify/annoy \"Link to annoy repo\")) library for similarity queries with a Word2Vec model built with gensim.\n",
     "\n",
-    "See the [Word2Vec tutorial](https://github.com/RaRe-Technologies/gensim/blob/develop/docs/notebooks/word2vec.ipynb) for how to initialize and save this model."
+    "## Why use Annoy?\n",
+    "The current implementation for finding k nearest neighbors in a vector space in gensim has linear complexity via brute force in the number of indexed documents, although with extremely low constant factors. The retrieved results are exact, which is an overkill in many applications: approximate results retrieved in sub-linear time may be enough. Annoy can find approximate nearest neighbors much faster.\n",
+    "\n",
+    "\n",
+    "## Prerequisites\n",
+    "Additional libraries needed for this tutorial:\n",
+    "- annoy\n",
+    "- psutil\n",
+    "- matplotlib\n",
+    "\n",
+    "## Outline\n",
+    "1. Download Text8 Corpus\n",
+    "2. Build Word2Vec Model\n",
+    "3. Construct AnnoyIndex with model & make a similarity query\n",
+    "4. Verify & Evaluate performance\n",
+    "5. Evaluate relationship of `num_trees` to initialization time and accuracy"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPython 3.6.1\n",
+      "IPython 6.0.0\n",
+      "\n",
+      "gensim 2.1.0\n",
+      "numpy 1.12.1\n",
+      "scipy 0.19.0\n",
+      "psutil 5.2.2\n",
+      "matplotlib 2.0.2\n",
+      "\n",
+      "compiler   : GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)\n",
+      "system     : Darwin\n",
+      "release    : 14.5.0\n",
+      "machine    : x86_64\n",
+      "processor  : i386\n",
+      "CPU cores  : 8\n",
+      "interpreter: 64bit\n"
+     ]
+    }
+   ],
+   "source": [
+    "# pip install watermark\n",
+    "%reload_ext watermark\n",
+    "%watermark -v -m -p gensim,numpy,scipy,psutil,matplotlib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Download Text8 Corpus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os.path\n",
+    "if not os.path.isfile('text8'):\n",
+    "    !wget -c http://mattmahoney.net/dc/text8.zip\n",
+    "    !unzip text8.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Import & Set up Logging\n",
+    "I'm not going to set up logging due to the verbose input displaying in notebooks, but if you want that, uncomment the lines in the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "LOGS = False\n",
+    "\n",
+    "if LOGS:\n",
+    "    import logging\n",
+    "    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Build Word2Vec Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": true
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Word2Vec(vocab=6981, size=100, alpha=0.025)\n"
+      "Word2Vec(vocab=71290, size=100, alpha=0.05)\n"
      ]
     }
    ],
    "source": [
-    "# Load the model\n",
-    "import gensim, os\n",
-    "from gensim.models.word2vec import Word2Vec\n",
+    "from gensim.models import Word2Vec, KeyedVectors\n",
+    "from gensim.models.word2vec import Text8Corpus\n",
     "\n",
-    "# Set file names for train and test data\n",
-    "test_data_dir = '{}'.format(os.sep).join([gensim.__path__[0], 'test', 'test_data']) + os.sep\n",
-    "lee_train_file = test_data_dir + 'lee_background.cor'\n",
+    "# using params from Word2Vec_FastText_Comparison\n",
     "\n",
-    "class MyText(object):\n",
-    "    def __iter__(self):\n",
-    "        for line in open(lee_train_file):\n",
-    "            # assume there's one document per line, tokens separated by whitespace\n",
-    "            yield gensim.utils.simple_preprocess(line)\n",
+    "lr = 0.05\n",
+    "dim = 100\n",
+    "ws = 5\n",
+    "epoch = 5\n",
+    "minCount = 5\n",
+    "neg = 5\n",
+    "loss = 'ns'\n",
+    "t = 1e-4\n",
     "\n",
-    "sentences = MyText()\n",
-    "model = Word2Vec(sentences, min_count=1)\n",
+    "# Same values as used for fastText training above\n",
+    "params = {\n",
+    "    'alpha': lr,\n",
+    "    'size': dim,\n",
+    "    'window': ws,\n",
+    "    'iter': epoch,\n",
+    "    'min_count': minCount,\n",
+    "    'sample': t,\n",
+    "    'sg': 1,\n",
+    "    'hs': 0,\n",
+    "    'negative': neg\n",
+    "}\n",
+    "\n",
+    "model = Word2Vec(Text8Corpus('text8'), **params)\n",
     "print(model)"
    ]
   },
@@ -70,22 +165,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "#### Comparing the traditional implementation and the Annoy  \n"
+    "See the [Word2Vec tutorial](https://github.com/RaRe-Technologies/gensim/blob/develop/docs/notebooks/word2vec.ipynb) for how to initialize and save this model."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These benchmarks are run on a 2.4GHz 4 core i7 processor  "
+    "#### Comparing the traditional implementation and the Annoy approximation"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -96,27 +190,25 @@
     "    raise ValueError(\"SKIP: Please install the annoy indexer\")\n",
     "\n",
     "model.init_sims()\n",
-    "annoy_index = AnnoyIndexer(model, 300)"
+    "annoy_index = AnnoyIndexer(model, 100)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(u'the', 1.0),\n",
-       " (u'on', 0.999976396560669),\n",
-       " (u'in', 0.9999759197235107),\n",
-       " (u'two', 0.9999756217002869),\n",
-       " (u'after', 0.9999749660491943)]"
+       "[('the', 0.9999998807907104),\n",
+       " ('of', 0.8208043575286865),\n",
+       " ('in', 0.8024208545684814),\n",
+       " ('a', 0.7661813497543335),\n",
+       " ('and', 0.7392199039459229)]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -130,44 +222,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Gensim: 0.002638526\n",
-      "Annoy: 0.001149898\n",
-      "\n",
-      "Annoy is 2.29 times faster on average over 1000 random queries on this particular run\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import time, numpy\n",
-    "\n",
-    "def avg_query_time(annoy_index=None):\n",
+    "import time\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def avg_query_time(annoy_index=None, queries=1000):\n",
     "    \"\"\"\n",
     "    Average query time of a most_similar method over 1000 random queries,\n",
     "    uses annoy if given an indexer\n",
     "    \"\"\"\n",
     "    total_time = 0\n",
-    "    for _ in range(1000):\n",
-    "        rand_vec = model.wv.syn0norm[numpy.random.randint(0, len(model.vocab))]\n",
+    "    for _ in range(queries):\n",
+    "        rand_vec = model.wv.syn0norm[np.random.randint(0, len(model.wv.vocab))]\n",
     "        start_time = time.clock()\n",
     "        model.most_similar([rand_vec], topn=5, indexer=annoy_index)\n",
     "        total_time += time.clock() - start_time\n",
-    "    return total_time / 1000\n",
+    "    return total_time / queries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gensim (s/query):\t0.00571\n",
+      "Annoy (s/query):\t0.00028\n",
+      "\n",
+      "Annoy is 20.67 times faster on average on this particular run\n"
+     ]
+    }
+   ],
+   "source": [
+    "queries = 10000\n",
     "\n",
-    "gensim_time = avg_query_time()\n",
-    "annoy_time = avg_query_time(annoy_index)\n",
-    "print \"Gensim: {}\".format(gensim_time) \n",
-    "print \"Annoy: {}\".format(annoy_time)\n",
-    "print \"\\nAnnoy is {} times faster on average over 1000 random queries on \\\n",
-    "this particular run\".format(numpy.round(gensim_time / annoy_time, 2))"
+    "gensim_time = avg_query_time(queries=queries)\n",
+    "annoy_time = avg_query_time(annoy_index, queries=queries)\n",
+    "print(\"Gensim (s/query):\\t{0:.5f}\".format(gensim_time))\n",
+    "print(\"Annoy (s/query):\\t{0:.5f}\".format(annoy_time))\n",
+    "speed_improvement = gensim_time / annoy_time\n",
+    "print (\"\\nAnnoy is {0:.2f} times faster on average on this particular run\".format(speed_improvement))"
    ]
   },
   {
@@ -186,52 +297,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## What is Annoy?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Annoy is an open source library to search for points in space that are close to a given query point. It also creates large read-only file-based data structures that are mmapped into memory so that many processes may share the same data. For our purpose, it is used to find similarity between words or documents in a vector space. [See the tutorial on similarity queries for more information on them](https://github.com/RaRe-Technologies/gensim/blob/develop/docs/notebooks/Similarity_Queries.ipynb)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Getting Started"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "First thing to do is to install annoy, by running the following in the command line:\n",
-    "\n",
-    "`sudo pip install annoy`\n",
-    "\n",
-    "And then set up the logger: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "# import modules & set up logging\n",
-    "import logging\n",
-    "logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Making a Similarity Query"
+    "## 3. Construct AnnoyIndex with model & make a similarity query"
    ]
   },
   {
@@ -245,55 +311,63 @@
     "\n",
     "**`model`**: A `Word2Vec` or `Doc2Vec` model\n",
     "\n",
-    "**`num_trees`**: A positive integer. `num_trees` effects the build time and the index size. **A larger value will give more accurate results, but larger indexes**. More information on what trees in Annoy do can be found [here](https://github.com/spotify/annoy#how-does-it-work). The relationship between `num_trees`, build time, and accuracy will be investigated later in the tutorial. \n"
+    "**`num_trees`**: A positive integer. `num_trees` effects the build time and the index size. **A larger value will give more accurate results, but larger indexes**. More information on what trees in Annoy do can be found [here](https://github.com/spotify/annoy#how-does-it-work). The relationship between `num_trees`, build time, and accuracy will be investigated later in the tutorial. \n",
+    "\n",
+    "Now that we are ready to make a query, lets find the top 5 most similar words to \"science\" in the Text8 corpus. To make a similarity query we call `Word2Vec.most_similar` like we would traditionally, but with an added parameter, `indexer`. The only supported indexer in gensim as of now is Annoy. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "from gensim.similarities.index import AnnoyIndexer\n",
-    "# 100 trees are being used in this example\n",
-    "annoy_index = AnnoyIndexer(model, 100)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
+   "execution_count": 10,
    "metadata": {},
-   "source": [
-    "Now that we are ready to make a query, lets find the top 5 most similar words to \"army\" in the lee corpus. To make a similarity query we call `Word2Vec.most_similar` like we would traditionally, but with an added parameter, `indexer`. The only supported indexer in gensim as of now is Annoy. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(u'science', 0.9998273665260058)\n",
-      "(u'rates', 0.9086664393544197)\n",
-      "(u'insurance', 0.9080813005566597)\n",
-      "(u'north', 0.9077721834182739)\n",
-      "(u'there', 0.9076579436659813)\n"
+      "Approximate Neighbors\n",
+      "('science', 1.0)\n",
+      "('interdisciplinary', 0.6099119782447815)\n",
+      "('astrobiology', 0.5975957810878754)\n",
+      "('actuarial', 0.596003383398056)\n",
+      "('robotics', 0.5942946970462799)\n",
+      "('sciences', 0.59312504529953)\n",
+      "('scientific', 0.5900688469409943)\n",
+      "('psychohistory', 0.5890524089336395)\n",
+      "('bioethics', 0.5867903232574463)\n",
+      "('cryobiology', 0.5854728817939758)\n",
+      "('xenobiology', 0.5836742520332336)\n",
+      "\n",
+      "Normal (not Annoy-indexed) Neighbors\n",
+      "('science', 1.0)\n",
+      "('fiction', 0.7495021224021912)\n",
+      "('interdisciplinary', 0.6956626772880554)\n",
+      "('astrobiology', 0.6761417388916016)\n",
+      "('actuarial', 0.6735734343528748)\n",
+      "('robotics', 0.6708062887191772)\n",
+      "('sciences', 0.6689055562019348)\n",
+      "('scientific', 0.6639128923416138)\n",
+      "('psychohistory', 0.6622439622879028)\n",
+      "('bioethics', 0.6585155129432678)\n",
+      "('vernor', 0.6571990251541138)\n"
      ]
     }
    ],
    "source": [
+    "# 100 trees are being used in this example\n",
+    "annoy_index = AnnoyIndexer(model, 100)\n",
     "# Derive the vector for the word \"science\" in our model\n",
     "vector = model[\"science\"]\n",
     "# The instance of AnnoyIndexer we just created is passed \n",
-    "approximate_neighbors = model.most_similar([vector], topn=5, indexer=annoy_index)\n",
+    "approximate_neighbors = model.most_similar([vector], topn=11, indexer=annoy_index)\n",
     "# Neatly print the approximate_neighbors and their corresponding cosine similarity values\n",
+    "print(\"Approximate Neighbors\")\n",
     "for neighbor in approximate_neighbors:\n",
+    "    print(neighbor)\n",
+    "\n",
+    "normal_neighbors = model.most_similar([vector], topn=11)\n",
+    "print(\"\\nNormal (not Annoy-indexed) Neighbors\")\n",
+    "for neighbor in normal_neighbors:\n",
     "    print(neighbor)"
    ]
   },
@@ -301,27 +375,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Analyzing the results"
+    "#### Analyzing the results"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The closer the cosine similarity of a vector is to 1, the more similar that word is to our query, which was the vector for \"science\"."
+    "The closer the cosine similarity of a vector is to 1, the more similar that word is to our query, which was the vector for \"science\". There are some differences in the ranking of similar words and the set of words included within the 10 most similar words."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Persisting Indexes\n",
+    "### 4. Verify & Evaluate performance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Persisting Indexes\n",
     "You can save and load your indexes from/to disk to prevent having to construct them each time. This will create two files on disk, _fname_ and _fname.d_. Both files are needed to correctly restore all attributes. Before loading an index, you will have to create an empty AnnoyIndexer object."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {
     "collapsed": true
    },
@@ -341,29 +422,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(u'science', 0.9998273665260058)\n",
-      "(u'rates', 0.9086666032671928)\n",
-      "(u'insurance', 0.9080811440944672)\n",
-      "(u'north', 0.9077721834182739)\n",
-      "(u'there', 0.9076577797532082)\n"
+      "('science', 1.0)\n",
+      "('interdisciplinary', 0.6099119782447815)\n",
+      "('astrobiology', 0.5975957810878754)\n",
+      "('actuarial', 0.596003383398056)\n",
+      "('robotics', 0.5942946970462799)\n",
+      "('sciences', 0.59312504529953)\n",
+      "('scientific', 0.5900688469409943)\n",
+      "('psychohistory', 0.5890524089336395)\n",
+      "('bioethics', 0.5867903232574463)\n",
+      "('cryobiology', 0.5854728817939758)\n",
+      "('xenobiology', 0.5836742520332336)\n"
      ]
     }
    ],
    "source": [
     "# Results should be identical to above\n",
     "vector = model[\"science\"]\n",
-    "approximate_neighbors = model.most_similar([vector], topn=5, indexer=annoy_index2)\n",
-    "for neighbor in approximate_neighbors:\n",
-    "    print neighbor"
+    "approximate_neighbors2 = model.most_similar([vector], topn=11, indexer=annoy_index2)\n",
+    "for neighbor in approximate_neighbors2:\n",
+    "    print(neighbor)\n",
+    "    \n",
+    "assert approximate_neighbors == approximate_neighbors2"
    ]
   },
   {
@@ -377,13 +464,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Save memory by memory-mapping indices saved to disk"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "#### Save memory by memory-mapping indices saved to disk\n",
+    "\n",
     "Annoy library has a useful feature that indices can be memory-mapped from disk. It saves memory when the same index is used by several processes.\n",
     "\n",
     "Below are two snippets of code. First one has a separate index for each process. The second snipped shares the index between two processes via memory-mapping. The second example uses less total RAM as it is shared."
@@ -391,57 +473,73 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
+   "outputs": [],
+   "source": [
+    "# Remove verbosity from code below (if logging active)\n",
+    "\n",
+    "if LOGS:\n",
+    "    logging.disable(logging.CRITICAL)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from multiprocessing import Process\n",
+    "import os\n",
+    "import psutil"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Bad Example: Two processes load the Word2vec model from disk and create there own Annoy indices from that model. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Process Id:  6216\n",
-      "(u'klusener', 0.9090957194566727)\n",
-      "(u'started', 0.908975400030613)\n",
-      "(u'gutnick', 0.908865213394165)\n",
-      "(u'ground', 0.9084076434373856)\n",
-      "(u'interest', 0.9074432477355003)\n",
-      "Memory used by process 6216= pmem(rss=126914560, vms=1385103360, shared=9273344, text=3051520, lib=0, data=1073524736, dirty=0)\n",
-      "Process Id:  6231\n",
-      "(u'klusener', 0.9090957194566727)\n",
-      "(u'started', 0.908975400030613)\n",
-      "(u'gutnick', 0.908865213394165)\n",
-      "(u'ground', 0.9084076434373856)\n",
-      "(u'interest', 0.9074432477355003)\n",
-      "Memory used by process 6231= pmem(rss=126496768, vms=1385103360, shared=8835072, text=3051520, lib=0, data=1073524736, dirty=0)\n",
-      "CPU times: user 64 ms, sys: 12 ms, total: 76 ms\n",
-      "Wall time: 2.86 s\n"
+      "Process Id:  6452\n",
+      "\n",
+      "Memory used by process 6452:  pmem(rss=425226240, vms=3491692544, pfaults=149035, pageins=0) \n",
+      "---\n",
+      "Process Id:  6460\n",
+      "\n",
+      "Memory used by process 6460:  pmem(rss=425136128, vms=3491692544, pfaults=149020, pageins=0) \n",
+      "---\n",
+      "CPU times: user 489 ms, sys: 204 ms, total: 693 ms\n",
+      "Wall time: 29.3 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "\n",
-    "# Bad example. Two processes load the Word2vec model from disk and create there own Annoy indices from that model. \n",
-    "\n",
-    "from gensim import models\n",
-    "from gensim.similarities.index import AnnoyIndexer\n",
-    "from multiprocessing import Process\n",
-    "import os\n",
-    "import psutil\n",
-    "\n",
     "model.save('/tmp/mymodel')\n",
     "\n",
     "def f(process_id):\n",
-    "    print 'Process Id: ', os.getpid()\n",
+    "    print ('Process Id: ', os.getpid())\n",
     "    process = psutil.Process(os.getpid())\n",
-    "    new_model = models.Word2Vec.load('/tmp/mymodel')\n",
+    "    new_model = Word2Vec.load('/tmp/mymodel')\n",
     "    vector = new_model[\"science\"]\n",
     "    annoy_index = AnnoyIndexer(new_model,100)\n",
     "    approximate_neighbors = new_model.most_similar([vector], topn=5, indexer=annoy_index)\n",
-    "    for neighbor in approximate_neighbors:\n",
-    "        print neighbor\n",
-    "    print 'Memory used by process '+str(os.getpid())+'=', process.memory_info()\n",
+    "    print('\\nMemory used by process {}: '.format(os.getpid()), process.memory_info(), \"\\n---\")\n",
     "\n",
     "# Creating and running two parallel process to share the same index file.\n",
     "p1 = Process(target=f, args=('1',))\n",
@@ -453,60 +551,49 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Good example. Two processes load both the Word2vec model and index from disk and memory-map the index\n"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 16,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Process Id:  6246\n",
-      "(u'science', 0.9998273665260058)\n",
-      "(u'rates', 0.9086664393544197)\n",
-      "(u'insurance', 0.9080813005566597)\n",
-      "(u'north', 0.9077721834182739)\n",
-      "(u'there', 0.9076579436659813)\n",
-      "Memory used by process 6246 pmem(rss=125091840, vms=1382862848, shared=22179840, text=3051520, lib=0, data=1058062336, dirty=0)\n",
-      "Process Id:  6261\n",
-      "(u'science', 0.9998273665260058)\n",
-      "(u'rates', 0.9086664393544197)\n",
-      "(u'insurance', 0.9080813005566597)\n",
-      "(u'north', 0.9077721834182739)\n",
-      "(u'there', 0.9076579436659813)\n",
-      "Memory used by process 6261 pmem(rss=125034496, vms=1382862848, shared=22122496, text=3051520, lib=0, data=1058062336, dirty=0)\n",
-      "CPU times: user 44 ms, sys: 16 ms, total: 60 ms\n",
-      "Wall time: 202 ms\n"
+      "Process Id:  6461\n",
+      "\n",
+      "Memory used by process 6461:  pmem(rss=357363712, vms=3576012800, pfaults=105041, pageins=0) \n",
+      "---\n",
+      "Process Id:  6462\n",
+      "\n",
+      "Memory used by process 6462:  pmem(rss=357097472, vms=3576012800, pfaults=104995, pageins=0) \n",
+      "---\n",
+      "CPU times: user 509 ms, sys: 181 ms, total: 690 ms\n",
+      "Wall time: 2.61 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "\n",
-    "# Good example. Two processes load both the Word2vec model and index from disk and memory-map the index\n",
-    "\n",
-    "from gensim import models\n",
-    "from gensim.similarities.index import AnnoyIndexer\n",
-    "from multiprocessing import Process\n",
-    "import os\n",
-    "import psutil\n",
-    "\n",
     "model.save('/tmp/mymodel')\n",
     "\n",
     "def f(process_id):\n",
-    "    print 'Process Id: ', os.getpid()\n",
+    "    print('Process Id: ', os.getpid())\n",
     "    process = psutil.Process(os.getpid())\n",
-    "    new_model = models.Word2Vec.load('/tmp/mymodel')\n",
+    "    new_model = Word2Vec.load('/tmp/mymodel')\n",
     "    vector = new_model[\"science\"]\n",
     "    annoy_index = AnnoyIndexer()\n",
     "    annoy_index.load('index')\n",
     "    annoy_index.model = new_model\n",
     "    approximate_neighbors = new_model.most_similar([vector], topn=5, indexer=annoy_index)\n",
-    "    for neighbor in approximate_neighbors:\n",
-    "        print neighbor\n",
-    "    print 'Memory used by process '+str(os.getpid()), process.memory_info()\n",
+    "    print('\\nMemory used by process {}: '.format(os.getpid()), process.memory_info(), \"\\n---\")\n",
     "\n",
     "# Creating and running two parallel process to share the same index file.\n",
     "p1 = Process(target=f, args=('1',))\n",
@@ -521,92 +608,88 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Relationship between num_trees and initialization time"
+    "### 5. Evaluate relationship of `num_trees` to initialization time and accuracy"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 17,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYkAAAEaCAYAAADkL6tQAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3XeYU2Xax/HvDYLYsRdQUOwoNkR9bWNHBVHXAlbQ1bW7\n9rYr2Nu6NuwiAgrYsKDAsquMIruAigiIgAWQJgiKoggCc79/PGckDslMZibJSSa/z3XNRXLOyTn3\nhDO583Rzd0RERJKpF3cAIiKSv5QkREQkJSUJERFJSUlCRERSUpIQEZGUlCRERCQlJQkREUlJSUIk\nDWY2yMzOzPSxSV7bzMzKzKxebc9VxXUmmNlBmT5vimstMrPmubiWZJ5pMJ1kg5lNBc5193fjjiVO\nZnY28Gd3PzDN45sBXwMN3L0sQzH0BGa4+82ZOF8V1xoG9HH3Z7N9LckNlSQkFmZWP+4YcsQAfROT\nwuXu+qljP8BU4CrgU+AHoB/QMNp3NjC8wvFlwDbR457Ao8AgYBEwHNgUeAD4HpgI7FbF9XsDK4Bf\ngJ+Aq4Fm0XXOAaYDpdGx+wIjojg/AQ5OOM+6wDPAbGAGcBsrS78tgFJgITAP6JcilkHARRW2jQWO\njx4/AMwFfozer51TnGcYcE7iewjcF70nXwFtKx4L7Aj8CiyL3svvo/3HAGOia04Huia8tln03tVL\nct2x0fv5U3S+MuCgaN9LwJzofSwFdoq2nwf8BiyJXvdGwj1yaPS4IfAgMAuYGb0nDaJ9B0fv/ZXR\n+zQL6JziPbodWA4sjq71cG3vL2Bz4JXo//gr4NK4/76K7Sf2APSThf/U8AEwMvrjaxz94Z0f7Tsb\neL/C8Ssq/BHPA3aPPjzeIVR/nE74Vnwb8G6aMRyS8Lw8STwHrAGsDmwBzAeOio45LHq+YfT8NeAx\noBGwUfQ7nRft6wvcED1uCPxfijjOBD5IeL5z9GHUADgS+BBYJ9q3A7BpivNUTBJLCYnAgAuAWZUc\nW/H9PghoGT3ehfDhflzC+5Q0SVQ4x3nR/+va0fPOwJrR7/VP4JOEY3sCtyb5/ylPErcC/wU2jH5G\nALdE+w4mJLmuQH3gaELyX6+q96m291f0/CPgpujazYEvgSPi/hsrph9VN9VdD7n7XHdfCAwk/FGm\nYhWev+buY939N8IH9a/u/oKHv9wXqzhXZed1wrfmX919KXAG8La7/wvA3d8hfCgcY2abED6QrnD3\nJe4+n/Btt2N0rmVAMzNr4u6/uft/U8TwGrCbmW0ZPT8NGODuy6JzrAPsbGbm7pPdfW6av9t0d382\nek96AZtHMVfJ3d9398+ixxOA/oQP47SY2QGED9P27v5zdJ7n3H1x9HvdSvid10nzlKcRksICd18A\n3EJIruV+A25z9xXuPhj4mZBQ0w65wvN07682wEbufkd07WmEkmVHJGeUJOquxA+7xcDaNXztr0me\nV+dcFc1MeNwMOMXMvo9+fgD2J1QxNCN8K56TsO8JYOPotdcQ7t/RZjbezLoku1j0ITqIlR8snYAX\non3DgO6E6o+5ZvaEmaX7u32bcI1fo4dpvdbM2pjZu2Y2z8wWAn8hlJTSee2WhA/Ss9z9q2hbPTO7\n28y+jM43lZCQ0zonoUT3TcLz6dG2cgv8j43o1b2fKkr3/toKaFLh/rgBSCsZS2YoSRSfXwjVEgCY\n2WZZuk6qxtrE7TOA3u6+QfSzvruv4+73RvuWEKqeyvc1dvdWAO4+z93Pd/cmhOqex8xsmxTX7Aec\nZmb7AqtHyYHoPN3dvTWhGmoHQvLJpGTvQ1/gdaCJuzcGnmTVb9urMLNGhG/e/3T3oQm7TgPaE6qP\nGhOqZSzhnFU1nM8mJOVyzaJtNZHJRvoZwNcV7o/13L19Bq8hVVCSKD6fAi3NrJWZrU6oa67uH3aV\nH2iEb9oVP7Qrvu55oL2ZHRl9G25kZgeb2Rbu/i0wFHjAzNaxYJvyvv1mdpKZNYnOs5DQ3pGqy+gg\nwgffrYRv4UTnaB19q1+N8A12SSXnqKm5QFMza5CwbW3gB3dfZmZtCB/yiVK9vz2Bz939/grb1yG0\nkfxgZmsBd/HH/9O5rPp/kagf8Dcz28jMNgL+DvSp7JeqRFXXSkf57z8aWGRm10b3Rn0za2lmrWt5\nfqmGrCYJM+thZnPNbFwVx+1tZsvM7MRsxlNEUn7ou/sXhA/Ld4AphN4lGTt/gruBv0fVBFcme527\nzwQ6ADcC3xGqOa5m5X15FqFxcyKhsflloLzkszcwysx+Inwrvyyqs1412FD3PYDQMN43Yde6wNPR\nuacSGs3vS/H7VPU7e4rH7wKfAd+a2bxo28XAbWb2I/A3EhJXFec6FTghGpy2yMx+MrP9Cb3JviH0\nPJpAaIRO1IPwxeB7MxuQ5Ly3E9qCxhG+RHwE3JHm71rRQ8DJZrbAzB5M4/iU54+quNoR2iimEhq8\nnyb8v0mOZHUwXdTA9jOhSqFVimPqAf8mfJN71t0HJDtORERyL6slCXf/gNBvuzKXsrIftIiI5JFY\n2yTMbAvCoKbHSa+eW/KEmW2ZUOVR/lP+vGnc8YlIZqwW8/UfBK5LeK5EUSDcfQahwVRE6rC4k0Rr\noL+ZGaFP99Fmtszd36x4oJlp/hsRkRpw9xp/Ac9FdVNif+0/cPdtop+tCe0SFyVLEAnH68edrl27\nxh5DvvzovdB7ofei8p/aympJwsz6AiXAhmb2DaFPfkPA3f2pCoerpCAikmeymiTcveIgocqOPSeb\nsYiISPVpxHUBKikpiTuEvKH3YiW9FyvpvcicglmZLkzSWRixiojkCzPD87zhWkRECpSShIiIpKQk\nISIiKSlJiIhISkoSIiKSkpKEiIikpCQhIiIpKUmIiEhKShIiIpKSkoSIiKSkJCEiIikpSYiISEpK\nEiIiBebXX2H58txcS0lCRKTA/PWv0LYtLFuW/WspSYiIFBB3eOst+OUXuPDC8DyblCRERArI+PHQ\nqBH8+9/w8cdw773ZvV5Wly8VEZHMGjIkVDWtvTYMHAj77QctWsBJJ2XneipJiIgUkMGD4eijw+Om\nTeGNN0K108KF2bmeli8VESkQixbBFlvAt9/CWmut3H7uubD55nD77au+RsuXiogUiXfegX33/WOC\nALj5Znj8cZg3L/PXVJIQESkQ5e0RFTVrBqefDnfdlflrZrW6ycx6AO2Aue7eKsn+04DroqeLgAvd\nfXyKc6m6SUTqtNmzQylhvfVW3ecOW28NgwbBzjuvuv/bb6FlSxg7FrbccuX2fK9u6gkcVcn+r4GD\n3H034Hbg6SzHIyKSt84/Hzp1Sj72YdIkKCuDnXZK/trNNoPzzoPbbstsTFlNEu7+AfBDJftHuvuP\n0dORQJNsxiMikq+WLIH334dp06Bv31X3l1c1WSVlgmuvhQEDYOrUzMWVT20SfwYGxx2EiEgchg+H\nXXaB3r3hyivhu+9W7isfZV3e9TWVDTaAESOgefPMxZUXScLMDgG6sLJ9QkSkqJSPf2jdGs46Cy6/\nPGyfORPat4f58+GII6o+zw47VF7aqK7YR1ybWSvgKaCtu6esmgLo1q3b749LSkooKSnJamwiIrky\nZAj06hUe33ILtGoFl14K/fuHfwcMgIYNqz5PaWkppaWlGYsr64PpzKw5MNDdd02ybyvgHeBMdx9Z\nxXnUu0lE6qTp02HvvUMPpXpR/c5774XBcQ88EKqhaqq2vZuy3QW2L1ACbAjMBboCDQF396fM7Gng\nRGA6YMAyd2+T4lxKEiJSJz35ZGiTeP75zJ87r5NEJilJiEhddfzxcPLJYUBcpilJiIgUsN9+g403\nhi+/DP9mWr4PphMRKWru0LUrpGpLHjEi9EjKRoLIBCUJEZEs6toVevSAyy4LI6YrGjw4+XxM+UJJ\nQkQkSx5+OHRhHTMmLBLUr98f95eVwdtvVz1ILk5KEiIiWdC3L9x3HwwdCptsEmZo/fvfQxtEuVtu\ngcaNoU3SPp35QUlCRCTD5s2DSy4JVUnlU2QcfDBsvz0880x4/uqr0LNnGCRXv35soVYp9hHXIiJ1\nTc+ecMIJqw6Cu+OOMMXGHnvABReEUdabbhpPjOlSkhARyaCyMnj6aXjhhVX37bUX7L9/KFX06hWe\n5zslCRGRDBo2LCwclKqd4R//gGOOCetGFAINphMRyaBTT4WDDoKLL447kkAjrkVE8sS8eWFg3NSp\noddSPtCIaxGRPNGrV2iwzpcEkQlqkxARyQB3eOop6NMn7kgyS0lCRKSWJk4MPZrWWAP22SfuaDJL\n1U0iIjWwdCk8+mgY83DEEWFA3IABmV06NB+oJCEiUg1lZfDii3DTTbDTTvDPf4beTPk8aro2lCRE\nRNI0bhycc05YYvTZZ6GkJO6Isk/VTSIiVSgrC4PgDjssjH8YNao4EgSoJCEiUqlp06BLF1i+HEaP\nhq23jjui3FJJQkQkiWXLwlTfrVuHRYFKS4svQYBKEiIiqxgxAi66KMzQOnIkbLtt3BHFR0lCRIQw\nGG7IELjnnjCtxl13hUn46lqX1upSkhCRojZtGrzyShgpXVYG110XJulr0CDuyPJDVif4M7MeQDtg\nrru3SnHMw8DRwC9AZ3cfm+I4TfAnIjW2fDncfz98+WVIBmVlMGFCSBInnACnnBJ6L9W1kkNezwJr\nZgcAPwO9kyUJMzsauMTdjzWzfYCH3H3fFOdSkhCRGpk/P5QO6teHk08O4xzq1YNmzcJAuNXqcJ1K\nbZNEtd4aM1sLWOLuK9I53t0/MLNmlRzSAegdHTvKzNYzs03dfW514hIRSeXTT0NJ4eST4c476+7I\n6GyptAusmdUzs9PM7G0zmwdMAuaY2UQzu8/Matvm3wSYkfB8VrRNRKTWBg6Eww8PyeGee5QgaqKq\ncRLDgBbADcBm7r6lu28CHACMBO4xszOyHKOISLU99RScfz4MGgQdO8YdTeGqqrrpcHdfVnGju38P\nvAq8ama16QMwC9gy4XnTaFtS3bp1+/1xSUkJJcUyLl5E0uYOXbtC374wfHjxjXEoLS2ltLQ0Y+dL\nq+HazFoAM919qZmVAK0IjdEL03htc2Cgu++aZN8xwMVRw/W+wINquBaRmho+HG69FRYuhLffhk02\niTui+OWkd5OZjQVaA82BQcAbQEt3P6aK1/UFSoANgblAV6Ah4O7+VHRMd6AtoQtsF3cfk+JcShIi\nAoQk0L07rL46rL8+NGwIPXrAzJlw/fVw1llhn+QuSYxx9z3N7BpC76ZHzOwTd9+jpheuLiUJEYEw\nvqFDh9AI3aIF/PADLFoUtnXsWLe7s9ZErrrALjOzTsDZQPtom8YjikhKTzwBLVvCgQdm9rx33QXf\nfw/DhoUShGRXurPAdgH2A+5w96lmtjVQx5b7FpFMmTwZLrsMnnkms+cdOjQsGfryy0oQuZLVEdeZ\npOomkcLgHqbWbtECXn8dZs3KzFQX06fDPvuEpUMPPrj25ysWta1uqmow3UAza5+sm6uZbWNmt5rZ\nOTW9uIjUPa+/DjNmwEMPwRprwGef1f6cpaWw//7wt78pQeRaVW0S5wFXAg+a2ffAd0AjQi+nr4Du\n7v5GViMUkYKxeDFccUVY/7lBAzjiiFBFtMsuNTvfihVw++3w5JPw3HNw5JEZDVfSkHZ1UzTeYXPg\nV2CKuy/OXlhJr6/qJpE8d/PNoT3ixRfD8wEDwsjnIUOqd55ly+DNN8OsrY0awQsvwOabZz7eYpDX\ns8BmkpKESH5bvDh8kE+YAFtG8ygsXBgef/dd+LCvysKFcO+90LMnbLddmFajUyfNuVQbWW2TEBFJ\n17vvwp57rkwQAI0bw667huVAqzJ6NOyxB8ybF871/vtwxhlKEHFTkhCRjHjrLWjXbtXt5e0SqbjD\ngw+G195/f+g2u9NO2YtTqiftJGFma5jZDtkMRkQKk3vqJHHkkamTxPjxYX/fvjBqFJx4YnbjlOpL\nK0mYWXtgLDAker67mb2ZzcBEpHB8+mno7rr99qvua9MGpk6FuQlLic2dC3/5S1gu9LjjQnXU1lvn\nLl5JX7oliW5AG2AhQLQOtf5LRQQIM64ee2zyQXMNGsAhh8A774TxE1dcEaqT1l479IS69NJwjOSn\ndJPEMnf/scI2dTUSESB1VVO5I4+E666D3XcPDdHjxoX2h/XXz12MUjPpTvD3mZmdBtQ3s+2Ay4D/\nZi8sESkU8+bB55/DQQelPuaUU2D58tBbSYmhsKQ7VfiawE3AkYAB/wJuc/cl2Q3vDzFonIRIHurV\nK6wl/corcUciyWgwnYjE6uSTQ3tE585xRyLJ5GrRodbAjYQ5m36vonL3VjW9cHUpSYjkn99+C0uE\nTp4Mm24adzSSTK4WHXoBuAYYD5TV9GIiUnesWAF33hl6KilB1F3pJonv3F3jIkQEgClTQvVSo0bQ\nr1/c0Ug2pVvddBjQCXgHWFq+3d0HZC+0VWJQdZNIzNyhe3e45Rbo1g0uugjqaXKfvJar6qYuwI6E\nda3Lq5scyFmSEJF4LVgAXbrAnDnwv/+FWVql7ks3Sezt7pq3SaRIPPssvPoq7LZbmNl19dXh4ovD\neIdXXtH60sUk3STxXzPb2d0nZjUaEYnVkiVhmowRI1YuINSnT1hf+skn4eij445Qci3dJLEvMNbM\nphLaJAzwdLrAmllb4EHCFCA93P2eCvu3BHoBjaNjbnD3wen/CiJSU+PHw9KloWSwdGloY2jePMzI\nus46cUcn+SDdhutmyba7+/QqXlcPmAIcBswGPgQ6uvukhGOeBMa4+5NmthMwyN1XmTxQDdcimeMe\nSgrPPANNmoTxDsuWwZ//DFdemXyiPilMWW24NrN13f0nYFENz98G+KI8mZhZf6ADMCnhmDJg3ehx\nY2BWDa8lImkoK4PLLw9VSp9+GgbDiaRSVXVTX6Ad8DGhN1NiNnJgmype3wSYkfB8JiFxJLoFGGpm\nlwFrAodXcU4RqaFly+Ccc0Ibw7BhsN56cUck+a7SJOHu7aJ/s7l2RCegp7s/YGb7As8DLbN4PZGi\ntHw5nH46/PwzDBkCa64Zd0RSCNJquDazd9z9sKq2JTEL2CrheVNWrU46FzgKwN1HmlkjM9vI3edX\nPFm3bt1+f1xSUkJJSUk64YsUvRUr4Oyz4aef4I03QpdWqZtKS0spLS3N2Pkqbbg2s0aEKqBhQAkr\nq5vWBYa4+46VntysPjCZ0HA9BxgNdHL3zxOOeRt4yd17RQ3X/3b3pknOpYZrkRooK4Nzz4VvvgmL\nA62xRtwRSS5le8T1X4C/AlsQ2iXKL/QT0L2qk7v7CjO7BBjKyi6wn5vZLcCH7v4WcDXwtJldQWjE\nPrtGv4mI/MHy5VBaCo8+GkZLDx6sBCHVl24X2Evd/ZEcxFNZDCpJiKRh3rwwr9Irr4QxD6ecAhdc\nENaUluJT25JEWlNzxZ0gROSPfv4ZnngChg8PYx7KvftumEZjzTXDgLjRo+Hqq5UgpOa0Mp1IAVm8\nGB5/HO67D/bdFyZODAngssvgq6+gR4+wnOgRR8QdqeSLXM0CKyIxmzoVDjggJId//xt23TU0Sv/r\nX/Dww6HH0iefaAEgyay0SxJm1gRoxh+XL30/S3Elu75KElLUjjsO9tkHbrop7kikkOSkJGFm9wCn\nAhOBFdFmB3KWJESK2cCBYUbWl1+OOxIpNun2bpoMtHL3pVUenCUqSUixWrwYWraEp5+GwzVpjVRT\nTno3AV8TVqUTkSyaOzcsDTpgQJhnCeDuu6FNGyUIiUe6JYlXgd1YdY3ry7IX2ioxqCQhddaPP4Ye\nS48/Dn/6E0yaBFOmQMeO8PzzMHYsNF1lHgKRquWqd9Ob0Y+IZNi4caGUcOyxMGYMNItWb5k0KXRp\nfeABJQiJT3V6NzUEto+eTnb3ZVmLKvn1VZKQOmfpUth7b7jiCujSJe5opC7KSZuEmZUAXwCPAo8B\nU8zsoJpeVKTYTJ8Ohx4Kb1Yoj998M7RoAZ07xxKWSJXSrW66HzjS3ScDmNn2QD9gr2wFJlJXjBsH\nxxwDnTqFOZSmTQsjpIcPhz59wupwWi5U8lW6SaJBeYIAcPcpZqbeTiJVKC0NE+w9/HBohL744tD2\nMHlymJX1ySdh443jjlIktXR7Nz1LmMb7+WjT6UB9dz8ni7FVjEFtElJQyhNE//6hqqncwoVw6qmw\nzTahN5NINtW2TSLdJLE6cDFwQLRpOPBYLgfXKUlIIZkxI4xt6NMn9fgGd1UzSfblJEnkAyUJKRRL\nlsCBB4ZSxDXXxB2NFLusJgkze8ndTzGz8YS5mv7A3VvV9MLVpSQhhcAdzjknTKXRv79KChK/bA+m\nuzz6t11NLyBSLNzhrrvg44/hf/9TgpC6odJxEu4+J3p4kbtPT/wBLsp+eCL5xR3++1947rmwOly5\nX36B004LS4a+9RastVZsIYpkVLoT/CVb5+roTAYiks/mz4d774WddgrVSa+8EqbPuOYaeO+9sBDQ\n6qvDiBGw1VZxRyuSOZVWN5nZhYQSwzZmNi5h1zrAiGwGJpIv3KFDh/Dh/+yzsN9+oSpp2jTo3h3O\nPBNuuCEMlFMVk9Q1VTVcrwesD9wFXJ+wa5G7f5/l2CrGooZricXAgXDjjWEm1vr1445GpHpy2gXW\nzDYBGpU/d/dvanrh6lKSkDisWAG77w533gnt28cdjUj15WqCv/Zm9gUwFXgPmAYMTvO1bc1skplN\nMbPrUhxzipl9Zmbjzez5ZMeIxKFvX1h3XWin/n1SpNIdcf0pcCjwH3ffw8wOAc5w93OreF09YApw\nGDAb+BDo6O6TEo7ZFngROMTdfzKzjdx9fpJzqSQhObV0Key4I/TuHQbHiRSiXC1fuszdFwD1zKye\nuw8DWqfxujbAF1G32WVAf6BDhWPOAx51958AkiUIkTg8+WRYW1oJQopZurPALjSztYH3gRfMbB7w\nSxqvawLMSHg+k5A4Em0PYGYfEJLWLe7+rzTjEsmYxx6Da6+FevWgQYNQkhihPnxS5NJNEh2AX4Er\nCDPArgfcmsEYtgUOArYC3jezXcpLFiK5MGQI3HZbGC292WawbBmstho0bhx3ZCLxSjdJXAk85+4z\ngF4AZnY+8FQVr5tF+OAv1zTalmgmMNLdy4BpZjYF2A74uOLJunXr9vvjkpISSkpK0gxfJLWJE+Gs\ns2DAANhhh7ijEamd0tJSSktLM3a+dBuu5wHfAZdE7RGY2Rh337OK19UHJhMarucAo4FO7v55wjFH\nRds6m9lGhOSwu7v/UOFcariWjJs/H/bZB7p2DYlCpK7JVcP1LMI0HHebWfnkx1Ve1N1XAJcAQ4HP\ngP7u/rmZ3WJm7aJj/gUsMLPPgHeAqysmCJFMcw8lh//7v7AAkBKESHLpliQ+ibq+NgIeB9YGdnX3\nHbMdYEIMKklIrbmHtaWvvz5M533PPXDkkZpOQ+qubE8VXu4jAHdfAnQxs4uBvWp6UZFcmzMHnn8e\nevUKiwJ17Qqnnx56MolIalqZTuq8Bx6AW2+FE0+Es8+GAw5QcpDikdWSRD6tTCdSE08/DQ8/DOPH\nQ9OmcUcjUniqmgV2c3efY2bNku2PFh/KCZUkpLpefBGuvDKs97DttnFHIxKPnM4CGyclCUnXb7/B\nSy/BVVfBf/4Du+4ad0Qi8cl2ddMiklQzEbq/uruvW9MLi9RWWRksWAALF8KPP8KMGfDGG2H9h+23\nD/8qQYjUjkoSEotly2DYsND9tDpGjQqJYPRo+OijsAjQ+uuH6TM23hiOOQZOOEHtDyLltOiQFKTB\ng+HYY+Hrr6F58/ReM2YMHHUUXHhhGCW9996wySZZDVOk4OVq0aHjarrokEgyAwfCBhvAU1XN/hWZ\nPz90YX3ssdCd9dhjlSBEciHd3uK3AfsCU9x9a8JcTCOzFpXUae7w1lvwzDPw7LNhSu7KLF8eps7o\n2BFOPjk3MYpIkO1Fh0RW8emn0LAhdOgQFvUZMKDy46+9NkzbfccduYlPRFZKN0lUXHToIdJbdEhk\nFQMHQvv2Yb6kCy+Exx9Pfty8eaEEMWQI9OsXGqlFJLfSTRKJiw4NAb4C2mcrKKk7LrgglBwSDRwI\n7dqFxx06wJdfwoQJK/e7Q//+0KoVbLVVWAhogw1yF7OIrKQusJI1s2fDlltCmzZhGdB69cJEezvv\nDHPnhionCJPtLVgAjzwSRkffemvY/+yzoReTiNRcVns3RetOY2aLzOynhJ9FZqblRaVSb78NJ50U\nSgY9e67cduSRKxMEwHnnQd++cPDB4fFZZ8HYsUoQIvmg0hHX7n5A9O86uQlH6pI334ROnWCnnaBt\nWzj++FDVVLGHUtOmYX2HJk1CG8Rq6U5gLyJZl+6iQ33c/cyqtmWTqpsKy+LFsNlmMH16GBF96aXw\n00/w2mswdSpsuGHcEYoUh1wtOtSywkVXQ4sOSSXeeQf22iskCIDbboMdd4Tdd1eCECkkVU3wdwNw\nI7BGQhuEAb8BaY6VlWJU3s21XOPG0KdPmLNJRApHutVNd7n7DTmIp7IYVN1UIMrKQvvC++/DdtvF\nHY1Iccv2VOE7uvsk4GUz27PifncfU9MLS9318ceh5KAEIVL4qmqTuBI4H7g/yT4HDs14RFLwKlY1\niUjh0mA6ybjddw8D4w48MO5IRCQnU4VHF/o/MzvNzM4q/0nzdW3NbJKZTTGz6yo57k9mVpasWksK\nw4oVYZT0zJmw335xRyMimZBWF1gz6wO0AMYCK6LNDvSu4nX1gO6EqcVnAx+a2RtRO0ficWsDl6Hp\nxwuSexg4d9NNoS3i7bc1IE6krkj3T7k1sHMN6nvaAF+4+3QAM+tPmCxwUoXjbgPuBq6t5vklZhMn\nwkUXhbmX7r47LAZkNS7Yiki+Sbe6aQKwWQ3O3wSYkfB8ZrTtd2a2B9DU3bXSXQFZvBhuuCHMt3Ty\nyWGupXbtlCBE6pp0SxIbARPNbDTw+zpi7n5cbS5uZgb8Ezg7cXNtzinZtWBBWFGue/fQMD1uHGy+\nedxRiUi2pJskutXw/LOArRKeN422lVuHMOVHaZQwNgPeMLPjko3B6NZtZRglJSWUlJTUMCyprpkz\nwxTeL79V3Qp9AAANgElEQVQc1oB4/fUw7YaI5JfS0lJKS0szdr6sdoE1s/rAZELD9RxgNNDJ3T9P\ncfww4Ep3/yTJPnWBjYE7PP10aJQ+7zy4/HLYdNO4oxKRdGV7xPUiQi+mVXYB7u7rVvZ6d19hZpcA\nQwntHz3c/XMzuwX40N3fqvgSVN2UN776KiSGn3+GYcNgl13ijkhEck2D6WQVv/0G//gH/POfYZ2H\nv/5VXVpFClWupgqXIvHee3DhhdCiBXz0ETRvHndEIhInJQkB4Ouv4brrYNQoePBBOOEEdWcVkWpM\nyyF105w5cO21sPfesNtuMGkSnHiiEoSIBCpJFKGff4YBA+D55+HDD8O60hMmaLyDiKxKDddF5q23\n4IILYI894Mwzw5Tea6wRd1Qiki1quJa0fP996KU0YkRYRvSQQ+KOSEQKgdokisCAAbDrrrD++mEa\nDSUIEUmXShJ12LffwiWXhPaGF1+EAw6IOyIRKTQqSdRBy5fD44+H3krbbx9maFWCEJGaUEmiDnGH\nQYPgmmtgiy1g6NCQKEREakpJoo4YNQpuvBFmzw5TahxzjMY6iEjtqbqpwE2YAMcfDyedBJ06hYZp\nrQ4nIpmikkQB+uGHsK5D797w5ZdhxHT//tCoUdyRiUhdo8F0BcQd7rwT7r0XjjoqDIZr2xYaNIg7\nMhHJVxpMVyQWL4YuXWDaNJg4EZo0qfIlIiK1pjaJAjBjRlhPumHDMJW3EoSI5IqSRJ576SVo3TpM\nwte7t9odRCS3VN2UpxYsCKOlP/kEBg6ENm3ijkhEipFKEnnGPUyh0aoVbLppSBJKECISF5Uk8sjk\nyaH0MHeu5loSkfygkkQemD8frr4a9t8/jJQeM0YJQkTyg5JEjH78EW6+GXbYAX79FcaPhyuugNVU\nvhORPKGPoxxzh5EjoUcPePVV6NABPvoItt467shERFaV9ZKEmbU1s0lmNsXMrkuy/woz+8zMxprZ\nv81sy2zHFJfS0rD4T+fOsN128Nln8NxzShAikr+yOi2HmdUDpgCHAbOBD4GO7j4p4ZiDgVHuvsTM\nLgBK3L1jknMV7LQcv/4KN90UGqOfeALatdMEfCKSG7WdliPbJYk2wBfuPt3dlwH9gQ6JB7j7e+6+\nJHo6EqhT44lHjgyD4WbODDO0tm+vBCEihSPbbRJNgBkJz2cSEkcq5wKDsxpRjnzzDVx/Pbz/Ptx3\nH3TsqOQgIoUnb3o3mdkZwF7AfXHHUhu//AJ//zvssUdod5g8OazzoAQhIoUo2yWJWcBWCc+bRtv+\nwMwOB24ADoqqpZLq1q3b749LSkooKSnJVJy15h7mWbrmmjAZ36efQtOmcUclIsWmtLSU0tLSjJ0v\n2w3X9YHJhIbrOcBooJO7f55wzB7Ay8BR7v5VJefK24brjz4KyeGHH+CRR0KSEBHJB3ndcO3uK4BL\ngKHAZ0B/d//czG4xs3bRYfcCawEvm9knZvZ6NmPKpIkT4U9/CmMdTj01JAslCBGpS7QyXTWtWAFD\nh8Izz8Dw4WHp0IsvhjXWiDsyEZFVaWW6LBoyBP7yF9h4Y9hqK9hoIxg8GDbbDP78Z+jZE9ZdN+4o\nRUSyRyWJFCZMgEMPDQv9bLBB6NI6ezYcfDDstlvOwhARqZXaliSUJJKYNw/22Qduuw3OOCMnlxQR\nyYq8brguREuWwAknwOmnK0GIiKgkkeCbb8LkextuGOZZqqcUKiIFTiWJDHAPs7HutRccfjj066cE\nISICRdy76euvw4R748eHKby/+w7+8x81SouIJCq66qa5c8O4hg8+CCWHXXeFVq3CoLjVV89AoCIi\neUTjJNLkDi+8AFddBeeeC88/D40axR2ViEh+K4okMXIk/O1voUpp0KBQghARkarV6ebZMWPg2GPh\nlFNWzq2kBCEikr46myR694ajjw4/X3wB550HDRrEHZWISGGpk9VNDzwQfkpLYaed4o5GRKRw1akk\n4R7aHgYMCL2Xttqq6teIiEhqdSZJfPghXHklLF8epvDeaKO4IxIRKXwF3ybxzTdw5plh4Z/OnUMJ\nQglCRCQzCjZJzJgBF10Eu+8OzZrB5Mlh/EP9+nFHJiJSdxRkkrjqqjB9xjrrwKRJcPvt4bGIiGRW\nwbVJjBsHL78cSg4bbxx3NCIidVvBlSReeCGs9aAEISKSfQU1wd+KFU7z5vD222FiPhERqVxRrScx\nfDg0bqwEISKSK1lPEmbW1swmmdkUM7suyf6GZtbfzL4ws/+ZWcohcH37hqomERHJjawmCTOrB3QH\njgJaAp3MbMcKh50LfO/u2wEPAvemOt+rr0KnTtmKtnCUlpbGHULe0Huxkt6LlfReZE62SxJtgC/c\nfbq7LwP6Ax0qHNMB6BU9fgU4LNXJdt5ZU22A/gAS6b1YSe/FSnovMifbSaIJMCPh+cxoW9Jj3H0F\nsNDMNkh2MlU1iYjkVj42XKdshT/ppFyGISIiWe0Ca2b7At3cvW30/HrA3f2ehGMGR8eMMrP6wBx3\n3yTJuQqjr66ISJ7J5zWuPwS2NbNmwBygI1Cx6XkgcDYwCjgZeDfZiWrzS4qISM1kNUm4+wozuwQY\nSqja6uHun5vZLcCH7v4W0APoY2ZfAAsIiURERPJAwYy4FhGR3MvHhutVVDUgry4zs6Zm9q6ZfWZm\n483ssmj7+mY21Mwmm9m/zGy9uGPNBTOrZ2ZjzOzN6HlzMxsZ3Rv9zKzgJq2sKTNbz8xeNrPPo/tj\nn2K8L8zsCjObYGbjzOyFaIBu0dwXZtbDzOaa2biEbSnvAzN7OBq8PNbMdq/q/HmfJNIckFeXLQeu\ndPeWwH7AxdHvfz3wH3ffgdCOc0OMMebS5cDEhOf3APe7+/bAQsLgzGLxEDDI3XcCdgMmUWT3hZlt\nAVwK7OnurQhV6J0orvuiJ+HzMVHS+8DMjgZaRIOX/wI8UdXJ8z5JkN6AvDrL3b9197HR45+Bz4Gm\n/HEQYi/g+HgizB0zawocAzyTsPlQ4NXocS/ghFzHFQczWxc40N17Arj7cnf/kSK8L4D6wFpRaWEN\nYDZwCEVyX7j7B8APFTZXvA86JGzvHb1uFLCemW1a2fkLIUmkMyCvKJhZc2B3YCSwqbvPhZBIgFW6\nDddBDwDXAA5gZhsCP7h7WbR/JrBFTLHl2tbAfDPrGVW/PWVma1Jk94W7zwbuB74BZgE/AmOAhUV6\nX5TbpMJ9UJ4IKn6ezqKKz9NCSBICmNnahGlLLo9KFBV7HNTpHghmdiwwNypVJXaHLtau0asBewKP\nuvuewC+EKoZiuy8aE74dNyMkgrWAtrEGlZ9qfB8UQpKYBSTO2NQ02lY0omL0K0Afd38j2jy3vJho\nZpsB8+KKL0f2B44zs6+BfoRqpocIxeXy+7iY7o2ZwAx3/yh6/iohaRTbfXE48LW7fx9N6/Ma4V5p\nXKT3RblU98EsYMuE46p8bwohSfw+IM/MGhLGUbwZc0y59iww0d0fStj2JtA5enw28EbFF9Ul7n6j\nu2/l7tsQ7oF33f0MYBhhECYUwftQLqpKmGFm20ebDgM+o8juC0I1075m1sjMjJXvQ7HdF8YfS9WJ\n90FnVv7+bwJnwe8zYiwsr5ZKeeJCGCdhZm0J3xrLB+TdHXNIOWNm+wPvA+MJRUYHbgRGAy8RvhVM\nB05x94VxxZlLZnYwcJW7H2dmWxM6M6wPfAKcEXVwqPPMbDdCI34D4GugC6ERt6juCzPrSvjisIxw\nD/yZ8A25KO4LM+sLlAAbAnOBrsDrwMskuQ/MrDuhSu4XoIu7j6n0/IWQJEREJB6FUN0kIiIxUZIQ\nEZGUlCRERCQlJQkREUlJSUJERFJSkhARkZSUJEQyxMzOjka3itQZShIimdOZFJOlJUwRIVJQdONK\nnRZN5zIxmiV1gpkNiaZwGGZme0bHbGhmU6PHZ5vZa9GCLV+b2cXRojZjzOy/0YRyya7zJ6A18Hx0\nbCMzm2pmd5vZR8BJZraNmQ02sw/N7L3yKTXM7ORoQalPzKw02razmY2KzjXWzFrk4v0SqUhJQorB\ntsAj7r4LYQGaP1H5bKktCeswtAHuAH6OZlodSTTvTUXu/iphnrHT3H1Pd18S7Zrv7q3d/SXgKeAS\nd9+bMOX549ExfweOdPc9gOOibRcAD0bXbU2Y0E8k5+rskn4iCaa6+/jo8RigeRXHD3P3xcBiM1sI\nvBVtHw/sWsnrKk6yBvAigJmtBfwf8HI0ER2EOZcARgC9zOwlYEC07X/ATdFCS6+5+5dVxCySFSpJ\nSDFYmvB4BeHL0XJW3v+NKjneE56XUf0vVr9E/9YjLJC0p7vvEf3sAuDuFwI3ESZj+9jM1nf3fkB7\nYAkwyMxKqnldkYxQkpBikGxhommEahxYOaV0bf0ErJtsh7svAqaa2Um/B2XWKvp3G3f/0N27Eub9\n39LMtnb3qe7+CGGa51YZilGkWpQkpBgka3/4B3ChmX0MbFCN11amF/BEecN1kteeDpwbNURPYGX7\nw31mNs7MxgEj3H0ccErU0P4JoY2kdzXiEMkYTRUuIiIpqSQhIiIpqXeTSDVFK3vtT6hOsujfh9y9\nV6yBiWSBqptERCQlVTeJiEhKShIiIpKSkoSIiKSkJCEiIikpSYiISEpKEiIiktL/A/f1rtiUE6Po\nAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x7fcea3149e50>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "import matplotlib.pyplot as plt, time\n",
-    "x_cor = []\n",
-    "y_cor = []\n",
-    "for x in range(100):\n",
-    "    start_time = time.time()\n",
-    "    AnnoyIndexer(model, x)\n",
-    "    y_cor.append(time.time()-start_time)\n",
-    "    x_cor.append(x)\n",
-    "\n",
-    "plt.plot(x_cor, y_cor)\n",
-    "plt.title(\"num_trees vs initalization time\")\n",
-    "plt.ylabel(\"Initialization time (s)\")\n",
-    "plt.xlabel(\"num_tress\")\n",
-    "plt.show()"
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Initialization time of the annoy indexer increases in a linear fashion with num_trees. Initialization time will vary from corpus to corpus, in the graph above the lee corpus was used"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Relationship between num_trees and accuracy"
+    "#### Build dataset of Initialization times and accuracy measures"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 18,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYMAAAEaCAYAAADzDTuZAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xm8nPPd//HXJ0gsEUIImliCKCo0IlSUI2qtSuwllFBR\nSxf6cxelSevufYu2VNVaepc6BAlqi9ByVCmyIJFIokQIWckmgsT5/P74XlcyOZk5Z7Zr1vfz8ZjH\nmbnmWr5z5pz5zOe7mrsjIiL1rV25CyAiIuWnYCAiIgoGIiKiYCAiIigYiIgICgYiIoKCgYiIoGAg\nVcTMZphZ/3KXQ6QWKRhIzTCzdcpdhmpiZvr/l1X0xyBZib6V/9TMXjezhWZ2r5m1j547w8yeb7F/\ns5n1iO7/n5ndaGZPmNlSM3vezLqa2XVm9rGZTTGzPdu4/l3AtsCjZrbEzP6fmW0XXecsM5sJ/CPa\ndz8zeyEq56tmdlDKeTqZ2e1m9qGZvW9mV5mZRc/taGZNZrbIzOaZ2b0ZyvKEmZ3fYttrZjYwun+d\nmc01s8XR72u3DOc5M3rtS8zsP2Y2pMXzA6LyLzazt8zssGh7ZzP7s5l9YGYfmdmDObwPN5nZ42a2\nFGgws6PMbEJ0jZlmNrTF8Qek/C5nmtn3zKyPmc2Jf2/RfseZ2WuZ30GpeO6um25t3oAZwEtAV2BT\nYAowJHruDOCfLfb/EugR3f8/YB6wF9Ce8KH9DjAIMOAq4Jksy3BwyuPtgGbgL8AGQAdgG2ABcHi0\nzyHR482jxw8BNwHrA12i13RO9Nw9wGXR/fbA/hnKcTrwr5THuwEfA+sBhwFjgY2j53YBumY4z5HA\n9tH9bwLLgL2ix32BRUD/6PHWQM/o/uPAvUAnYB3gmzm8DwuB/VJe44HA7tHjrwGzgWNSfr9LgJOi\n63QGekXPvRH/jqPHDwI/KfffqW7535QZSC6ud/e57r4IeJTw4Z6JtXj8kLu/5u5fED6Ql7t7o4dP\nkvvaOFdr53VgqLsvd/fPgdOAx919DIC7/wMYBxxlZlsSPoAvcvfP3H0B8Hvgu9G5VgDbmdlX3P0L\nd38xQxkeAvY0s+7R41OBB919RXSOjYHdzMzcfZq7z013Encf7e7vRvefB54iBAWAs4A73P2Z6PnZ\n7j7dzLYCDgfOdfcl7v5ldGy2v6+/uftL0Tm/cPd/uvvk6PEbwAggzqROAZ529/uj6yx094nRc3cR\ngiJmtllUprSZlFQHBQPJReqH2qdAxzyPXZ7mcS7namlWyv3tgJOi6qePzWwh0I/wzXo7wrf32SnP\n3QJsER17CeF/4hUzm2Rmg9NdzN0/AZ5gdRA5BWiMnnsW+CNwIzDXzG4xs7SvzcyONLN/R1U9CwmB\nqkv0dHfg7TSHdQc+dvclbfxOMnm/RRn6mtkzUbXYIuDcLMoAcDdwtJltQMgc/pkp6El1UDCQYlgG\nbBg/iL69JiHTFLup298H7nL3zaJbZ3ff2N2viZ77jFBlFD+3qbv3AnD3ee4+xN2/AvwAuCmub0/j\nXuBUM9sP6BAFAaLz/NHd+xCqj3YhBJk1RO0tI4FrgC3cvTMwmtXf5N8Hdkxz3feBzcysU5rnsnkf\nWv4O7wEeBr7i7psCt7Yow05pzoG7fwj8GziekI39Nd1+Uj0UDKQYXgd2N7NeZtYBGErmD+5MWlZn\npDMHaPnh3PK4u4HvmNlhZtbOzNY3s4PMbBt3n0OoirnOzDa2oIeZHQhgZieY2Vei8ywitEc0ZyjL\nE4RM41eEai6ic/SJvm2vS8h4PstwjvbRbYG7N5vZkYT2htgdwGAzOzgq5zZmtkv0GkYTAtWmZrau\nmcVVS/m8Dx2Bhe6+wsz6Eqq8Yo3AIdHvZR0z28zWbOj/K/BfhLaGB9u4jlQ4BQPJVsYPFXd/i/Ch\n+A9gOtBaHXbO509xNXBlVMVzcbrj3H0WMAC4HJgPzAT+H6v/1r9H+BCeQmj0fQCIv0HvA7xsZksI\n35Z/FNfpr1XY0PbxIKGB+p6UpzoBf4rOPYPQeP2bNMd/AvwIeMDMPiZUOf0t5fmxwGBCm8ZioInQ\nmwpCXf1KYCqhuu3H0TH5vA/nA1eZ2WLgClICm7u/DxxF+P19DLwK9Eo59iFCQHzQ3T/L4lpSwSy0\n3yV4AbN3CX/MzcAKd+9rZp0Jf3TbAe8CJ7n74kQLIiJFZ2b/IfQqe6bcZZHClCIzaAYa3P3r7t43\n2nYp8Hd33wV4BrisBOUQkSIys+OBZgWC2rBuCa5hrB10BrC6+9qdhBT40hKURSpY1FVzCmtW/Vj0\neLeoCkgqgJk9C+xKaDyWGlCKaqJ3CPWNDtzq7reb2cKo90S8z8fuvlmiBRERkYxKkRn0c/fZZrYF\n8JSZTWPtxsJkI5KIiLQq8WDg7rOjn/PN7GHCMPu5ZtbV3edGfaHnpTvWzBQkRETy4O7ZdNdeJdEG\nZDPbMB59aWYbEfpRTwIeAc6MdjuDlC51LZV7vo4kb0OHDi17GfTa9Pr0+mrvlo+kM4OuwEPRN/x1\ngUZ3f8rMxgH3m9lZhH7gJyVcDhERaUWiwcDdZ5BmAjJ3/xj4VpLXFhGR7GkEchk1NDSUuwiJqeXX\nBnp91a7WX18+Eu9aWogwA3Dllk9EpBKZGV5JDcgiIlIdFAxERETBQEQkk5kzYVadTIKiNgMRkQx+\n8ANYbz244YZylyQ3+bQZlGI6ChGRqjRxIjRnWt6oxigzEBFJo7kZNt0UvvwSFi6E9u3LXaLsqTeR\niEiRzJwJnTpBjx7wxhvlLk3yFAxERNKYOBF69YJ99oFXXil3aZKnYCAiksakSSEY9O0LY8eWuzTJ\nUzAQEUkjNTNQMBARqVMTJ8Iee4Tb22/DsmXlLlGyFAxERFpYvjw0IO+yS+hFtMceMGFCuUuVLAUD\nEZEWpkyBnj1Xdyeth6oiBQMRkRbi9oJYPfQoUjAQEWkhbi+I1UOPIgUDEZEW4m6lsZ49YcEC+Oij\n8pUpaQoGIiIp3OH119cMBu3awd5713Z2oGAgIpJi7twwL9HWW6+5vdarihQMRERSxI3H1mKat1rv\nUaRgICKSomV7QSzuUVSrEykrGIiIpGjZrTTWvXv4WeqVz778En71K/jii2Svo2AgIpKiZbfSmFl5\nqopGjICnnw4rriVJwUBEJLJyJUybBrvvnv75Ug8+i7OCYcPWbsMoNgUDEZHI9OnQrRtstFH650vd\no2jECNhyS+jfP/lraQ1kEZFIpiqiWJ8+MH586HraLuGv0nFWcNNNyWcFoMxARGSVTI3HsS5dYLPN\nQgaRtFJmBaBgICKySqZupalKUVVUyraCmIKBiEikrcwAStOjqNRZASgYiIgAsGhRmIhuhx1a3y/p\nHkXlyApAwUBEBIA33oCvfa3thuHevUN1UlKDwMqRFYCCgYgIkF0VEUDHjtCjRwgIxVaurAAUDERE\ngLa7laZKqt2gXFkBKBiIiADZZwaQTI+icmYFoGAgIkJzc2gzyCUzKHYjcjmzAihRMDCzdmY2wcwe\niR5vb2Yvmdl0M7vXzDQSWkTKZuZM2GSTMKAsG3vsAe+8A8uWFef65c4KoHSZwY+BKSmPhwO/c/ee\nwCLg7BKVQ0RkLbm0FwC0bx/2nzChONcvd1YAJQgGZtYNOAq4PWVzf2BUdP9O4NikyyEikkk2I49b\nKlZVUSVkBVCazOA64BLAAcxsc2ChuzdHz88CtilBOURE0sql8ThWrB5FlZAVQMLBwMy+Dcx199eA\n1JhXxvgnIrKmXKuJoDg9iiolK4Dkp7DuBxxjZkcBGwAbA9cDm5hZuyg76AZ8kOkEw4YNW3W/oaGB\nhoaGJMsrInVm+fLQgLzLLrkd17MnLFgQbl265HftYmUFTU1NNDU1FXQO8xKt7mxmBwE/dfdjzOw+\n4EF3v8/MbgZed/db0hzjpSqfiNSn8ePhrLPg9ddzP7Z/f/iv/4Ijjsj92C+/hN12C+sVHHJI7se3\nxsxw95xyjXKNM7gUuNjMpgObAXeUqRwiUufyaS+IFVJVVCltBbGS9e939+eA56L7M4B9S3VtEcne\nsmXgHubgqQf5tBfE9tkH/vKX3I8r9Spm2dAIZBFZw/DhMGRIuUtROvl0K43FPYpyrc3+xS+ge/fK\nyQpAwUBEWpg4EUaOhDlzyl2S5LmHtoJ8g0H37uHnrFnZH9PYCPfeG26VkhWAgoGItDBlCuy7L9x+\ne9v7Vru5c0NA2Hrr/I43y23w2UsvwUUXwSOPwBZb5HfNpCgYiMgqn30G778P114Lt94KK1eWu0TJ\nitsLCvmGnu3gs/feg+OPhz//OSyiU2kUDERklalTYccdwwfcttvCo4+Wu0TJKqS9IJZNj6Jly2DA\ngJAVHH10YddLioKBiKwyZUro+w5wwQVw443lLU/SCulWGuvTB8aNC9Ngp9PcDKefDl//Ovz0p4Vd\nK0kKBiKyyuTJsPvu4f7xx4dvzlOnlrdMSSqkW2msSxfYfHOYPj3981deCfPnw803V1aDcUsKBiKy\nSmow6NABvv/98CFWi1auhGnTVr/eQmSqKop7Dj34YPh9VjIFAxFZJbWaCODcc+Huu+GTT8pXpqRM\nnw7dusFGGxV+rnQ9iiq551A6CgYiAqzuSbTzzqu3bbstfPOb4RturSlGe0GsZY+iSu85lI6CgYgA\nq3sSrbfemtsvuCBMm1Brc0YWo70g1rt3aF/54ouQRR1zTGX3HEpHwUBEgLWriGKHHBKyhhdeKH2Z\nklSMbqWxjh2hR48wmvn000NwqOSeQ+koGIgIsGbjcap27eC882qvm2kxq4kgVBWdeWZY36DSew6l\no2AgIkDmYADhQ+7JJ2tnvqJFi+Cjj2CHHYp3zv33h08/rY6eQ+koGIgIkLmaCGDTTeHEE2tnvqI3\n3ggNu+2K+Ak4eHCoJqqGnkPpKBiISNqeRC2df37tzFdU7CoigHXWgU6dinvOUlIwEJGMPYlS7bVX\n7cxXlEQwqHYKBiLSahVRqkLmK/rsM3juOVixIr/ji6mY3UprhYKBiLTaeJzq+ONDfXuu8xXNmgUH\nHhgWnt92W7j8cnjnnfzKWqjm5vAaFAzWpGAgIlkHgw4d4Oyzc5uv6Pnnw9w9xx0H//kPPPNMyBL2\n3RcOPxxGjSpttjBzJmyyCWy2WemuWQ0UDEQk62oiyH6+IvcwcvmEE8K0DJdeGvre77prWDzn/ffh\ne9+DP/yhtNmCqojSUzAQqXPZ9CRKFc9XdM89rZ8zziBeeAGOOGLtfdZfHwYNCu0IqdnCYYclmy0U\nc+RxLVEwEKlz2fQkailuSE43X9GsWXDQQbB0Kfz737DTTm2fLzVbOOOMkC3svHNYIazYxo2DPfcs\n/nmrnYKBSJ3LpYoolmm+orh94Nhj4f77w5w9uUjNFnbdFf72t9yOb8vixfDss+kzlXqnYCBS57Jt\nPE4Vz1d0003hcab2gUIMGlT8qbNHjYL+/aFz5+KetxYoGIjUuXyCAYT5ikaPDr1z2mofyMfAgeF8\n8+YV53wQgsugQcU7Xy1RMBCpc/lUE8Hq+Yr23DO39oFsdewI3/52qG4qhg8+gFdfra41BkrJvIJX\nrDAzr+TyiVS7zz4LVSZLluTWgBx791146ik455xkpmwePRp++cuwhGShfvtbePNNuOOOws9V6cwM\nd8/pHVFmIFLH8ulJlGr77WHIkOTm7j/0UJgxIwxWK1RjI5x2WuHnqVUKBiJ1LN8qolJZd104+eTW\nxzRkY/JkmD8/dHmV9BQMROpYvo3HpTRoUBjxXEiNcWMjnHpqcdcvqDX61YhUoebmMFL39dcLO8/k\nyZWdGUAYt+AeBovlo7lZvYiyoWAgUoVGjYKnn4YRIwo7TzVkBmars4N8vPACbLyxpqBoi3oTiVSZ\n5ubwwXbiiSEYvPlmfudZvjz0JFq6NP8G5FJ5660wH9KsWaEdIRfnnhvWOr700mTKVonUm0ikDowa\nBRttBFdeGbqE5rq2QGzatMJ6EpXSzjvDdtvBP/6R23FffBF+X6eckky5akmbwcDM8p7s1cw6mNnL\nZvaqmU0ys6HR9u3N7CUzm25m95pZjrFepD41N4d+98OGhcbQAQPyn7+nGqqIUuVTVTR6dHiN222X\nTJlqSTaZwU1m9oqZnW9mm+Rycnf/HDjY3b8O7AUcaWb7AsOB37l7T2ARcHauBRepR3FWEE/5MHAg\nPPxwfueaMqW6gsHJJ4f1l3OZyfTuu9VwnK02g4G7fxMYBHQHxpvZPWZ2aLYXcPdPo7sdgHUBBw4G\nRkXb7wSOzaXQIvUoNSuIB3k1NIRqotmzcz9fNfQkStW1K3zjG9lnQosXh9HRJ56YbLlqRVZtBu7+\nFnAF8DPgIOAPZjbVzI5r61gza2dmrwJzgKeBt4FF7t4c7TIL2CafwovUk5ZZAUD79nDkkfDII7mf\nr9qqiSCMIM52JlPNUJqbbNoMepnZdcCbQH/gO+6+a3T/uraOd/fmqJqoG9AX+GphRRapP+mygtjA\ngbm3GyxfntvqZpViwIDQVXT+/Lb31diC3GTTcHsDcDtwubsvjze6+4dmdkW2F3L3JWbWBHwD2NTM\n2kXZQTfgg0zHDRs2bNX9hoYGGhoasr2kSM1IlxXEjjgCvv/90LOoU6fszldNPYlSdewYZh297z64\n8MLM+9XbDKVNTU00NTUVdI42xxmYWUdgubt/GT1uB6yf0hbQ2rFdgBXuvtjMNgDGAFcDZwAPuvt9\nZnYz8Lq735LmeI0zkLoXjyv4zW9ClVA6Rx0V1hc46aTsztnYGLKJYk0PXUqjR8OvfhWmzM6knmYo\nTSepcQZ/BzZIebxhtC0bWwPPmtlrwMvAGHd/ArgUuNjMpgObAXX6lom0rbWsIJZrr6Jq60mU6tBD\n4Z13Wp/J9O67NUNprrLJDF5z973a2pYEZQZS77LJCgDmzAlrBs+dGxqV2zJwYKhPr9aeNj/6EXTp\nAr/4xdrPTZ4Mhx8O771XvxPTJZUZLDOz3ikX2RtY3sr+IlIk2WQFAFttFYJBttXG1diTKFVrM5k2\nNoYRx/UaCPKVza/rJ8ADZva8mf0LuA9opelGRIqhtR5E6WRbVVStPYlSZZrJNJ6hVFVEuctm0NlY\nQnfQ84AfALu6+/ikCyZS77LNCmJxF9Pm5tb3q9aeRKnimUxbjjnQDKX5yzaR2gXYDegNnGJm30uu\nSCKSa1YA0LMnbLJJ2/P+V3sVUWzQoDBr68qVq7fFDcdJLcNZy7IZdDaUMNbgBsI0EtcAxyRcLpG6\nlmtWEMumqqiaexKlajmT6eefw8iRmqE0X9lkBicAhwBz3H0wsCeQ04R1IpK9fLKCWDbBoNrmJGrN\naaetnsl09Gj42tc0Q2m+sgkGy6ORwivNrBMwjzBpnYgkIN+sAKBPnzBB27RpmfeplWoiWHMmU00/\nUZhsgsE4M9sU+BMwHpgAtDL2T0TyVUhWAG2vcVALPYlSbbllmMn0r38NM5SecEK5S1S9Wg0GZmbA\n/7r7omi6iEOBM6LqIhEpskKyglhrVUW10JOopdNOg0suCTOUbrZZuUtTvVoNBtHw3ydSHr/r7hMT\nL5VIHVq5srCsINbQEOblSbfGQS1VEcUGDAgZlaqICpNNNdEEM9sn8ZKI1LkbbggjiQvJCmD1GgeP\nPrr2c7XSkyhVx45h0rpjtURWQbIJBvsC/zazt81sYrSWsbIDkSJ67z349a/h5puL00c+U1VRLfUk\nStWrF6yzTrlLUd2ymagubUctd5+ZSInWvLYmqpOa5x6qOvr2hSuyXiGkdUuWQLduMGvWmmsc7Lxz\naFyuxYAgqyU1UZ1nuIlIETz8cJiO+ZJLinfOTp3ggAPgySdXb4t7Eu20U/GuI7Ujm5XOHid8+Buw\nPrADMA2osZpHkdJbsiRMx9zYCB06FPfccVVRvOBN3JMomymupf5kM1HdHu7eK/q5M2EdY40zECmC\nK68Mc+8feGDxz33MMWFU7hdfhMe12JNIiiebzGAN7j7BzPZNojAi9WTs2LDs5OTJyZw/dY2Dww4L\nPYnUViCZtBkMzOzilIftCDOXfphYiUTqwMqVcO65YQWzJAdKxVVFhx0Wgo764ksm2TQgb5xy60Bo\nQxiQZKFEat0NN4QgkPSHc+oaB6omkta02bW0nNS1VGrRe+9B795hoFQp5gjabbcwfuHww0ODtRqQ\na18iXUvN7Oloorr4cWczG5NPAUXqnTtceCH85Celmyxu4EAYPlw9iaR12VQTbeHui+IH7r4Q2DK5\nIonUriTGFLRl4MDQq0hVRNKabILBl2a2bfwgGpGsuhuRHMVjCm65pfhjClrTpw9ss416Eknrsula\n+nPgX2b2HGHg2TeBIYmWSqQGXXll6NWTxJiC1rRrB5ddBvtouklpRVYNyGbWBdgveviSuy9ItFSr\nr6sGZKkJY8fCd74TevRsvnm5SyO1LqkG5GOBFe7+mLs/Rlj+cmC+hRSpN6ljChQIpFJl02Yw1N0X\nxw+ixuShyRVJpLbccAN07hxW5BKpVNm0GaQLGDlPYyFSj6ZPD+sUvPhicdYpEElKNpnBODO71sx2\njG7XAuOTLphItVu4EI4+Gq6+Gnr2LHdpRFqXzeI2GwFXAt+KNj0N/Le7L0u4bGpAlqq1YkVYerJX\nL7j22nKXRupNPg3Imo5CJAEXXAAzZoR1iLUco5RaPsEgm1lLtwD+i7CYzfrxdnfvn3MJRerAjTeG\naaNffFGBQKpHNm0GjcBUwgpnvwTeBcYmWCaRqvX003DVVSEj2GSTcpdGJHvZtBmMd/e9zWyiu/eK\nto1198THM6qaSKrJtGlhdPEDD5R+lLFIqkSqiYAV0c/ZZvZtwsI2CS7HIVJ9Pv44jDD+n/9RIJDq\nlE1mcDTwPNAduAHoBPzS3R9JvHDKDKQKqOeQVJqK601kZt2Au4CuQDPwJ3f/g5l1Bu4DtiO0QZyU\nOso55XgFA1nl88/h1FNh0qTsj/nNb2BAwuvynX8+zJwJjzyiBmOpDJUYDLYCtnL318ysI2Gw2gBg\nMPCRu19jZj8DOrv7pWmOVzAQICwKc9ZZsGhRWKglGy+9BNdfD+PGJTf698Yb4aabwqplnTolcw2R\nXFVcMFjrYmYPA3+Mbge5+9woYDS5+1fT7K9gIAD89rfQ2AjPPw8dO2Z3THNzWE2ssRH226/t/XP1\n9NNw+umhC2mPHsU/v0i+Epm1tFjMbHtgL+AloKu7zwVw9zlo5TRpxWOPwXXXhWqYbAMBhHn8zzsv\nfHMvtmnTwsRz99+vQCC1IetgYGb7mdmTZtaU6xTWURXRSODH7v4Ja6+Upq//ktakSTB4MIwaBd27\n53784MGhz//8+cUr06JF6jkktSdj11Iz2yr61h67GDiWsNrZy8DD2VzAzNYlBIK/uvvfos1zzaxr\nSjXRvEzHDxs2bNX9hoYGGhoasrms1ID58+GYY+D3v8+/mmfzzcMawHfcAZeu1SqVn+HD4YAD4Oyz\ni3M+kUI1NTXR1NRU0DkythlE9fsTgGvc/TMzu43QxbQZON/d+2V1AbO7gAXufnHKtuHAx+4+XA3I\nks7nn8O3vhW+ef/614Wda9w4OOEEePvtwnv7LFgAu+wCr74K227b9v4i5VD0BmQz+w7wY0L30JHA\nqcCGwL3u3mbibWb9gH8CkwhVQQ5cDrwC3E8YuzCT0LV0UZrjFQzqUNxzaPFiGDky1P0Xat994Yor\nQvVOIS67LFQT3Xxz4WUSSUoivYnMbB3gfOBo4Nfu/s/8i5gbBYP6lE/PobbceSfcey88+WT+51BW\nINWiqL2JzOwYM3sWeBJ4AzgZGGBmI8xsx8KKKtXmX/8K39aTlm/PobacfDJMmAD/+U/+5/jd7+Ck\nkxQIpDa11mYwEegLbACMcfe+0fadgavc/buJF06ZQUVwh4MOgpdfDqt3bbhhMtd54w3o3z8EgiTG\nBfzsZ2Fx+t/9LvdjlRVINSn2OIPFwHHA8aT09nH3t0oRCKRyPPsszJkDe+0VRvUmYf78UJ9/3XXJ\nBAKAH/wgVBd9+mnuxyorkFrXWmbQBTiFMGvpPe6+pJQFi8qgzKDM4qzgnHNg6tTQG+dXvyruNYrZ\nc6gtRx8Nxx2XW5WXsgKpNkXNDNx9gbvf4O63lCMQSGWIs4JTToGGhrCCV7FdeCFssUVYFCZpF1wQ\n5hPK5TuGsgKpB1oDWTJKzQpOPx2WLYOuXWHevOK1GyxYEKZz+PDD4jYYZxLPV3TPPaG7aTblU1Yg\n1aai5yaS6pOaFQBstBHsuWdx2w3+/vcQcEoRCGD1fEU33pjd/soKpF5ks9KZ1CF3GDYMrrwS1k35\nK4mrivr3L851xoyBww8vzrmyNXgw7LRTaLTeYovM+y1YALfdFrICkVqnzEDSapkVxIrZbuBenmAQ\nz1f05z+3vp+yAqknajOQtbRsK0hVzHaDiRPDh/Lbbye3+Ewmbc1XpLYCqWZqM5CiyJQVQHHbDeKs\noNSBAKBPnxDUnngi/fPKCqTeKBjIGjK1FaQqVlXRmDFwxBGFnydf55+ffuGbuK3gsstKXyaRclEw\nkDW0lhXEihEMli0L01scfHBh5ynEySfD+PFrz1ekrEDqkYKBrBJnBb/4ReasAGD//cOkb/lM6xB7\n7jno3bu8i8ivv37oWZQ6HbWyAqlXCgayyrPPwty58N02Zp4qRrtBOXoRpdNyviJlBVKvFAwEyK6t\nIFWhVUWVEgx22CFMjDdihLICqW8KBgJknxXECgkGM2fCxx/D17+e3/HFFs9X9NvfKiuQ+qVxBrJq\nXMGQIXDaadkdU8h4g9tuC20GjY25lzUJ8XxF8+bB5MkKBlL9NM5A8pJrVgCFtRs8+WRlVBHF2rWD\nyy+HH/5QgUDqlzKDOpdPVhD7+c9zX99gxYowH9DUqbDVVrldT0Syo8xAcpZPVhDLp93g5ZdDo60C\ngUhlUTCoY7n2IGopn/EGldKLSETWpGBQBf7yl9DY+tlnxTvn0qWh90y+WQHk126gYCBSmRQMKtys\nWXDxxXDXXdC9e7j/5pv5n2/cuNA+sO224UN8xIj8soJYLlVFCxaEtoJ+/fK/nogkQ8Ggwl19NZx9\ndvhG/cryqYktAAAMu0lEQVQrsMEGYWGZgw7KPltYuhRuvRX23htOPBG23x6mTIFRowrv659LMIhX\nNWvfvrBrikjxqTdRBZs1C3r1Ct+mt9xy9fYVK+DRR8MH/IQJYc2Bc86BXXdd8/jx48M+DzwQAsiQ\nIXDooaErZbHkMt5g8OAQkC68sHjXF5G15dObSMGggl14YcgEfvObzPvMmAG33x5W7dp55/CBv2xZ\nGNi1cGEIEmeeCVtvnVw5+/WDq65qfSlMd+jWLWQRO++cXFlERMGgpmTKCjKJs4Xbbw/f0IcMgW99\nq7hZQCbZjDeYNAkGDCjPqmYi9SafYFBA06EkKW4ryCYQAKy3Hhx3XLiVWkNDyAxa8+STYSEbBQKR\nyqRgUIFmzYJ77glZQTVIHW+Qqd1gzJgw3YOIVCb1JqpAuWYF5dbWeINKWNVMRFqnzKDCVFtWEIu7\nmKZrRK6EVc1EpHXKDCpMtWUFsdbGG2jUsUjlU2+iCpJrD6JK0tp4g69+NQyQ23vv8pRNpN5o1tIq\nN3x4dWYFkLndoNJWNROR9NRmUCE++CB8e662toJU6doNxowp/qhnESm+RP9FzewOM5trZhNTtnU2\ns6fMbJqZjTGzTZIsQ7Wo1raCVOnaDcaMCeMLRKSyJdpmYGYHAJ8Ad7l7r2jbcOAjd7/GzH4GdHb3\nSzMcXxdtBh98AHvsUZ1tBalathvEq5pNmxa2i0hpVFybgbv/C1jYYvMA4M7o/p3AwCTLUA1qISuA\ntdsN4lXNFAhEKl852gy2dPe5AO4+x8yq/COwMLXQVpAqtd1AXUpFqkclNOvVfj1QK2olK4ilthso\nGIhUj3JkBnPNrKu7zzWzrYB5re08bNiwVfcbGhpoaGhItnQlVGtZAayep+j997WqmUipNDU10ZTt\nKlMZJD7ozMy2Bx519z2ix8OBj919eL03IP/wh7D++q2vV1CN+vWD3XeH2bPDtNoiUloVN4W1md0D\nNACbm9l7wFDgauABMzsLmAmclGQZKlUtZgWxhoYwgO73vy93SUQkW5qOokxqNSsAePppOOwwmD5d\nq5qJlEPFZQaS3tKlcNdd4cOyFvXrBxddBDvtVO6SiEi2lBmUwV13hUXqVZ8uIkmouEFnkt7dd8Np\np5W7FCIiqykzKLHZs2G33UIDcqYlIkVECqHMoAqMGAEDBigQiEhlUTAoscZGGDSo3KUQEVmTgkEJ\nTZ0KH36Yfp1gEZFyUjAoocZG+O53YZ11yl0SEZE1aZxBibiHYPDAA+UuiYjI2pQZlMi//w0dOkDv\n3uUuiYjI2hQMSiRuOLacOnuJiJSGxhmUwIoVsM02YeWvHj3KXRoRqXUaZ1ChxoyBnj0VCESkcikY\nlEBjo6afEJHKpmqihC1dCt26wdtvQ5cu5S6NiNQDVRNVoIceggMPVCAQkcqmYJAwzVAqItWg7qqJ\nPvwQ3nkHDjigqKdNa84c2HVXzVAqIqWlaqI2fPIJHHkkHH00/Pd/Q3NzstfTDKUiUi3qJhg0N4dB\nX337wpQp8PjjcMIJoYE3KXffrRlKRaQ61E0wuPxyWLwYbrwxDABragqNuvvum8xaxFOnhuohzVAq\nItWgLoJBvObwyJHQvn3Y1qED3HYb/OQnof3g8ceLe83GRjjlFM1QKiLVoeYbkF98EQYODJnAbrtl\n3ufEE+G880IG0a7AEOkOO+4YAtDeexd2LhGRXKkBuYWZM0O7wJ13Zg4EAPvvD2PHhuzgxBMLb0fQ\nDKUiUm1qNhh88gkccwxccknoQdSWuB1h881hv/3grbfyv7ZmKBWRalOT1UTNzXDssbDFFvCnP+X+\noXzbbXDFFfCXv8BRR+V2rGYoFZFyUzVR5PLLYdEiuOmm/L6dDxkCDz8cfv785zBvXvbHaoZSEalG\nNRcM4p5Do0at7jmUj/33h1degdmzYZdd4OST4Zln2h6oFlcRiYhUk5qqJop7Dj37LOy+e/HKsXhx\nGEB2662wfDmccw6ceSZsueWa+2mGUhGpBHVdTTRzJhx/fKjnL2YgANhkE7jgAnj99RAUpk5dnS38\n4x+rswXNUCoi1aomMoNPPoF+/cK39YsuSr5ckD5beOyxEDROPrk0ZRARSSefzKAmgsH//m+omsmn\n51Ch3EPbwq23wgsvwKuvamI6ESmvug0GX34ZboU0GIuI1Ip8gsG6SRWmlNZZR3MAiYgUomYakEVE\nJH9lCwZmdoSZTTWz6Wb2s3KVQ0REyhQMzKwd8EfgcGB34BQz+2o5ylJOTU1N5S5CYmr5tYFeX7Wr\n9deXj3JlBn2Bt9x9pruvAEYAA8pUlrKp5T/IWn5toNdX7Wr99eWjXMHgK8D7KY9nRdtERKQM1IAs\nIiLlGWdgZvsBw9z9iOjxpYC7+/AW+1XuIAgRkQpWFYPOzGwdYBpwCDAbeAU4xd3fLHlhRESkPIPO\n3P1LM7sQeIpQVXWHAoGISPlU9HQUIiJSGhXZgFzrA9LM7F0ze93MXjWzV8pdnkKZ2R1mNtfMJqZs\n62xmT5nZNDMbY2ablLOMhcjw+oaa2SwzmxDdjihnGfNlZt3M7Bkzm2xmk8zsR9H2mnj/0ry+H0bb\na+X962BmL0efJZPMbGi0fXszeyn6DL3XzNqsBaq4zCAakDad0J7wITAW+K67Ty1rwYrIzN4B9nb3\nheUuSzGY2QHAJ8Bd7t4r2jYc+Mjdr4kCemd3v7Sc5cxXhtc3FFjq7teWtXAFMrOtgK3c/TUz6wiM\nJ4z5GUwNvH+tvL6TqYH3D8DMNnT3T6O22BeAHwMXAyPd/QEzuxl4zd1vbe08lZgZ1MOANKMyf/d5\ncfd/AS0D2wDgzuj+ncDAkhaqiDK8PgjvY1Vz9znu/lp0/xPgTaAbNfL+ZXh98Zimqn//ANz90+hu\nB0I7sAMHA6Oi7XcCx7Z1nkr8QKqHAWkOjDGzsWZ2TrkLk5At3X0uhH9IYMs29q9GF5jZa2Z2e7VW\no6Qys+2BvYCXgK619v6lvL6Xo0018f6ZWTszexWYAzwNvA0scvd4xfZZwDZtnacSg0E96OfufYCj\nCH+QB5S7QCVQWfWRhbsJ2NHd9yL8E1Z1dUNUhTIS+HH0Dbrl+1XV71+a11cz75+7N7v71wkZXV8g\nr3neKjEYfABsm/K4W7StZrj77OjnfOAhwhtYa+aaWVdYVW87r8zlKSp3n5+y8tKfgH3KWZ5CRI2L\nI4G/uvvfos018/6le3219P7F3H0J0AR8A9g0an+FLD9DKzEYjAV2MrPtzKw98F3gkTKXqWjMbMPo\nWwpmthFwGPBGeUtVFMaadbCPAGdG988A/tbygCqzxuuLPiBjx1Hd7+GfgSnufn3Ktlp6/9Z6fbXy\n/plZl7iKy8w2AA4FpgDPAidGu2X1/lVcbyIIXUuB61k9IO3qMhepaMxsB0I24ITGnsZqf31mdg/Q\nAGwOzAWGAg8DDwDdgZnASe6+qFxlLESG13cwof65GXgXODeuY68mZtYP+CcwifA36cDlhFkB7qfK\n379WXt+p1Mb7twehgbhddLvP3X8dfc6MADoDrwKnRR1yMp+rEoOBiIiUViVWE4mISIkpGIiIiIKB\niIgoGIiICAoGIiKCgoGIiKBgIFIQMzujxQAmkaqkYCBSmDPJMJFiynQAIhVPf6xSc6KpTKaY2W1m\n9oaZPWlm65vZs2bWO9pnczObEd0/w8weihZzecfMLjCzi6JFT140s00zXOd4oA9wd7Tv+mY2w8yu\nNrNxwAlm1sPMRkcz1D5nZj2jY7uY2choYZKXzewb0faDooVKJpjZ+GjKEpHEKRhIrdoJuMHdvwYs\nAo6n9Zk4dyfM2d8X+DXwibv3Jkzn/L10F3D3UYS5tE51997u/ln01AJ37+Pu9wO3ARe6+z7AJcDN\n0T7XA9e6+77ACcAd0fafAudH1/4msDyvVy+SozaXQhOpUjPcfVJ0fwKwfRv7PxstEvKpmS0CHou2\nTwL2aOW4lhP0AdwHqyYi3B94wMzifdaLfn4L2DVle0cz25CwUtV1ZtYIPOjuNTVjr1QuBQOpVZ+n\n3P8S2ABYyepseP1W9veUx83k/n+yLPrZDlgYfctvyYB900weNtzMHgO+DbxgZoe5+/Qcry+SM1UT\nSa1Kt6Thu4Q6flg9vW+hlgCd0j3h7kuBGWZ2wqpCmfWK7j5FWKs23r5n9LOHu09292sIVVB5LVQi\nkisFA6lV6doHfgucZ2bjgc1yOLY1dwK3xA3IaY4dBJwdLa/4BnBMtP3HQB8zez3afm60/SdmNsnM\nXgO+AEbnUBaRvGkKaxERUWYgIiJqQBbJipn9EehHqAay6Of17n5nWQsmUiSqJhIREVUTiYiIgoGI\niKBgICIiKBiIiAgKBiIigoKBiIgA/x+X3mvtI8m3lQAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x7fcebcdc5910>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "exact_results = [element[0] for element in model.most_similar([model.wv.syn0norm[0]], topn=100)]\n",
-    "x_axis = []\n",
-    "y_axis = []\n",
-    "for x in range(1,30):\n",
+    "\n",
+    "x_values = []\n",
+    "y_values_init = []\n",
+    "y_values_accuracy = []\n",
+    "\n",
+    "for x in range(1, 300, 10):\n",
+    "    x_values.append(x)\n",
+    "    start_time = time.time()\n",
     "    annoy_index = AnnoyIndexer(model, x)\n",
-    "    approximate_results = model.most_similar([model.wv.syn0norm[0]],topn=100, indexer=annoy_index)\n",
+    "    y_values_init.append(time.time() - start_time)\n",
+    "    approximate_results = model.most_similar([model.wv.syn0norm[0]], topn=100, indexer=annoy_index)\n",
     "    top_words = [result[0] for result in approximate_results]\n",
-    "    x_axis.append(x)\n",
-    "    y_axis.append(len(set(top_words).intersection(exact_results)))\n",
-    "    \n",
-    "plt.plot(x_axis, y_axis)\n",
+    "    y_values_accuracy.append(len(set(top_words).intersection(exact_results)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plot results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1gAAAGoCAYAAABbkkSYAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xd8VfX9x/HXJxAIe8geYcsmoAyti1atE7UOLHUvrP21\n1lW1auturXV3O+oWQdEq4sI9C4KSsJEdSIAwAmFkf35/nEMbaSAJ5Obk3ryfj8d95N4z37lJ7snn\nnO/5fs3dERERERERkf2XFHUAERERERGRRKECS0REREREpJqowBIREREREakmKrBERERERESqiQos\nERERERGRaqICS0REREREpJqowBIREREREakmKrBEImJmb5nZBdW9bDnrdjczN7P6+7utCvYzz8xG\nV/d297CvbWbWsyb2JSJSW5jZCjM7JuocIrJ3poGGJV6Y2QrgUnd/L+osUTKzCwneh8MruXx3YDmQ\n7O7F1ZThKWC1u99SHdurYF8fAc+5++Ox3peISG1W0XHQzOpX1+d8XWBm9dy9JOocknh0BUsSxq4r\nNCIiItUtvHp0nZllmNkWM5toZinhvAvN7LPdlncz6x0+f8rM/hq2INhmZp+bWQcze8jMNpvZQjMb\nVsH+nwVSgSnhNq4v00LhEjNbBXwQLnuImX1hZrlmll62dYGZtTCzJ8ws28zWmNldZlYvnNfbzD4O\nv78NZjZxD1neMrOf7zYt3cxOt8CDZrbezLaa2RwzG7SH7VxkZgvMLM/MlpnZ5bvNP9XMZofbWWpm\nx4fTW5vZk2aWFb5//6rCz+FvZvammW0Hvm9mJ5nZN+E+Ms3stt3WP7zMe5kZ7mOEma3b9b6Fy51u\nZul7/glKneLueuhR4QNYAVwHZABbgIlASjjvQuCz3ZZ3oHf4/Cngr8BbwDbgc6AD8BCwGVgIDKtg\n/88CpcDOcBvXA93D/VwCrAI+CZc9BPgCyAXSgdFlttMCeALIBtYAdwH1wnm9gY/D728DMHEPWd4C\nfr7btHTgdMCAB4H1wFZgDjBoD9v5iOBM5H/eQ+C+8D1ZDpyw+7JAfyAfKAnfh9xw/knAN+E+M4Hb\nyqy7632qX85+08Pt7Hr4rvcLeAlYG74fnwADw+njgSKgMFxnSpnfkWPC5w3Dn29W+HgIaBjOGw2s\nBq4N36ds4KI9vEd3h99rfrivP+/v7xfQCZgM5ITv85VR/33poYcetf8RfsbNCD9DWgMLgJ+G8y6k\n4uPgBuBgIIWgEFoOnA/UIzgWfVjJDMeUeb3r8/0ZoAnQCOgMbAROJDiRfmz4um24zqvAP8Ll24Xf\n0+XhvAnAzeF6KcDhe8hxPvB5mdcDCI65DYHjgFlAS4JjYn+g4x62cxLQK1zuKGAHcFA4byTB8efY\nME9noF84byrB/yGtgGTgqCr8HLYAh5X5HkcDg8PXQ4B1wGnh8t2APGBcuJ8DgKHhvPl89zj9KnBt\n1L+netSOh65gSVWMBY4HehB8CF1YxXVvAdoABcCXwNfh65eBB/a2srufR1BEjXH3pu5+b5nZRxF8\ngB9nZp0JPnjvIjgAXgdMNrO24bJPAcUExdQw4IcEhQvAncC7BB/YXYA/7SHOBIIPWwDMbADBh/DU\ncHtHAgcSFHNjCQ5slTEKWETwntwLPGFmttv7sAD4KfBl+D60DGdtJzjgtSQ4YF1hZqdVtEN3Twu3\n0xS4Jtz/1+Hst4A+BAfgr4Hnw3UeDZ/fG647ppxN30xQ6A4F0ggOlGWbE3YgeH86ExTIfzGzVuXk\nuxn4lKCgberuP999mVClfr/MLAmYQlBYdgaOBq4ys+P28jaJiOzyiLtnufsmgs+SoVVY91V3n+Xu\n+QT/jOe7+zMeNFGbSHBM2le3uft2d98JnAu86e5vunupu08DZgInmll7gsLrqnD59QQnBX8cbqeI\n4HjWyd3z3f2zcvZFmH+omXULX58DvOLuBeE2mgH9CG5FWeDu2eVtxN2nuvtSD3xMcAw+Ipx9CfBP\nd58Wfh9r3H2hmXUETiAobje7e1G4bmW95u6fh9vMd/eP3H1O+DqD4Bh/VLjsT4D33H1CuJ+N7j47\nnPc0wXuNmbUmKCxfqEIOSWAqsKQqdGAJvxeq4cBSjpXu/lj4njwNdATaV2bFCg4QFTKzwwmK0lPc\nfWu4zX+6e174fd0GpJlZi0pu8hzgDndf7+45wO3AeWXmF4Xzi9z9TYIrT30rm7cclf39GkFwFvcO\ndy9092XAY/z3d0BEZG/Wlnm+A2hahXXXlXm+s5zXVdnW7jLLPO8GnBU2acs1s1zgcIJjSjeCKzHZ\nZeb9g+BEGgStQwyYYUHHRReXtzN3zyM4qbjrs3Mc/z0J9wHwZ+AvwHoze9TMmpe3HTM7wcz+bWab\nwiwnEpwYA+gKLC1nta7AJnffXMF7sidl3yvMbJSZfWhmOWa2heAkZkUZAJ4DxphZE4KTfJ9W4Xgv\nCU4FllSFDixU34GlHP95f919R/i0Uu9LBQeIitbtCkwCLnD3xeG0emZ2T9jmfStBsxQqu02CJjQr\ny7xeGU7bZaN/90bsqv4+7a6yv1/dgE67/X7cRCULWRGRPdgONN71wsw6xGg/e+qZrOz0TOBZd29Z\n5tHE3e8J5xUAbcrMa+7uAwHcfa27X+bunYDLgb/uun+pHBOAcWZ2KEFTuw//E8b9EXc/mKDp4IHA\nr3Zf2cwaEjTXvg9oH7bIeJPgOLzr++hVzn4zgdZm1rKceZX5Oez+Hr4AvA50dfcWwN8rkQF3X0PQ\nWuJ0ghOIz5a3nNRNKrCkOujAUsUDy34q733Y2wFij8ysEfAv4CF3f6vMrJ8ApwLHEDTl675rlb1k\nKCuLoJjZJTWcti+qs6vTTGD5br8fzdz9xGrch4jUPenAQDMbakHHF7fFaD/rgIqGqNh1ZeW48GRZ\nipmNNrMu4RWWd4H7zay5mSWZWS8zOwrAzM4ysy7hdjYTfP6W7mE/bxJ8zt9BcM9yabiNEeFJv2SC\n/w/y97CNBgT3bOUAxWZ2AkEz+12eAC4ys6PDnJ3NrF/4PbxFcIxuZWbJZnZkuM6+/ByaEVwRyzez\nkQTHv12eB44xs7FmVt/MDjCzsq13niE4OTsYeKUS+5I6QgWWVAcdWKp+YNkf64AuZtagzLS9HSD2\n5p/AQv/uPW27tldAcP9YY+B35WTY289iAnCLmbU1szbAbwl+NvuiMj/3ypoB5JnZDWbWKPwdGWRm\nI6pp+yJSB4VX/+8A3gO+Jei0KBZ+T/DZmmtm1+0hSybBCbKbCIqXTIITfbv+5zufoLiZT3Cse5mg\nlQcEzainm9k2gpN2vwybUpe3nwKCouIYvnvvUXOCptebCVovbAT+WM76ecCVBC0oNhMct14vM38G\ncBFBU/4tBJ1Q7Tpxdx5BU/OFBJ0lXRWusy8/h58Bd5hZHsGxalKZDKsImi1eC2wCZhPcV7zLq2Gm\nV8u0PBFRL4J6VO7B//ZcdBvB2ES7Xt9M0ENSJsF9ULv32nNXmWUvBT4q87o3UFyJDKcSdHSRS9B5\nRXfK9I5XZrlRBB/EmwgOLlOB1HBeC+BvBL3YbSHoee/H4bx7CXoW3EbQ5np8BXmeCPc/osy0owl6\nWtwWvh/PA033sP5H7NaL4G7zy76HZZdtEH5Pm4AN4bQzCQ5kecAbBM0Unwvnfed92m1bTtA8r2xP\ngkcQNKl7LdzeSoIDctk8fQgONLnAv3b/HSG4qvcIQQ+B2eHzXb1OjiYYQ2uPv1+7zTsUWExwAH6k\nnPfmKarw+0XQVHECQZPMzcC/97RvPfTQQw899NjbI/x/QccQPb7z0EDDIiIiIiJVZGZnAH8ADvSw\nJYsIgAZmFREREakFzCyVoOleeQZ40GRNagEz+4jgXuvzVFzJ7nQFS2oNHVhEREREJN6pwBIRERER\nEakmcdFEsE2bNt69e/eoY4iISIzMmjVrg7u3jTrHvtJxSkQksVXlOBUXBVb37t2ZOXNm1DFERCRG\nzGxlxUvFZL+/BC4jGOPtMXd/yMxaAxMJeuBcAYx19817246OUyIiia0qxymNgyUiInWSmQ0iKK5G\nEoxtc3I4uPiNwPvu3gd4P3wtIiJSKSqwRESkruoPTHf3He5eTDB+3ukEY+49HS7zNHBaRPlERCQO\nqcASEZG6ai5whJkdYGaNgROBrkB7d88Ol1kLtI8qoIiIxJ+4uAdLRESkurn7AjP7A/AusB2YDZTs\ntoybWbnd7ZrZeGA8QGpqaozTiohIvNAVLBERqbPc/Ql3P9jdjwQ2A4uBdWbWESD8un4P6z7q7sPd\nfXjbtnHbAaKIiFQzFVgiIlJnmVm78Gsqwf1XLwCvAxeEi1wAvBZNOhERiUdqIigiInXZZDM7ACgC\n/s/dc83sHmCSmV0CrATGRppQRETiigosERGps9z9iHKmbQSOjiCOiIgkADURFBERERERqSYqsERE\nRERERKqJCiwREREREZFqogJLRERERESkmqjAEhERERERqSYqsEREZJ8VFJdEHUFERKRWUTftIiKy\nT7Jyd3LxU19x3qHdOGdUt6jjiIhIAistdb7J3MyU9Gw+X7KB4lKv0vpvXnkEjRrUi1G671KBJSIi\nVTY/aysXPTWDHQUldD+gSdRxREQkAbk787K2MiU9izcyslmTu5OG9ZM4rHcbmjasWhljFqOQ5VCB\nJSIiVfLJ4hx+9vzXNEupz0tXHEq/Ds2jjiQiIgnk23V5TEnPYkpGNss3bKd+knHkgW351XF9OWZA\n+yoXVzWtdqcTEZFaZdJXmfz61Tn0adeUpy4aSYcWKVFHEhGRBLBy43beyMhmSnoWC9fmkWTwvV5t\nuPzInhw/qAMtGzeIOmKlqcASEZEKuTsPvvctj7z/LUf0acNfzzmIZinJUccSEZE4lr1lJ1PDoip9\n9RYAhndrxe2nDOSEwR1o1yw+T+KpwBIRkb0qLC7lxlcyeOXrNZx1cBd+d/pgkuupE1oREam6DdsK\neGtONlPSs5mxYhMAgzo356YT+3HSkE50btko4oT7TwWWiIjs0db8Iq54bhafL9nINcceyC9+0Bur\nyTuFRUQk7m3ZUcQ789YyJSOLz5dsoNShT7umXHvsgZyc1okebRKrsyQVWCIiUq6s3J1c9ORXLM3Z\nxn1npXHmwV2ijiQiInFie0Ex7y1Yx5T0LD5enENRidPtgMb8bHRvxqR1om+HZlFHjBkVWCIi8j/K\ndsP+1EUjObxPm6gjiYhIOXb1uDc3a2vUUf6jsLiUmSs3kV9USscWKVz4ve6MSevE4M4t6kQrCBVY\nIiLyHeqGXUSkdiuvx70D2zerNffHmsHY4V0Zk9aJg1NbkZSU+EVVWSqwREQECHoKnDAjk9++Npfe\n6oZdRKRWSdQe9xKRCiwREWH91nxuenUO7y1Yr27YRURqiQ3bCnhr7lqmzM76T497gzu3SKge9xKR\nCiwRkTrM3Xltdha3vj6P/KISbjmpPxcd1oN6daw5h4hIbTJr5WYeem8xXyzdSEmpJ3SPe4lIBZaI\nSB21Pi+fm1+dy7T56zgotSV/PCuNXm2bRh1LRKTOKiwu5eH3F/O3j5bSrlkKVxzVK+F73EtEMSuw\nzCwF+ARoGO7nZXe/1cyeAo4CtoSLXujus2OVQ0REvsvdeT09uGq1o7CEm0/sz8WH66qViEiUFq7d\nytUT01mQvZWzh3fllpP7q6l2nIrlFawC4Afuvs3MkoHPzOytcN6v3P3lGO5bRETKsWFbAbe8Ope3\n561laNeW3HdWGr3b6aqViEhUSkqdxz5dxgPvLqZ5o/o8dv5wjh3QPupYsh9iVmC5uwPbwpfJ4cNj\ntT8REdm7NzKy+M2/5rK9sIQbT+jHZUf01FUrEZEIrdq4g2tfms1XKzZz/MAO3P2jQRzQtGHUsWQ/\nxfQeLDOrB8wCegN/cffpZnYFcLeZ/RZ4H7jR3QvKWXc8MB4gNTU1ljFFRBLaxm0F/Oa1ubw5Zy1p\nXVpw31lp9Gmv9vwiIlFxd178KpM735hPvSTjwbPTOG1o5zoxCG9dENMCy91LgKFm1hJ41cwGAb8G\n1gINgEeBG4A7yln30XA+w4cP15UvEZF9MG3+Om6cnEFefjHXH9+X8Uf0pH4tGYhSRKQuWr81nxsm\nZ/DhohwO630AfzwzjU7qbj2h1Egvgu6ea2YfAse7+33h5AIzexK4riYyiIjUJaWlzsPvf8vD73/L\noM7NeeGsoeqFSkQkYlMzsrn5X3PYWVjCbWMGcP6h3UlSU+2EE8teBNsCRWFx1Qg4FviDmXV092wL\nroGeBsyNVQYRkbooL7+IayalM23+Os46uAt3njaIlOR6UccSEamT3J0F2Xn8/eOlvJ6eRVqXFtw/\ndqg6GEpgsbyC1RF4OrwPKwmY5O5vmNkHYfFlwGzgpzHMICJSpyzfsJ3LnpnJ8g3buW3MAC74Xne1\n6RcRicDSnG1MSc9iSnoWS3O2Uz/JuObYA/nZ6F5qqp3gYtmLYAYwrJzpP4jVPkVE6rKPFq3nFxO+\noX6S8ewlI/lerzZRRxIRqVMyN+3gjYxspqRnMT97K2YwsntrLjqsBycM6qAeAuuIGrkHS0REYsfd\n+fvHy7j3nYX069CcR887mK6tG0cdS0SkTli3NZ+pGdlMycjim1W5AAzt2pLfnDyAkwZ3pEOLlIgT\nSk1TgSUiEsd2FpZw/eQMpqRncfKQjtx75hAaN9BHu4gklpJS56sVm1iyflvFC9eQnYUlfLBwPf9e\nvhF36N+xOdcf35cxQzrpJFcdp6OwiEicyty0g8ufncWCtVu54fh+/PSonrrfSkQShrszOzOXKenZ\nTJ2Txbqt/zNsauR6tmnClT/ow5i0jvRup55aJaACS0QkDn25dCP/98LXFJWU8s8LRvD9fu2ijhS3\nzOxq4FLAgTnARQQdNb0IHADMAs5z98LIQorUEbt63JuSEXQOsXrzThrUS2J037aMSevEiO6tSaol\n/UMkmXFAkwY6sSX/QwWWiEgccXee+XIld7wxn+4HNOax84fTs626+t1XZtYZuBIY4O47zWwS8GPg\nROBBd3/RzP4OXAL8LcKoIglt9x736iUZh/duw1XHHMixA9rTolFy1BFFKk0FlohInHB37pq6gCc+\nW84x/dvx4NlDaZaifzqqQX2gkZkVAY2BbOAHwE/C+U8Dt6ECS6Rabd5eyItfZf5Pj3sXH96D4weq\nxz2JXyqwRETixP3vLuaJz5Zz4fe689uTB5CUpGYp+8vd15jZfcAqYCfwLkGTwFx3Lw4XWw103n1d\nMxsPjAdITU2tmcAiCeKDheu4YfIccvIK1OOeJBwVWCIiceAvHy7hzx8uYdzIVG4dM0Bt/quJmbUC\nTgV6ALnAS8DxlVnX3R8FHgUYPny4xyqjSCLZVlDM3VPnM2FGJv06NOPJC0cwqHOLqGOJVCsVWCIi\ntdyTny/nj+8s4rShnbjrtEEqrqrXMcByd88BMLNXgMOAlmZWP7yK1QVYE2FGkYQwY/kmrn1pNqs3\n7+SnR/Xi6mP70LB+vahjiVQ7FVgiIrXYxK9WcfuU+Rw3sD33nZVGPTULrG6rgEPMrDFBE8GjgZnA\nh8CZBD0JXgC8FllCkTiXX1TCg9MW8+iny+jaqjGTLj+UEd1bRx1LJGZUYImI1FKvzV7Dja/M4agD\n2/LIuGHUr1dL+iZOIO4+3cxeBr4GioFvCJr9TQVeNLO7wmlPRJdSJH7Ny9rCNRPTWbQuj5+MSuXm\nE/vTpKH+/ZTEpt9wEZFa6J15a7lmUjoju7fm7+cerGY0MeTutwK37jZ5GTAygjgiCaG4pJR/fLKM\nh95bTKvGDXjyohF8v6/G65O6QQWWiEgt8/HiHH7xwjcM7tyCJy4cQaMGKq5EJH4s37CdayfN5utV\nuZw8pCN3njqIVk0aRB1LpMaowBIRqUWmL9vI5c/OpFe7pjx90UiaqimNiMQJd+e56av43dQFNKif\nxCPjhnFKWqeoY4nUOB25RURqidmZuVz81Fd0btmIZy8ZSYvGGkRYROLD2i35XD85g08W53DkgW25\n94whGtNK6iwVWCIitcD8rK2c/8R0DmjakOcvPYQ2TRtGHUlEpELuzuvpWfzmX3MpKnHuPG0Q545K\n1XASUqepwBIRidiS9ds474npNGlYn+cvHaWzviISFzZvL+SW1+YyNSObg1Jb8sDYoXRv0yTqWCKR\nU4ElIhKR/KISPl6cw62vzcMMnrt0FF1bN446lohIhT5cuJ7rJ2eQu6OQ64/vy+VH9tI4fSIhFVgi\nIjWooLiETxdvYOqcbKbNX8e2gmLaNWvIc5eOolfbplHHExHZq+0Fxdw1dQETZqyiX4dmPH3RSAZ0\nah51LJFaRQWWiEiMFRaX8vmSDbyRkc2789eSl19Mi0bJnDi4AycP6cShvQ4gWYMIi0gt99WKTVw7\nKZ3MzTu4/KieXHPsgRqjT6QcKrBERGKgqKSUL5du5I2MLN6Zt44tO4tollKfHw7owMlpHTmsVxsa\n1FdRJSK1X0FxCQ9MW8yjnyyjS6tGTLr8UEZ0bx11LJFaSwWWiEg12rKziHvfXsibc7LZvKOIpg3r\nc+yA9pw8pCOH92mjs70iElfmZW3hmonpLFqXx7iRqdx8Un+NzydSAf2FiIhUk20FxVz45AzmrtnC\nCYM6cvKQjhx5YFtSklVUiUj82LKziHfnrWVKRjafL9lA6yYNePLCEXy/X7uoo4nEBRVYIiLVIL+o\nhEuf/oqM1Vv42zkH8cOBHaKOJCJSaTsKi3lvwXqmpGfx8aIcCktK6dq6EZcf2ZPLjuhJqyYNoo4o\nEjdUYImI7KeC4hIuf3YW05dv4qGzh6q4EpG4sGuoiCnpWby/YD07i0po37wh5x3ajTFpnUjr0kID\nBovsAxVYIiL7oaiklF+88A0fL87h3jOGcOrQzlFHEhHZo6KSoFfTKenZvDtvLXkFxbRu0oAzDu7M\nmCGdGNG9NUkaz0pkv6jAEhHZRyWlzrWT0nl3/jpuP2UgY0d0jTqSiMgevTd/HTe9Oof1eQU0S6nP\n8YM6MCatE9/rdQD1NVSESLVRgSUisg9KS52bXpnD6+lZ3HB8Py74XveoI4mIlCsvv4i73ljAxJmZ\n9OvQjLtOG8RRfduqV1ORGFGBJSJSRe7OHW/MZ+LMTK78QW+uGN0r6kgiIuWavmwj176UTlbuTn42\nuhe/PKaPCiuRGFOBJSJSBe7Ove8s4qkvVnDp4T24+tgDo44kIvI/8otKuP/dRTz+2XJSWzdm0uWH\nMlyDA4vUCBVYIiJV8OcPlvC3j5ZyzqhgwE31sCUitc3cNVu4euJsvl2/jXNGpXLTif1posGBRWqM\n/tpERCrp8U+Xcf+0xZx+UGfuPHWQiisRqVWKS0r520dLefj9b2ndpAFPXTSC0X01OLBITVOBJSJS\nCc/9eyV3TV3ASYM7cu8ZQ9SNsYjUKstytnHNpHRmZ+YyJq0Td546kJaNNTiwSBRUYImIVGDyrNXc\n8q+5/KBfOx48e6i6MxaRWqO01Hlu+kp+9+YCGtavxyPjhnFKWqeoY4nUaSqwRET2YtbKzVw/OYPD\neh/AX885iAb1VVyJSPRydxTy9ty1TJqZyderchndty1/OGMI7ZunRB1NpM5TgSUisgfbCoq5euJs\nOrZI4e/nHkxKsro2FpHo5OUX8d6CdUxJz+aTxTkUlzo92jThdz8azLiRXXVfqEgtoQJLRGQP7pwy\nn9Wbd/Di+ENplpIcdRwRqYN2Fpbw4aL1TEnP4oOF6ykoLqVzy0ZcckQPxgzpxMBOzVVYidQyMSuw\nzCwF+ARoGO7nZXe/1cx6AC8CBwCzgPPcvTBWOURE9sU789YycWYmPxvdi5E9NHaMiNScwuJSPv02\nhynpWUybv47thSW0bdaQcSNTGZPWiWFdW6qjHZFaLJZXsAqAH7j7NjNLBj4zs7eAa4AH3f1FM/s7\ncAnwtxjmEBGpkvV5+fz6lTkM6tycq47RQMIiUjPcnT9/sITHPl3G1vxiWjZO5pShnRmT1pFRPQ6g\nnooqkbgQswLL3R3YFr5MDh8O/AD4STj9aeA2VGCJSC3h7lz/cgbbC4p56Oyh6tRCRGrM/e8u5s8f\nLuGY/u05Z1Qqh/dpQ7J6LRWJOzG9B8vM6hE0A+wN/AVYCuS6e3G4yGqg8x7WHQ+MB0hNTY1lTBGR\n/3hu+io+WpTD7acMpHe7ZlHHEZE64k/vf8ufP1zCuJFdufu0wWoCKBLHYnpaxN1L3H0o0AUYCfSr\nwrqPuvtwdx/etm3bmGUUEdllac427p46nyMPbMv5h3aLOo6I1BH/+Hgp909bzOnDOqu4EkkANXLd\n2d1zgQ+BQ4GWZrbrylkXYE1NZBAR2ZuiklKunjibRsn1+OOZQ9Qrl4jUiKc+X87v31rIyUM6cu+Z\nQ1RciSSAmBVYZtbWzFqGzxsBxwILCAqtM8PFLgBei1UGEZHKeuT9b8lYvYXfnz5YA3WKSI14Yfoq\nbpsynx8OaM+DZw+lvu63EkkIsfxL7gh8aGYZwFfANHd/A7gBuMbMlhB01f5EDDOIiFRo1spN/OXD\nJZx1cBeOH9Qx6jhSg8ysr5nNLvPYamZXmVlrM5tmZt+GX1tFnVUSy8uzVnPzv+bw/b5t+dNPhqkz\nC5EEEsteBDOAYeVMX0ZwP5aISOS2FRRz9cR0OrdqxK2nDIw6jtQwd18EDIX/dMy0BngVuBF4393v\nMbMbw9c3RBZUEsrr6Vlc/3I6h/Vqw9/OPZiG9etFHUlEqpFOl4hInXbHlHms3ryDB8cOpWnDmHas\nKrXf0cBSd18JnEowlAjh19MiSyUJ5e252Vw9cTbDu7fmsfOHk5Ks4kok0ajAEpE66515a5k0czU/\nG92b4d1bRx1HovdjYEL4vL27Z4fP1wLtd1/YzMab2Uwzm5mTk1NTGSWOvb9gHb+Y8A1pXVrwzwtH\n0KiBiiuRRKQCS0TqpPVb87lxcgaDO7fgl8f0iTqORMzMGgCnAC/tPs/dHfBypms4Eam0TxbncMVz\nX9O/Y3OeunikrpiLJDAVWCJS57g710/OYGdRCQ+ePVQ3lwvACcDX7r4ufL3OzDoChF/XR5ZM4t6X\nSzcy/tk60H++AAAgAElEQVSZ9GzbhGcuHknzlOSoI4lIDOm/ChGpc57790o+WpTDzSf2p3e7plHH\nkdphHP9tHgjwOsFQIqAhRWQf7Sws4dVvVnPJ01/RtVVjnr90FC0bN4g6lojEmK5Pi0idsixnG3e/\nuYDRfdty7iHdoo4jtYCZNSEYq/HyMpPvASaZ2SXASmBsFNkk/hQUl/DJ4g1MSc/ivQXr2FFYQp92\nTXn+0lEc0LRh1PFEpAaowBKROqOk1Ln2pXQa1q/HH84YgplFHUlqAXffTjAuY9lpGwl6FRSpUHFJ\nKV8s3ciU9CzenreWvPxiWjVO5rRhnRkzpBMje7SmXpI+b0TqChVYIlJn/OOTpXyzKpdHxg2jffOU\nqOOISBwrLXW+WrGJKRlZvDVnLRu3F9KsYX1+OLADY9I6cljvNrq/U6SOUoElInXCwrVbeXDaYk4a\n3JExQzpGHUdE4pC7k756C1PSs5iakc3arfmkJCdxTP/2jEnrxFEHttW4ViKiAktEEl9hcSlXT0yn\nRaMG3HnaIDUNFJFKc3cWrs1jSnoWUzKyyNy0kwb1kjiqb1tuSuvP0f3a0URdrotIGfpEEJGE96cP\nvmVB9lYeO384rZuoBy8RqdiynG1MSc9mSkYWS9Zvo16ScVjvNlz5gz78cGAHWjRSV+siUj4VWCKS\n0GZn5vLXj5Zy5sFdOHZA+6jjiEgttnrzDt7IyGZKehbzsrZiBiO7t+bC0wZxwqAO6gVQRCpFBZaI\nJKz8ohKumTSb9s0a8tsxA6KOIyK1UFFJKRNmrOK12VnMWrkZgKFdW/Kbkwdw0uCOdGihDnFEpGpU\nYIlIwvrjO4tYlrOd5y8dRfMUNecRkf91z1sLeeKz5fTv2Jzrj+/LyYM7kXpA46hjiUgcU4ElIgnp\n38s28s/Pl3PBod04rHebqOOISC304cL1PPHZcs4/tBt3nDoo6jgikiA0QIOIJJxtBcVc91I63Vo3\n5oYT+kUdR0RqofVb87nupXT6dWjGTSf2jzqOiCQQXcESkYRz99T5ZOXu5KWfHkrjBvqYE5HvKi11\nrp40m+2FxUz8ySEau0pEqpWuYIlIQvlw0XomzMhk/JG9OLhb66jjiEgt9I9PlvH5ko3cNmYgvds1\nizqOiCQYFVgikjBydxRyw8sZ9G3fjKuP7RN1HBGphb5ZtZn7313ESYM7cvaIrlHHEZEEpLYzIpIw\nbn19Hpu2F/LPC0fQsL6a/IjId23NL+LKF7+hffMUfnf6YMws6kgikoB0BUtEEsKbc7J5bXYWVx7d\nh0GdW0QdR0RqGXfnllfnkpWbzyPjhtKikYZuEJHYUIElInEvJ6+Am1+dw5AuLbhidK+o44hILTT5\n6zW8np7FVUf30f2ZIhJTaiIoIrVOQXEJGau3sC2/mLyCYvLyi9iWX8y2gmLy8oPHtoKi/7zO3pLP\n9sISHhibRnI9nTcSke9alrON3742l0N6tuZn3+8ddRwRSXAqsESkVikuKeWcx6Yzc+Xm/5mXZNC0\nYX2apSSHX+vTukkDUls35tShndUbmIj8j4LiEn4x4Rsa1E/iobOHUS9J912JSGypwBKRWuWR979l\n5srN3HJSfw7u1opmKck0S6lP04b1adygnm5KF5EqufftRczL2spj5w+nQ4uUqOOISB2gAktEao3p\nyzby5w+XcMZBXbj0iJ5RxxGROPfhwvU88dlyLji0G8cOaB91HBGpI3SzgojUClt2FHH1xNmktm7M\n7acOjDqOiMS59Vvzue6ldPp1aMavT+wfdRwRqUN0BUtEIufu/PrVDNbnFTD5iu/RtKE+mkRk35WW\nOtdMSmd7YTEvjjuElGSNiyciNUdXsEQkchO/yuTNOWu57ri+pHVtGXUcEYlz//hkGZ8t2cCtYwbS\np706vxGRmqXTxCISqSXrt3H7lPkc1vsAxuu+KxHZD8Ulpfzjk2U8MG0xJw3uyI9HdI06kojUQSqw\nRCQyBcUlXDnhG1KSk3hg7FCS1H2yiOyjFRu2c82k2Xy9KpeThnTkntMHq9dREYmECiwRicy9by9i\nfvZWHj9/OO2bq/tkEak6d+e56av43dQFJNczHhk3jFPSOkUdS0TqMBVYIhKJjxYF3Seff2g3jlH3\nySKyD9Zuyef6yRl8sjiHI/q04Y9npmmsKxGJnAosEalxOXkFXPdSOn3bN+MmdZ8sIvvgtdlr+M2/\n5lJU4tx52iDOHZWqJoEiUiuowBKRGlVa6lz3Ujp5+cU8f6m6TxaRqtm8vZDfvDaXNzKyOSi1JfeP\nHUqPNk2ijiUi8h8qsESkRj35xQo+XpzDnacOpG8HdZ8sIpX34aL13PByBpt3FPKr4/py+ZE9qV9P\nI86ISO2iAktEasy8rC384a2FHNO/Pece0i3qOCISJ7YXFHPX1AVMmLGKvu2b8eRFIxjYqUXUsURE\nyhWzAsvMugLPAO0BBx5194fN7DbgMiAnXPQmd38zVjlEpHbYUVjMlRO+oVWTZO49c4julRCRSpm5\nYhPXTEonc/MOLj+qJ9cceyAN66tpsYjUXrG8glUMXOvuX5tZM2CWmU0L5z3o7vfFcN8iUsvc+cZ8\nlm3YznOXjKJ1kwZRxxGRWq6guIQHp33LPz5ZSpdWjZg4/lBG9mgddSwRkQrFrMBy92wgO3yeZ2YL\ngM6x2p+I1E4FxSU89skyJszI5KdH9eKw3m2ijiTyHWbWEngcGETQ4uJiYBEwEegOrADGuvvmiCLW\nOfOztnLNpNksXJvHuJGp3HxSf5o21F0NIhIfauTOUDPrDgwDpoeTfm5mGWb2TzNrtYd1xpvZTDOb\nmZOTU94iIlKLuTtvz13LsQ98wn3vLua4ge259ocHRh1LpDwPA2+7ez8gDVgA3Ai87+59gPfD1xJj\nJaXOXz9awql/+YyN2wt58sIR/P70wSquRCSuxPwTy8yaApOBq9x9q5n9DbiT4CzhncD9BGcLv8Pd\nHwUeBRg+fLjHOqeIVJ+5a7Zw5xvzmb58Ewe2b8ozF4/kyAPbRh1L5H+YWQvgSOBCAHcvBArN7FRg\ndLjY08BHwA01n7DuWLFhO9e+lM6slZs5aXBH7jptEK3UnFhE4lBMCywzSyYorp5391cA3H1dmfmP\nAW/EMoOI1Jz1efnc984iXpq1mpaNkrnztEGMG9FV3ShLbdaDoNOlJ80sDZgF/BJoHzZ1B1hL0GHT\nd5jZeGA8QGpqas2kTUDuzvPTV3H31AUk1zMe/vFQTknrpI5wRCRuxbIXQQOeABa4+wNlpncsc9D6\nETA3VhlEpGbkF5XwxGfL+euHSygsKeXSw3vw8x/0oUWj5KijiVSkPnAQ8At3n25mD7Nbc0B3dzP7\nn5YUammx/9Zuyef6yRl8sjiHI/q04Y9nptGhRUrUsURE9kssr2AdBpwHzDGz2eG0m4BxZjaUoIng\nCuDyGGYQkRhyd6bOyeb3by5kTe5Ojh3QnptO7E+PNk2ijiZSWauB1e6+6x7hlwkKrHW7TgiaWUdg\nfWQJE9Tr6Vn85l9zKSgu4c5TB3LuId101UpEEkIsexH8DCjvk1JjXokkgIzVudwxZT4zV26mX4dm\nvHDpKL6nHgIlzrj7WjPLNLO+7r4IOBqYHz4uAO4Jv74WYcyE4u7c9OocJszIZFhqSx4YO1QnZUQk\noahbHhGpstdmr+GXL86mTdMG/P70wYwd3pV6STrzLHHrF8DzZtYAWAZcRNDL7iQzuwRYCYyNMF9C\nmTAjkwkzMhl/ZE+uP66v7tEUkYRTpQLLzJoA+e5eEqM8IlLLrdy4nZtemcPwbq148qIRNEvRfVYS\n39x9NjC8nFlH13SWRLd4XR63T5nHEX3acOPx/UjSiRkRSUB7PW1kZklm9hMzm2pm64GFQLaZzTez\nP5pZ75qJKSK1QWFxKVdO+IZ6ScbD44apuBKRSssvKuHKCd/QLKU+949NU3ElIgmrouvyHwK9gF8D\nHdy9q7u3Aw4H/g38wczOjXFGEaklHpi2mPTVW/jDGUPo3LJR1HFEJI787s0FLFybx31npdGumXoK\nFJHEVVETwWPcvWj3ie6+iWB8q8nhWFcikuA+/TaHv3+8lHEjUzlhcMeo44hIHHln3lqe+XIllx3R\ng9F920UdR0QkpvZ6BWtXcWVmvcysYfh8tJldaWYtyy4jIolrw7YCrpmUTu92TfntyQOijiMicSQr\ndyfXv5zB4M4t+NVx/aKOIyISc5XtumcyUBLec/Uo0BV4IWapRKTWKC11rnspnS07i/jTuGE0alAv\n6kgiEidKSp2rJs6muKSUR8YNo0F99RgoIomvsp90pe5eDPwI+JO7/wpQGyGROuDJL1bw0aIcbjmp\nP/07No86jojEkb98uIQZyzdx52mDNNaViNQZlS2wisxsHMFgi2+E03TvlUiCm7tmC394ayHH9G/P\neYd0izqOiMSRmSs28dB7i/nRsM6cflCXqOOIiNSYyhZYFwGHAne7+3Iz6wE8G7tYIhK17QXFXDnh\nG1o3acAfzxyCmbpUFpHK2bKjiF++OJuurRtzx6kDo44jIlKjKjXQsLvPB64s83o58IdYhRKR6N0+\nZR7LN27n+UtH0apJg6jjiEiccHdufCWDdVvzmXzF9zRenojUORUNNDzFzMaU1xW7mfU0szvM7OLY\nxRORKLyensWkmav5v9G9+V6vNlHHEZE4MmFGJm/NXcuvjutLWteWUccREalxFV3Bugy4BnjIzDYB\nOUAK0B1YCvzZ3V+LaUIRqVGZm3Zw8ytzOCi1Jb88pk/UcUQkjixel8ftU+ZxRJ82XHZEz6jjiIhE\nYq8FlruvBa4Hrjez7gQ9B+4EFrv7jpinE5EaVVRSypUvfgPAwz8eRnI9daksIpWTX1TClRO+oVlK\nfe4fm0ZSku7bFJG6qVL3YAG4+wpgRcySiEjkHn7vW75Zlcufxg2ja+vGUccRkTjyuzcXsHBtHk9d\nNIJ2zVKijiMiEhmdnhYRAL5YuoG/fLSEs4d3ZUxap6jjiEgceXfeWp75ciWXHdGD0X3bRR1HRCRS\nKrBEhFkrN3P1xNn0aNOEW08ZEHUcEYkj7s49by2kX4dm/Oq4flHHERGJXKULLDNrZGZ9YxlGRGpW\n5qYd/N8LX3PG377AHf487iAaN6h0y2EREb5YupFlG7Yz/sieNKiv87YiIpX6T8rMxgD3AQ2AHmY2\nFLjD3U+JZTgRiY0tO4v464dLePLzFSQlwS+P7sP4I3vSpKGKKxGpmme+XEHrJg04cXDHqKOIiNQK\nlf1v6jZgJPARgLvPNrMeMcokIjFSVFLKhBmreOi9b9m8o5AzDurCdT/sS4cWuiFdRKoue8tOps1f\nx/gje5GSXC/qOCIitUJlC6wid99i9p0uVz0GeUQkBtydDxau53dvLmBpznYO7XkAN5/Un0GdW0Qd\nTUTi2ITpq3DgnFGpUUcREak1KltgzTOznwD1zKwPcCXwRexiiUh1mZ+1lbvfnM/nSzbSs00THjt/\nOMf0b8duJ0xERKqksLiUF2Zk8v2+7TSsg4hIGZUtsH4B3AwUABOAd4A7YxVKRPbfuq353P/uIl6a\ntZoWjZK5bcwAzjmkmwYPFpFq8c68tWzYVsB5h3aLOoqISK1SqQLL3XcQFFg3xzaOiFSHjNW5nPP4\ndPKLSrj08B78/Pt9aNE4OepYIpJAnv33SlJbN+aoPm2jjiIiUqtUthfB4cBNQPey67j7kNjEEpF9\ntXDtVs7/5wxaNk7mmYsPp0ebJlFHEok5Mxvs7nOizlFXLFy7lRnLN3HTif1ISlJzYxGRsirbRPB5\n4FfAHKA0dnFEZH8sy9nGuY/PIKV+PV649BDdFyF1yV/NrCHwFPC8u2+JOE9Ce+7fK2lQP4mzDu4a\ndRQRkVqnsgVWjru/HtMkIrJfMjft4JzHpwPO85epuJK6xd2PCDthuhiYZWYzgCfdfVrE0RJOXn4R\nr369hjFDOtGqSYOo44iI1DqVLbBuNbPHgfcJOroAwN1fiUkqEamS7C07+cnj/2ZHYQkvjj+EXm2b\nRh1JpMa5+7dmdgswE3gEGGZBd5k36XhVfV79Zg3bC0s4X51biIiUq7IF1kVAPyCZ/zYRdEAHLJGI\n5eQVcM7j09m8vYjnLx1F/47No44kUuPMbAjBseokYBowxt2/NrNOwJfoeFUt3J1nv1zJkC4tSOva\nMuo4IiK1UmULrBHu3jemSUSkynJ3FHLeE9PJyt3JMxeP0j88Upf9CXic4GrVzl0T3T0rvKol1WD6\n8k18u34b956pPq5ERPaksgXWF2Y2wN3nxzSNiFRaXn4RF/xzBstytvPEhcMZ2aN11JFEonQSsNPd\nSwDMLAlIcfcd7v5stNESx7NfrqRFo2ROSesUdRQRkVqrsiOOHgLMNrNFZpZhZnPMLCOWwURkz3YU\nFnPxU18xL2srfz3nII7QODQi7wGNyrxuHE6TarJuaz7vzFvL2OFdSEmuF3UcEZFaq7JXsI6PaQoR\nqbT8ohLGPzOLWSs388i4YRwzoH3UkURqgxR337brhbtvMzN1pVmNXpyRSXGpc84odW4hIrI3ey2w\nzKy5u28F8mooj4jsRVFJKT9/4Ws+W7KB+85K4+QhaqYjEtpuZge5+9cAZnYwsLOCdQiXXUFwnCsB\nit19uJm1BiYC3YEVwFh33xyD3HGhqKSUF2as5KgD29Jdg5eLiOxVRVewXgBOBmYR9BpYdrh2B3rG\nKJeI7Kak1Llq4mzeW7CeO08dyJkHd4k6kkhtchXwkpllERyrOgBnV2H977v7hjKvbwTed/d7zOzG\n8PUN1ZY2zrw3fx3rthZw92m6eiUiUpG9FljufnL4tUfNxBGR8mzZWcQt/5rL1IxsbjqxH+cd2j3q\nSCK1irt/ZWb9gF093i5y96L92OSpwOjw+dPAR9ThAuuZL1fSuWUjvt+vXdRRRERqvUp1cmFm71dm\nmohUL3dnSnoWxzzwMVMzsvjVcX0Zf2SvqGOJ1FZ9gQHAQcA4Mzu/kus58K6ZzTKz8eG09u6eHT5f\nC9TZmx2XrM/jy2UbOeeQVOolWcUriIjUcRXdg5VC0BNTGzNrxX+bCDYHOlewblfgGYKDkgOPuvvD\natcuUjmrNu7gltfm8sniHAZ3bsGTF45gUOcWUccSqZXM7FaCK04DgDeBE4DPCI5DFTnc3deYWTtg\nmpktLDvT3d3MvJx9jgfGA6Smpu7fN1CLPffvVTSol8TY4V2jjiIiEhcqugfrcoJ27Z0I7sPaVWBt\nBf5cwbrFwLXu/rWZNQNmmdk04ELUrl1kj4pKSnns02U8/N631E8ybhszgPMO7a4zxyJ7dyaQBnzj\n7heZWXvgucqs6O5rwq/rzexVYCSwzsw6unu2mXUE1pez3qPAowDDhw//nwIsEWwvKGbyrNWcOLgD\nbZo2jDqOiEhcqOgerIeBh83sF+7+p6psOGxakR0+zzOzBQRXvdSuXWQPZq7YxE2vzmHxum0cP7AD\nt54ygI4tGlW8oojsdPdSMys2s+YEBVGFl1zMrAmQFB6nmgA/BO4AXgcuAO4Jv74Wu+i1179mryGv\noFj3fYqIVEGlxsGqanG1OzPrDgwDplPJdu11pemFCEDujkL+8PZCJszIpHPLRjx+/nCNbyVSNTPN\nrCXwGEGLi23Al5VYrz3wqplBcEx8wd3fNrOvgElmdgmwEhgbm9i1l7vz7JcrGdCxOQeltow6johI\n3KjsQMP7zMyaApOBq9x9a3gQA/bcrj2cl/BNL0TcnddmZ3HnG/PJ3VnE+CN78suj+9CkYcz/NEUS\nhgUHlt+7ey7wdzN7G2ju7hkVrevuywiaFu4+fSNwdLWHjSMzV25m4do8fn/6YMoeu0VEZO9i+l+c\nmSUTFFfPu/sr4eQK27WL1AWrNu7gplfn8NmSDaR1bckzPxrEwE7qxEKkqsKTdW8Cg8PXK6JNlBie\n/XIlzVLqc+pQDWguIlIVlS6wzKwz0K3sOu7+yV6WN+AJYIG7P1Bmltq1S523s7CEc5+Yzubthdx5\n6kB+MqqbOrEQ2T9fm9kId/8q6iCJICevgLfmZnPuId1o3EBX1EVEqqJSn5pm9gfgbGA+UBJOdmCP\nBRZwGHAeMMfMZofTbiIorOp0u3aRB99bzKpNO3hx/CEc0vOAqOOIJIJRwDlmthLYTtDrrbv7kGhj\nxafJX6+mqMQ595BuUUcREYk7lT0tdRrQ190LKrthd/+M/3brvrs63a5d6raM1bk8/ukyxo1MVXEl\nUn2OizpAIpmxfBO92zWlV9umUUcREYk7SZVcbhmQHMsgInVBUUkpN0yeQ5umDbnxhH5RxxFJJL6H\nh1SRu5OxOpchXXRPqIjIvqjsFawdwGwzex/4z1Usd78yJqlEEtRjny5jQfZW/n7uwbRopHMWItVo\nKkFBZUAK0ANYBAyMMlQ8ytqSz4ZthQztqq7ZRUT2RWULrNfDh4jso+UbtvPQe99y/MAOHD+oQ9Rx\nRBKKuw8u+9rMDgJ+FlGcuJaemQvAkC4qsERE9kVlBxp+2swaAAeGkxa5e1HsYokkltJS58bJGTSs\nn8Ttp+qEukisufvXZjYq6hzxKH11Lsn1jP4dm0UdRUQkLlW2F8HRwNPACoLmF13N7IK9ddMuIv81\naWYm05dv4venD6Z985So44gkHDO7pszLJOAgICuiOHEtI3ML/To0p2H9elFHERGJS5VtIng/8EN3\nXwRgZgcCE4CDYxVMJFGs35rP3W8uYFSP1pw9vGvUcUQSVdnLLcUE92RNjihL3Cotdeau2cIpGlxY\nRGSfVbbASt5VXAG4+2Iz0x36IpVw6+vzKCgu5Z4zhpCkwYRFYsLdb486QyJYtmE7eQXFpKmDCxGR\nfVbZbtpnmtnjZjY6fDwGzIxlMJFE8Pbctbw1dy1XHdOHHm2aRB1HJGGZ2TQza1nmdSszeyfKTPEo\nY3XQwUWaOrgQEdlnlb2CdQXwf8Cubtk/Bf4ak0QiCWLLziJ++9pc+ndszmVH9Iw6jkiia+vuubte\nuPtmM2sXZaB4lJ6ZS+MG9ejdTgMMi4jsq8r2IlgAPBA+RKQS7nlrIRu2FfD4BcNJrlfZi8Uiso9K\nzCzV3VcBmFk3NNBwlaWv3sKgTi2op+bMIiL7bK8FlplNcvexZjaHcg5U7j4kZslE4ti/l21kwoxV\nXHZED40lI1IzbgY+M7OPCXq7PQIYH22k+FJYXMr87K2cf0i3qKOIiMS1iq5g/TL8enKsg4gkivyi\nEn79yhy6tm7E1cceWPEKIrLf3P3tcHDhQ8JJV7n7higzxZvF6/IoLC5VBxciIvtpr+2W3D07fPoz\nd19Z9gH8LPbxROLPnz74luUbtvO7Hw2mcYPK3uYoIvvDzH4EFLn7G+7+BlBsZqdFnSuepKuDCxGR\nalHZG0OOLWfaCdUZRCQRzM/ayj8+XsYZB3XhiD5to44jUpfc6u5bdr0IO7y4NcI8cScjcwutGifT\ntXWjqKOIiMS1iu7BuoLgSlVPM8soM6sZ8Hksg4nEm5JS58ZXMmjRKJlbTuofdRyRuqa8E4a6hFwF\n6atzGdylJWbq4EJEZH9UdPB5AXgL+D1wY5npee6+KWapROJIflEJn327gUkzM8lYvYVHxg2jVZMG\nUccSqWtmmtkDwF/C1/8HzIowT1zZUVjM4nV5HDugfdRRRETi3l4LrLC5xRZgHEA4pkgK0NTMmu7q\nDlekrskvKuGjRTm8NTeb9xesZ1tBMS0aJXPF6F6MGdIx6ngiddEvgN8AE8PX0wiKLKmEeVlbKXXd\nfyUiUh0q1XzCzMYQjIHVCVgPdAMWAANjF02kdtlRWMxHi3J4c042Hyxcz47CElo1TubkIR05YXBH\nvtfrAI13JRIRd9/Od1taSBWkZwYdXAzp2iLiJCIi8a+y7dPvIuj69j13H2Zm3wfOjV0skdphe0Ex\n/9/encdHVd59H//+CAlhRyCyK0FxYQcjuHRzrWgVUGtdqiAqtXe12mpbbZ+7tXft82hr61Zbq7Jp\ncd9LW5UKauvdCmELi8iWAEkRkkACJAGy/J4/5tCmFEICM3Nm+bxfr7xm5sz2vThhrvzmXOe65q7a\nqj8t36x5q0pVU1uvbu2zNH5kH104pJdOG9BVrSmqgNCZWY6k7yryxV/2vu3ufnZooZJIQXGlenXO\n1tEdsw/9YABAk5pbYNW6e7mZtTKzVu4+z8weimkyIGQvLyzWD15bpj11DereoY0uP6Wvxg7tqTG5\n3ZTRipPAgQQzS5HhgV+SdLOkiZJKQ02URAqKKzSsL0evACAamltgVZhZB0kfSJplZlslVcUuFhCu\nOSu36LsvL9WY3G66/dyByuvflaIKSGzd3H2qmd3m7u9Let/MFoQdKhlUVO9VUXm1vpzXL+woAJAS\nmltgjZNUI+lbkq6R1FnS/8QqFBCm/KJtuuXZRRrat4uempin9m2Y6RlIArXB5WYzu0jSPyR1DTFP\n0igojiwfxgQXABAdzT155NuS+rh7nbvPdPdHJF0Ww1xAKFZv2anJMxaoT5e2mj7pVIorIHnca2ad\nJd0h6U5JTynypSAOoaA4MsHFUIYIAkBUNLfAulXSW8HkFvvcHIM8QGhKKmp03dT5ys7M0MzJo9WV\ntayApOHus9290t2Xu/tZ7n6Ku78Zdq5ksLS4UgO6t1fntplhRwGAlNDcAqtE0lhJ95nZd4JtnJCC\nlLG9aq8mTpuvqr11mjl5tPp1bRd2JACICya4AIDoavb80sGiwp+XNMjMXpLUNmapgDiq3lunyTMX\naOO2aj11XZ5O7tUp7EgAEBefVu7Wlh17NIzzrwAgappbYOVLkrvvdvfrJb0nifFTSHq19Q265dnF\nWrqpQo9cOUJjBnQLOxIAxM3S4Pyr4SwwDABR06wCy91v2u/2Y+4+IDaRgPhwd9396jLNXbVVPxk/\nRBcM6RV2JABHyMxOM7O3zOw9Mxsfdp5EV1BcoYxWpsG9KbAAIFqanCLNzF509yvMbJkk3/9+dx8W\ns+vxU58AACAASURBVGRAjP3s7U/08sJifevcE3TNmGPDjgPgMJhZT3f/tNGmb0uaoMh5wh9Jer0Z\nr5GhyEiNEnf/kpnlSnpeUjdJCyVd6+57ox4+ARQUV+rEHh2VnZkRdhQASBmHmoP6tuDyS7EOAsTT\n1L8W6jfvrdM1Y47RN885Puw4AA7f42a2SNLP3H23pApJl0tqkLSjma9xm6SPJe07AfN+SQ+6+/Nm\n9rikGyT9Jrqxw+fuKiiu1IVDe4YdBQBSSpNDBN19c3C54UA/8YkIRNcbS0r0k9krdcHgnvqfcUNk\nxoSYQLJy9/GSFkuabWbXSbpdUhtFjj4dcoigmfWVdJEi62bJIh8IZ0t6OXjIzOa8TjLaUF6typpa\nJrgAgChrssAys51mtuMAPzvNrLnfDAIJ4y9rSnXnS0s1JrerHrpyhDJaUVwByc7dfy/pi5I6S3pN\n0mp3f8TdS5vx9IckfVeRI15SpDCrcPe64HaxpD4HeqKZTTGzfDPLLy1tzlslln0TXDBFOwBE16GO\nYHV0904H+Ono7sxljaSyestO3fzMQh2X00FPTszjnAMgBZjZJWY2T9JbkpZL+oqkcWb2vJkdd4jn\nfknSVndfeDjv7e5PuHueu+fl5OQczkuEaummSmVnttIJPTqGHQUAUsqhzsH6N2Z2tKTsfbeDtbGA\nhFdb36A7Xlyq7MwMzZw8Wp2yM8OOBCA67pU0WpG1Gd9299GS7jCzgZJ+KunKJp57pqRLzOxCRfq2\nTpIeltTFzFoHR7H6SiqJZQPCUlBcocG9Oyszo9lLYgIAmqFZn6rBN4RrJBVKel9SkaQ/xTAXEFW/\nfX+dlpVU6t7xQ9SjU/ahnwAgWVRKulTSZZK27tvo7mvcvaniSu5+t7v3dff+ihRic939GknzFJko\nQ5ImSnojFsHDVFffoOX/qGR4IADEQHO/tvqJpNMUGdeeK+kcSX+PWSogij7evEMPv7tGFw/vrbFD\nWesKSDETFDlvqrWkq6P0mt+T9G0zWxu89tQovW7CWLN1l3bXNmg4E1wAQNQ1d4hgrbuXm1krM2vl\n7vPM7KGmnmBm0xSZ3n2ruw8Jtt0j6SZJ+84G/r67//EwswOHVFvfoDtfWqrObTP140sGhx0HQJS5\ne5mkR6PwOu9Jei+4vl6RYYcpq4AJLgAgZppbYFWYWQdJH0iaZWZbJVUd4jkzJP1K0tP7bX/Q3R9o\nUUrgMP163jqt+McOPf7VU9S1fVbYcQAgISzZVKlO2a3Vv1v7sKMAQMpp7hDBcZJqJH1LkZma1km6\nuKknuPsHkrYdUTrgCKz4R6UenbtG40b01gVDWEgTAPYpKK7QsL5d1IqlKgAg6ppVYLl7lbvXu3ud\nu88M1hcpP8z3vMXMCsxsmpkddZivATRpb12D7nypQEe1z9I9FzM0EAD22V1br08+3cnwQACIkUMt\nNPzX4HL/BYcPd6Hh30g6TtIISZsl/aKJ907qBRwRrl/NW6uPN+/Q/50wVEcxNBAA/mnl5h2qa3AN\nY4ILAIiJQy00/Jngcv8Fhw9roWF33xIcCWuQ9KSaOIk42RdwRHiWl1Tq1/PW6tKRfXTeoB5hxwGA\nhFKwKTLBxfB+HMECgFho7jpYzzRnWzNep/Ec2RMkLW/pawBNiQwNXKqu7bP0I4YGAsB/KCiuVE7H\nNurJmoAAEBPNnUXw3/5SNbPWkk5p6glm9pykL0jqbmbFkn4k6QtmNkKSK7JY8ddamBdo0qNz12jV\npzs1dWKeOrfLDDsOACScJcUVGt63i8yY4AIAYqHJAsvM7pb0fUltG51zZZL2Snqiqee6+1UH2Jxy\nizUicRQUV+jX763TZaP66pyTGRoIAPvbsbtW60urNGFEn7CjAEDKOtQ5WP/P3TtK+vl+5191c/e7\n45QROKQ9dfW686Wl6t4hSz+8eFDYcQAgIS0vrpQkDevHBBcAECuHOoJ1kruvkvSSmY3a/353XxSz\nZEALPPznNVq9ZZemX3+qOrdlaCAAHMjSfQVWHya4AIBYOdQ5WN+WNEUHnk7dJZ0d9URACy3ZVKHH\n31+nK/L66qwTjw47DgAkrILiCh3TtR3LVwBADDVZYLn7lODyrPjEAVpmd21kaGCPTtn6P19iaCAA\nNKWguFKjjj0q7BgAkNKaO4ugzOwMSf0bP8fdn45BJqDZHvzzaq3dukszJ49Wp2yGBgLAwZTu3KOS\nihpdf2b/sKMAQEprVoEVrHl1nKQlkuqDzS6JAguhmfXRBj35wXpdeWo/ff4EFqMGgKYUFEcWGB7W\nlwkuACCWmnsEK0/SIHf3WIYBmqOhwXX/26v02/fX66wTc5g1EACaYWlxpVqZNKRPp7CjAEBKa26B\ntVxST0mbY5gFOKR951zNLtisa8Ycox9fMlitM5pcbQAAoMgRrIFHd1S7rGafHQAAOAzN/ZTtLmml\nmc2XtGffRne/JCapgAPYXrVXU57J14Ki7bpr7En62ucGyMzCjgUACc/dVVBcqXNPZqZVAIi15hZY\n98QyBHAoG8urNWn6fBVX1OhXV4/Ul4b1DjsSACSN4u012la1l/OvACAOmlVgufv7sQ4CHMzijdt1\n48x81btr1o1jdGr/rmFHAoCksmjjdknScAosAIi5JgssM9upyGyB/3GXJHd3zpRFTL21/FPd/sJi\nHd0xWzOuP1UDcjqEHQkAks4fl21W9w5tdHKvjmFHAYCUd6iFhvkkRmim/rVQ9/5hpYb37aKnJuap\ne4c2YUcCgKRTUb1Xc1dt1XWn92dSIACIA6YSQsKpb3Dd+4eVmv5hkb44uIce+spItc3KCDsWACSl\n2QWbVVvvmjCyT9hRACAtUGAhodTsrdftLyzW2yu2aPKZufrBRScroxUzBQLA4XptcYlO6NFBg3sz\nqh8A4oECCwmjak+drp36kRZvqtCPLh6k68/MDTsSACS1DeVVWrhhu753wUksawEAcUKBhYRQV9+g\nW55dpCWbKvTrq0dp7NBeYUcCgKT36qISmUnjR7K0BQDECwUWQufu+u83VmjeJ6X66YQhFFcAEAXu\nrteXlOiM47qpV+e2YccBgLTBdEII3a/fW6fn5m/U179wnK4Zc2zYcQAgJSzauF0byqs1YWTfsKMA\nQFqhwEKoXl9cop+//YkuGd5b3zn/xLDjAEDKeHVRibIzW+mCIT3DjgIAaYUCC6H533Vl+s7LSzUm\nt6t+/uVhasVsgQAQFXvq6jW7YLO+OLinOrThbAAAiCcKLIRi9Zad+tozC3Vst/Z64to8tWnNOlcA\nEC3zVpWqsqaWta8AIAQUWIi7LTt2a9K0+crOzNCM609V53aZYUcCgJTy2uJide/QRp85vnvYUQAg\n7VBgIa527anT5BkLVFFTq+mTTlXfo9qFHQkAUkpF9V7NXbVV40b0VusMunkAiDc+eRE3tfUN+sas\nRVr16U49ds0oDenTOexIANKcmWWb2XwzW2pmK8zsx8H2XDP7yMzWmtkLZpYVdtbmml2wWbX1zvBA\nAAgJBRbiwt31368v1/urS3Xv+CE668Sjw44EAJK0R9LZ7j5c0ghJF5jZaZLul/Sgux8vabukG0LM\n2CKvLS7RCT06aHDvTmFHAYC0RIGFuHhs3lo9v2CTbjnreF01+piw4wCAJMkjdgU3M4Mfl3S2pJeD\n7TMljQ8hXottKK/Swg3bNWFkX5kxMysAhIECCzH32uJiPfDOak0Y2Ud3nH9C2HEA4N+YWYaZLZG0\nVdIcSeskVbh7XfCQYkn/Md7OzKaYWb6Z5ZeWlsYvcBNeXVQiM2n8yN5hRwGAtEWBhZj637Vl+u7L\nBTp9QDfdf9kwvlEFkHDcvd7dR0jqK2m0pJOa+bwn3D3P3fNycnJimrGZefT6khKdPqCbenVuG3Yc\nAEhbFFiImRcWbNSkGQuU2729Hr/2FGW15tcNQOJy9wpJ8ySdLqmLme1bobevpJLQgjXToo3btaG8\nmsktACBk/MWLqNtdW6/vvVyg772yTKP7d9VzN52mzm1Z6wpA4jGzHDPrElxvK+k8SR8rUmhdHjxs\noqQ3wknYfK8uKlF2ZiuNHdor7CgAkNZaH/ohQPNt2latr89aqOUlO3TLWcfrW+edoIxWDAsEkLB6\nSZppZhmKfOn4orvPNrOVkp43s3slLZY0NcyQh7Knrl6zCzbr/EE91aENXTsAhIlPYUTNvE+26vbn\nl6jBXU9dl6dzB/UIOxIANMndCySNPMD29Yqcj5UU5q0qVWVNrSaMYnggAISNAgtHrKHB9fC7a/TI\n3DU6qWcnPf7VUTq2W/uwYwFA2nhtcbG6d2ijzx7fPewoAJD2KLBwRLZX7dXtLyzR+6tLddmovrp3\n/BC1zcoIOxYApI2K6r2au2qrrj2tv1pncGo1AISNAguHbVlxpW7+3UKV7tyjn04YoqtHH8M07AAQ\nZ7MLNqu23nUpwwMBICFQYOGwPD9/o3745gp1b5+lF28+XSP6dQk7EgCkpdcWl+iEHh00uHensKMA\nABTDadrNbJqZbTWz5Y22dTWzOWa2Jrg8Klbvj9jYXVuv7768VHe9ukxjcrtq9jc/S3EFACHZUF6l\nhRu2a8LIvowgAIAEEcvB2jMkXbDftrskvevuAyW9G9xGkqirb9BNT+frxfxi3Xr28Zpx/Wh1bZ8V\ndiwASFuvLiqRmTR+ZO+wowAAAjErsNz9A0nb9ts8TtLM4PpMSeNj9f6IvgfeWa2/rCnTfZcO1R3n\nn8j6VgAQInfX60tKdPqAburVuW3YcQAAgXhPN9TD3TcH1z+VdNCFksxsipnlm1l+aWlpfNLhoN5a\nvlmPv79OV485RleOPibsOACQ9hZt3K4N5dWaMJLJLQAgkYQ2n6u7uyRv4v4n3D3P3fNycnLimAz7\nW7t1l+54calG9OuiH108KOw4AABFhgdmZ7bS2KG9wo4CAGgk3gXWFjPrJUnB5dY4vz9aaNeeOn3t\nmXxlZ2boN18dpTatWeMKAMK2p65esws26/xBPdWhDRMCA0AiiXeB9aakicH1iZLeiPP7owXcXd95\naakKy6r06NUjGeMPAAli8cYKVdbU6uLhTG4BAIkmltO0Pyfpb5JONLNiM7tB0n2SzjOzNZLODW4j\nQf32g/X60/JPdffYk3XGcd3DjgMACKwvrZIkDWLtKwBIODEbV+DuVx3krnNi9Z6Ing/Xlulnb63S\nRcN66cbP5oYdBwDQSGHZLrVp3Uq9OmWHHQUAsJ/QJrlA4iqpqNGtzy3WcTkd9LPLhrF4JQAkmMKy\nah3brZ1asVwGACQcCiz8m9219fqv3y3U3roGPX7tKWrPydMAkHCKyqvUv1v7sGMAAA6AAgv/5se/\nX6GlxZX6xRXDdVxOh7DjAAD2U9/g2lherdwcCiwASEQUWPinFxZs1HPzN+m/vnCcvji4Z9hxAAAH\n8I+KGu2tb1AuR7AAICFRYEGSVFBcof9+Y4U+O7C77jj/xLDjAAAOorAsMoNg/+4UWACQiCiwoG1V\ne/X13y1SToc2evjKkcrgpGkASFhF5ZECK5cCCwASEjMYpLm6+gbd+twile7ao1duPkNd22eFHQkA\n0ITCsiq1y8rQ0R3bhB0FAHAAHMFKY7X1Dbr71WX6cG257h0/REP7dg47EgDgEIrKIjMIsoQGACQm\njmClqR27a/WNWYv0lzVluu2cgboir1/YkQAAzVBYVqXBvflCDAASFQVWGiqpqNHk6Qu0rnSXfn75\nMH2Z4goAkkJtfYM2ba/RRcN6hR0FAHAQFFhpZllxpSbPXKDdtfWaOXm0zjy+e9iRAADNVLy9RvUN\nziLDAJDAKLDSyJ9XbtGtzy1W1/ZZevbGMRrYo2PYkQAALVAUTNE+gEWGASBhUWCliRkfFup/Zq/U\nkD6d9dTEPB3dMTvsSACAFlq/bw0sjmABQMKiwEpx9Q2ue/+wUtM/LNJ5g3ro4StHqF0Wux0AklFR\nWZU6ZrdmSQ0ASGD8pZ3CqvfW6bbnl2jOyi2afGaufnDRySwiDABJrKi8SrndmaIdABIZBVaK2rpz\nt26cma/lJZX68SWDNfGM/mFHAgAcocKyKp1y7FFhxwAANIGFhlPQ6i07NeGx/9WaLbv0xLV5FFcA\nkAL21NWrpKKG868AIMFxBCvFLNywXZOmz1d2ZoZe/NrpGtqXxSgBIBVsLK+Wu5TbnQILABIZBVYK\nWbt1pybPWKBu7bM066bT1KdL27AjAQCipHDfDIIUWACQ0BgimCI2V9bouqnzldW6lZ65YQzFFQA0\ng5n1M7N5ZrbSzFaY2W3B9q5mNsfM1gSXoZ/4VFQeKbByGSIIAAmNAisFVFbXatK0Bdqxu07TJ52q\nfl3bhR0JAJJFnaQ73H2QpNMkfcPMBkm6S9K77j5Q0rvB7VAVllWra/ssdW6XGXYUAEATKLCS3O7a\net30dL7Wl+3SE9eeoiF9OOcKAJrL3Te7+6Lg+k5JH0vqI2mcpJnBw2ZKGh9Own8pLNul/t34Ag0A\nEh0FVhKrb3Dd9vxizS/apl9eMUJnHN897EgAkLTMrL+kkZI+ktTD3TcHd30qqccBHj/FzPLNLL+0\ntDTm+YrKqjn/CgCSAAVWknJ3/fCN5Xp7xRb98EuDdPHw3mFHAoCkZWYdJL0i6XZ339H4Pnd3Sb7/\nc9z9CXfPc/e8nJycmOar2VuvT3fs5vwrAEgCFFhJ6tG5azXro426+fPHafJncsOOAwBJy8wyFSmu\nZrn7q8HmLWbWK7i/l6StYeWTGk1wkUOBBQCJjgIrCT03f6N+OWe1Lh3VR9+74MSw4wBA0jIzkzRV\n0sfu/stGd70paWJwfaKkN+KdrbF/TtHOESwASHisg5Vk5qzcoh+8tkyfPyFH9182TJG/DQAAh+lM\nSddKWmZmS4Jt35d0n6QXzewGSRskXRFSPkmsgQUAyYQCK4nkF23TLc8u0tA+nfXra0YpM4MDkABw\nJNz9r5IO9k3VOfHM0pSisirldGyjDm3otgEg0fEXepJYs2WnbpiZr95d2mrapFPVnk4WANJGUXkV\nE1wAQJKgwEoCmytrdN20+cpq3UpPTx6tbh3ahB0JABBHhWXVymV4IAAkBQqsBLetaq8mTpuvnbvr\nNOP6U9WvK4tMAkA62bm7VmW79nD+FQAkCcaZJbBPK3frq1M/0qZt1Zo+6VQN7t057EgAgDgrKquW\nJOV25ws2AEgGFFgJqqisStc89ZEqa2o1c/JonTagW9iRAAAhKCxnBkEASCYUWAno4807dO3U+apv\naNCzN43RsL5dwo4EAAhJEWtgAUBSocBKMAs3bNf10+erXVZrPT/ldB1/dMewIwEAQlRYVqXenbOV\nnZkRdhQAQDNQYCWQv6wp1ZSnF6pHpzZ65oYxTGgBAFBhWRXDAwEgiTCLYIL407LNmjxjgY7t1k4v\n3nw6xRUAQFJkDSwKLABIHqEcwTKzIkk7JdVLqnP3vDByJIoX8zfprlcKNKJfF02fNFqd22WGHQkA\nkAC2V+1VRXUtiwwDQBIJc4jgWe5eFuL7J4Sn/rJe9/7hY312YHf99tpT1C6LUZsAgIh9MwiyyDAA\nJA/+mg+Ju+uXc1br0blrNXZITz105Qi1ac0JzACAf/nnDIIUWACQNMI6B8slvWNmC81syoEeYGZT\nzCzfzPJLS0vjHC+2Ghpc97y5Qo/OXasr8vrq0atGUlwBAP5DUVmVWpl0DOflAkDSCOsI1mfcvcTM\njpY0x8xWufsHjR/g7k9IekKS8vLyPIyQsVDf4PrOS0v16uIS3fTZXH3/wpNlZmHHAgAkoMLyavU5\nqq2yWjMnFQAki1A+sd29JLjcKuk1SaPDyBFvDQ2u771SoFcXl+iO806guAIANKmorEq53TuEHQMA\n0AJxL7DMrL2Zddx3XdL5kpbHO0e8ubt+9OYKvbywWLefO1C3njOQ4goAcFDursKyKuV2Y3ggACST\nMIYI9pD0WlBctJb0rLu/FUKOuHF33fenVXrm7xs05XMDdNs5A8OOBABIcGW79mrXnjomuACAJBP3\nAsvd10saHu/3DdMj767Vbz9Yr2tPO1Z3jz2JI1cAgEMqKmcGQQBIRpw1G2NPfrBeD/55tS4b1Vc/\nvmQwxRUAoFkKgynaB1BgAUBSocCKoWf+vkE//ePHumhoL91/2VC1akVxBQBonsKyKrVuZerTpW3Y\nUQAALUCBFSOvLCzWf7++XOecdLQe/MoItc7gnxoA0HxFZVU6pms7+g8ASDJ8asfAH5dt1ndeXqoz\nj++mx64ZxfolAIAWKyyr4vwrAEhC/OUfZXNXbdE3n1usUcccpSevy1N2ZkbYkQAAScbdtaG8Wv27\nUWABQLKhwIqiD9eW6ebfLdLJvTpp2vWnql1WGLPgAwCS3ZYde1RTW6/cHAosAEg2FFhRkl+0TTfO\nzFdut/Z6evJodcrODDsSACBJrS/bJUnK5QgWACQdCqwoWFZcqeunL1DPztl65sbROqp9VtiRAABJ\nrKisWpLUv3u7kJMAAFqKAusIrd6yU9dN+0id2mZq1o1jdHTH7LAjAQCSXFF5lbJat1LvzkzRDgDJ\nhgLrCGwsr9ZXn/pImRmt9OxNY9SbtUoAAFFQWFal/t3asX4iACQhCqzD9Gnlbl391N+1t75Bv7tx\njI5lnDwAIEoiBRb9CgAkIwqsw1C+a4+ueervqqiu1dOTR+uEHh3DjgQASBH1Da6N5dXKZQ0sAEhK\nFFgttGN3ra6bNl/F22s0dWKehvXtEnYkAEAK+UdFjfbWN7DIMAAkKQqsFqjeW6fJ0xdo9Zad+u21\np2jMgG5hRwIAHAEzm2ZmW81seaNtXc1sjpmtCS6PimemovIqSWKIIAAkKQqsZtpTV6+vPbNQizZu\n18NXjtQXTjw67EgAgCM3Q9IF+227S9K77j5Q0rvB7bgpLIsUWANYZBgAkhIFVjPU1Tfom88t1l/W\nlOm+y4bpwqG9wo4EAIgCd/9A0rb9No+TNDO4PlPS+HhmKiyrUrusDB3dsU083xYAECUUWIfQ0OD6\n7isFenvFFv3o4kG6Iq9f2JEAALHVw903B9c/ldQjnm9eVFalY7u1lxlTtANAMqLAaoK7657fr9Cr\ni0p0x3kn6Pozc8OOBACII3d3SX6g+8xsipnlm1l+aWlp1N6zqLxaud3bRe31AADxRYHVhAfe+URP\n/22DpnxugG45+/iw4wAA4mOLmfWSpOBy64Ee5O5PuHueu+fl5ORE5Y1r6xu0aRtTtANAMqPAOojf\nvLdOj81bp6tGH6O7x57EUA0ASB9vSpoYXJ8o6Y14vXHx9hrVNTgzCAJAEqPAOoBn/lak+99apXEj\neuve8UMorgAgRZnZc5L+JulEMys2sxsk3SfpPDNbI+nc4HZcFAUzCHIECwCSV+uwAySap/9WpB++\nsULnntxDD3x5uDJaUVwBQKpy96sOctc5cQ0S2DdFO4sMA0DyosBqZMaHhbrn9yt17sk99Ng1I5WZ\nwQE+AED8FJVXqWOb1urWPivsKACAw0SBFZj610L9ZPZKfXFwDz161Shltaa4AgDEV2FZlXJzmKId\nAJIZVYSkJz9Yr5/MXqmxQ3rqV1dTXAEAwlFYVsUEFwCQ5NK+knj8/XX66R8/1kVDe+mRqxgWCAAI\nx566ev2joobzrwAgyaX1EMHH5q3Vz9/+RBcP760Hrxiu1hRXAICQbNpWrQYXiwwDQJJL2wLr0XfX\n6BdzVmv8iN564MsUVwCAcBWWVUuScrt3CDkJAOBIpGWB9dCfV+uhP6/RpaP66OeXMxU7ACB8hWW7\nJEm5nIMFAEktrQosd9eDc1brkblrdfkpfXX/ZcMorgAACaGwrFpHtctU53aZYUcBAByBtCmw3F0P\nvPOJHpu3Tl/J66f/d+lQtaK4AgAkiKKyKia4AIAUkBYnHrm77n8rUlxdNfoYiisAQMIpKq9SLgUW\nACS9tCiwfvb2J3r8/XX66mnH6Kfjh1BcAQASSs3eem2u3M35VwCQAtJiiOCgXp006Yz++tHFg2RG\ncQUASCw1tfW6bFRfjTr2qLCjAACOUFoUWBcP762Lh/cOOwYAAAfUtX2WfnHF8LBjAACiIC2GCAIA\nAABAPFBgAQAAAECUhFJgmdkFZvaJma01s7vCyAAAAAAA0Rb3AsvMMiQ9JmmspEGSrjKzQfHOAQAA\nAADRFsYRrNGS1rr7enffK+l5SeNCyAEAAAAAURVGgdVH0qZGt4uDbf/GzKaYWb6Z5ZeWlsYtHAAA\nAAAcroSd5MLdn3D3PHfPy8nJCTsOAAAAABxSGAVWiaR+jW73DbYBAAAAQFILo8BaIGmgmeWaWZak\nKyW9GUIOAAAAAIiq1vF+Q3evM7NbJL0tKUPSNHdfEe8cAAAAABBtcS+wJMnd/yjpj2G8NwAAAADE\nSsJOcgEAAAAAyYYCCwAAAACihAILAAAAAKLE3D3sDIdkZqWSNhzBS3SXVBalOImOtqaudGovbU1N\nTbX1WHdP2kUP6adaLJ3aS1tTUzq1VUqv9h6src3up5KiwDpSZpbv7nlh54gH2pq60qm9tDU1pVNb\nWyrd/m3Sqb20NTWlU1ul9GpvNNrKEEEAAAAAiBIKLAAAAACIknQpsJ4IO0Ac0dbUlU7tpa2pKZ3a\n2lLp9m+TTu2lrakpndoqpVd7j7itaXEOFgAAAADEQ7ocwQIAAACAmKPAAgAAAIAoSekCy8wuMLNP\nzGytmd0Vdp5YMLMiM1tmZkvMLD/Y1tXM5pjZmuDyqLBzHg4zm2ZmW81seaNtB2ybRTwS7OsCMxsV\nXvKWO0hb7zGzkmDfLjGzCxvdd3fQ1k/M7IvhpD48ZtbPzOaZ2UozW2FmtwXbU27fNtHWVN232WY2\n38yWBu39cbA918w+Ctr1gpllBdvbBLfXBvf3DzN/WFK9r0rlfkqir0rhzzP6qhTct3Hrp9w9JX8k\nZUhaJ2mApCxJSyUNCjtXDNpZJKn7ftt+Jumu4Ppdku4PO+dhtu1zkkZJWn6otkm6UNKfJJmkC/4e\nlwAABp5JREFU0yR9FHb+KLT1Hkl3HuCxg4Lf5zaScoPf84yw29CCtvaSNCq43lHS6qBNKbdvm2hr\nqu5bk9QhuJ4p6aNgn70o6cpg++OSvh5c/y9JjwfXr5T0QthtCOHfLOX7qlTup4L89FWp+XlGX5WC\n+zZe/VQqH8EaLWmtu693972Snpc0LuRM8TJO0szg+kxJ40PMctjc/QNJ2/bbfLC2jZP0tEf8XVIX\nM+sVn6RH7iBtPZhxkp539z3uXihprSK/70nB3Te7+6Lg+k5JH0vqoxTct0209WCSfd+6u+8KbmYG\nPy7pbEkvB9v337f79vnLks4xM4tT3ESRrn1VSvRTEn1VE5L984y+6uCSdt/Gq59K5QKrj6RNjW4X\nq+lflmTlkt4xs4VmNiXY1sPdNwfXP5XUI5xoMXGwtqXq/r4lGGowrdEQmpRpa3CofaQi3yCl9L7d\nr61Siu5bM8swsyWStkqao8g3mxXuXhc8pHGb/tne4P5KSd3imzh0Sb/PmyHd+ikpxT/PDiAlP8/2\noa9KrX0bj34qlQusdPEZdx8laaykb5jZ5xrf6ZFjmik5F38qty3wG0nHSRohabOkX4QbJ7rMrIOk\nVyTd7u47Gt+Xavv2AG1N2X3r7vXuPkJSX0W+0Twp5EgIX9r2U1Lqt08p/Hkm0VcpBfdtPPqpVC6w\nSiT1a3S7b7Atpbh7SXC5VdJrivyibNl3WDq43Bpewqg7WNtSbn+7+5bgQ6BB0pP61+H3pG+rmWUq\n8iE+y91fDTan5L49UFtTed/u4+4VkuZJOl2RoTKtg7sat+mf7Q3u7yypPM5Rw5Yy+/xg0rCfklL0\n8+xAUvnzjL4qdfetFNt+KpULrAWSBgazgmQpcmLamyFniioza29mHfddl3S+pOWKtHNi8LCJkt4I\nJ2FMHKxtb0q6LpjF5zRJlY0O4Sel/cZuT1Bk30qRtl4ZzGyTK2mgpPnxzne4grHLUyV97O6/bHRX\nyu3bg7U1hfdtjpl1Ca63lXSeImP550m6PHjY/vt23z6/XNLc4BvhdJLSfVWa9lNSCn6eHUwKf57R\nV6Xgvo1bP7X/rBep9KPIjC6rFRlb+YOw88SgfQMUmcVlqaQV+9qoyNjQdyWtkfRnSV3DznqY7XtO\nkUPStYqMh73hYG1TZFaYx4J9vUxSXtj5o9DWZ4K2FAT/wXs1evwPgrZ+Imls2Plb2NbPKDKkokDS\nkuDnwlTct020NVX37TBJi4N2LZf0w2D7AEU637WSXpLUJtieHdxeG9w/IOw2hPTvlrJ9Var3U0Fb\n6KtS8/OMvioF9228+ikLngwAAAAAOEKpPEQQAAAAAOKKAgsAAAAAooQCCwAAAACihAILAAAAAKKE\nAgsAAAAAooQCC0hQZjbJzHqHnQMAgIOhrwL+EwUWkLgmSTpgp2VmGfGNAgDAAU0SfRXwbyiwgBYw\ns/5m9rGZPWlmK8zsHTNra2bvmVle8JjuZlYUXJ9kZq+b2RwzKzKzW8zs22a22Mz+bmZdD/I+l0vK\nkzTLzJYE71FkZveb2SJJXzaz48zsLTNbaGZ/MbOTgufmmNkrZrYg+Dkz2P754LWWBO/fMR7/ZgCA\n+KKvAsJFgQW03EBJj7n7YEkVki47xOOHSLpU0qmSfiqp2t1HSvqbpOsO9AR3f1lSvqRr3H2Eu9cE\nd5W7+yh3f17SE5JudfdTJN0p6dfBYx6W9KC7nxpkeyrYfqekb7j7CEmflbTvNQEAqYe+CghJ67AD\nAEmo0N2XBNcXSup/iMfPc/edknaaWaWk3wfbl0ka1sL3fkGSzKyDpDMkvWRm++5rE1yeK2lQo+2d\ngsd/KOmXZjZL0qvuXtzC9wYAJA/6KiAkFFhAy+1pdL1eUltJdfrXEeHsJh7f0Oh2g1r+f7AquGwl\nqSL4hm9/rSSd5u6799t+n5n9QdKFkj40sy+6+6oWvj8AIDnQVwEhYYggEB1Fkk4Jrl8epdfcKemA\nY8/dfYekQjP7siRZxPDg7nck3brvsWY2Irg8zt2Xufv9khZIOilKOQEAyaFI9FVAzFFgAdHxgKSv\nm9liSd2j9JozJD2+78ThA9x/jaQbzGyppBWSxgXbvykpz8wKzGylpJuD7beb2XIzK5BUK+lPUcoJ\nAEgO9FVAHJi7h50BAAAAAFICR7AAAAAAIEqY5AIImZk9JunM/TY/7O7Tw8gDAMD+6KuA5mOIIAAA\nAABECUMEAQAAACBKKLAAAAAAIEoosAAAAAAgSiiwAAAAACBKKLAAAAAAIEr+PynyxZtf4OScAAAA\nAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11e53e470>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(1, figsize=(12, 6))\n",
+    "plt.subplot(121)\n",
+    "plt.plot(x_values, y_values_init)\n",
+    "plt.title(\"num_trees vs initalization time\")\n",
+    "plt.ylabel(\"Initialization time (s)\")\n",
+    "plt.xlabel(\"num_trees\")\n",
+    "plt.subplot(122)\n",
+    "plt.plot(x_values, y_values_accuracy)\n",
     "plt.title(\"num_trees vs accuracy\")\n",
     "plt.ylabel(\"% accuracy\")\n",
     "plt.xlabel(\"num_trees\")\n",
+    "plt.tight_layout()\n",
     "plt.show()"
    ]
   },
@@ -614,30 +697,47 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This was again done with the lee corpus, a relatively small corpus. Results will vary from corpus to corpus"
+    "##### Initialization:\n",
+    "Initialization time of the annoy indexer increases in a linear fashion with num_trees. Initialization time will vary from corpus to corpus, in the graph above the lee corpus was used\n",
+    "\n",
+    "##### Accuracy:\n",
+    "In this dataset, the accuracy seems logarithmically related to the number of trees. We see an improvement in accuracy with more trees, but the relationship is nonlinear. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Recap\n",
+    "In this notebook we used the Annoy module to build an indexed approximation of our word embeddings. To do so, we did the following steps:\n",
+    "1. Download Text8 Corpus\n",
+    "2. Build Word2Vec Model\n",
+    "3. Construct AnnoyIndex with model & make a similarity query\n",
+    "4. Verify & Evaluate performance\n",
+    "5. Evaluate relationship of `num_trees` to initialization time and accuracy"
    ]
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Updates:
- Runs in python 3
- Added required packages (in addition to gensim) to top of notebook
- Cleaned up some descriptive language throughout the notebook.
- Used Text8 Corpus rather than Lee corpus, since I wasn't seeing an improvement using the Lee corpus. My hypothesis is that it's too small to see any benefit from approximating. 
- Added watermark info for benchmarking comparisons
- Reorganized and restructured notebook
  - Added an outline according to the logic of the notebook
  - separated notebook cells for import, function definition, and executing code
  - Added optional logging
  - Combined num_trees performance analysis into one loop & plots into one figure and upped num_trees to 300

@tmylk 