### PR TITLE
fixing a single phrase not returning back multiple bigrams, #794

### DIFF
--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -250,7 +250,7 @@ class Phrases(interfaces.TransformationABC):
                                 yield (out_delimiter.join((word_a, word_b)), score)
                             last_bigram = True
                             continue
-                        last_bigram = False
+                    last_bigram = False
 
     def __getitem__(self, sentence):
         """

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -127,20 +127,32 @@ class TestPhrasesModel(unittest.TestCase):
         """Test Phrases bigram export_phrases functionality."""
         bigram = Phrases(sentences, min_count=1, threshold=1)
 
-        # with this setting we should get response_time and graph_minors
-        bigram1_seen = False
-        bigram2_seen = False
+        seen_bigrams = set()
 
         for phrase, score in bigram.export_phrases(sentences):
-            if not bigram1_seen and b'response time' == phrase:
-                bigram1_seen = True
-            elif not bigram2_seen and b'graph minors' == phrase:
-                bigram2_seen = True
-            if bigram1_seen and bigram2_seen:
-                break
+            print(phrase)
+            seen_bigrams.add(phrase)
 
-        self.assertTrue(bigram1_seen)
-        self.assertTrue(bigram2_seen)
+        assert seen_bigrams == set([
+            b'response time',
+            b'graph minors',
+            b'human interface'
+        ])
+
+    def test_multiple_bigrams_single_entry(self):
+        """ a single entry should produce multiple bigrams. """
+        bigram = Phrases(sentences, min_count=1, threshold=1)
+
+        seen_bigrams = set()
+
+        test_sentences = [['graph', 'minors', 'survey', 'human', 'interface']]
+        for phrase, score in bigram.export_phrases(test_sentences):
+            seen_bigrams.add(phrase)
+
+        assert seen_bigrams == set([
+            b'graph minors',
+            b'human interface'
+        ])
 
     def testBadParameters(self):
         """Test the phrases module with bad parameters."""

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -130,7 +130,6 @@ class TestPhrasesModel(unittest.TestCase):
         seen_bigrams = set()
 
         for phrase, score in bigram.export_phrases(sentences):
-            print(phrase)
             seen_bigrams.add(phrase)
 
         assert seen_bigrams == set([


### PR DESCRIPTION
Here's another try at fixing #794. The previous PR #879 added a unit test, but didn't catch the issue because the bigram "human interface" was already included from the very first entry. Added a more targetted unit test to catch this. 