### PR TITLE
Fix doc2vec __init__ documentation

### DIFF
--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -565,7 +565,7 @@ class Doc2Vec(Word2Vec):
         `window` is the maximum distance between the predicted word and context words used for prediction
         within a document.
 
-        `alpha` is the initial learning rate (will linearly drop to zero as training progresses).
+        `alpha` is the initial learning rate (will linearly drop to `min_alpha` as training progresses).
 
         `seed` = for the random number generator.
         Note that for a fully deterministically-reproducible run, you must also limit the model to
@@ -587,10 +587,12 @@ class Doc2Vec(Word2Vec):
         `iter` = number of iterations (epochs) over the corpus. The default inherited from Word2Vec is 5,
         but values of 10 or 20 are common in published 'Paragraph Vector' experiments.
 
-        `hs` = if 1 (default), hierarchical sampling will be used for model training (else set to 0).
+        `hs` = if 1, hierarchical softmax will be used for model training.
+        If set to 0 (default), and `negative` is non-zero, negative sampling will be used.
 
         `negative` = if > 0, negative sampling will be used, the int for negative
         specifies how many "noise words" should be drawn (usually between 5-20).
+        Default is 5. If set to 0, no negative samping is used.
 
         `dm_mean` = if 0 (default), use the sum of the context word vectors. If 1, use the mean.
         Only applies when dm is used in non-concatenative mode.


### PR DESCRIPTION
Fixed descriptions of various arguments passed from `Doc2Vec.__init__` method up to the parent `Word2Vec.__init__` method.

- `alpha`: says will drop to 0 as training progressed, but should say `min_alpha`.
- `hs`: is said to be 1 by default, but is 0 by default (and also mentions "hierarchical sampling", rather than "hierarchical softmax").
- `negative`: doesn't mention that the default is 5.