### PR TITLE
Added sklearn interface for 'BaseTopicModel'

### DIFF
--- a/gensim/sklearn_integration/base_sklearn_wrapper.py
+++ b/gensim/sklearn_integration/base_sklearn_wrapper.py
@@ -17,6 +17,11 @@ class BaseSklearnWrapper(object):
     """
     __metaclass__ = ABCMeta
 
+
+    @abstractmethod
+    def get_params(self, deep=True):
+        pass
+
     @abstractmethod
     def set_params(self, **parameters):
         """
@@ -25,3 +30,15 @@ class BaseSklearnWrapper(object):
         for parameter, value in parameters.items():
             setattr(self, parameter, value)
         return self
+
+    @abstractmethod
+    def fit(self, X,  y=None):
+        pass
+
+    @abstractmethod
+    def transform(self, docs, minimum_probability=None):
+        pass
+
+    @abstractmethod
+    def partial_fit(self, X):
+        pass

--- a/gensim/sklearn_integration/base_sklearn_wrapper.py
+++ b/gensim/sklearn_integration/base_sklearn_wrapper.py
@@ -8,13 +8,16 @@
 Scikit learn interface for gensim for easy use of gensim with scikit-learn
 follows on scikit learn API conventions
 """
+from abc import ABCMeta, abstractmethod
 
 
-class SklearnWrapperBaseTopicModel(object):
+class BaseSklearnWrapper(object):
     """
-    BaseTopicModel module
+    Base sklearn wrapper module
     """
+    __metaclass__ = ABCMeta
 
+    @abstractmethod
     def set_params(self, **parameters):
         """
         Set all parameters.

--- a/gensim/sklearn_integration/base_sklearn_wrapper.py
+++ b/gensim/sklearn_integration/base_sklearn_wrapper.py
@@ -17,7 +17,6 @@ class BaseSklearnWrapper(object):
     """
     __metaclass__ = ABCMeta
 
-
     @abstractmethod
     def get_params(self, deep=True):
         pass
@@ -32,7 +31,7 @@ class BaseSklearnWrapper(object):
         return self
 
     @abstractmethod
-    def fit(self, X,  y=None):
+    def fit(self, X, y=None):
         pass
 
     @abstractmethod

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_basetopicmodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_basetopicmodel.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2011 Radim Rehurek <radimrehurek@seznam.cz>
+# Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
+#
+"""
+Scikit learn interface for gensim for easy use of gensim with scikit-learn
+follows on scikit learn API conventions
+"""
+
+
+class SklearnWrapperBaseTopicModel(object):
+    """
+    BaseTopicModel module
+    """
+
+    def set_params(self, **parameters):
+        """
+        Set all parameters.
+        """
+        for parameter, value in parameters.items():
+            setattr(self, parameter, value)
+        return self

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_ldamodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_ldamodel.py
@@ -9,14 +9,14 @@ Scikit learn interface for gensim for easy use of gensim with scikit-learn
 follows on scikit learn API conventions
 """
 import numpy as np
+import sklearn_wrapper_gensim_basetopicmodel
 
 from gensim import models
 from gensim import matutils
 from scipy import sparse
 from sklearn.base import TransformerMixin, BaseEstimator
 
-
-class SklearnWrapperLdaModel(models.LdaModel, TransformerMixin, BaseEstimator):
+class SklearnWrapperLdaModel(models.LdaModel, sklearn_wrapper_gensim_basetopicmodel.SklearnWrapperBaseTopicModel, TransformerMixin, BaseEstimator):
     """
     Base LDA module
     """
@@ -65,14 +65,6 @@ class SklearnWrapperLdaModel(models.LdaModel, TransformerMixin, BaseEstimator):
                 "offset": self.offset, "eval_every": self.eval_every, "iterations": self.iterations,
                 "gamma_threshold": self.gamma_threshold, "minimum_probability": self.minimum_probability,
                 "random_state": self.random_state}
-
-    def set_params(self, **parameters):
-        """
-        Set all parameters.
-        """
-        for parameter, value in parameters.items():
-            self.parameter = value
-        return self
 
     def fit(self, X,  y=None):
         """

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_ldamodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_ldamodel.py
@@ -12,16 +12,15 @@ import numpy as np
 
 from gensim import models
 from gensim import matutils
-from gensim.sklearn_integration import sklearn_wrapper_gensim_basetopicmodel
+from gensim.sklearn_integration import base_sklearn_wrapper
 from scipy import sparse
 from sklearn.base import TransformerMixin, BaseEstimator
 
 
-class SklearnWrapperLdaModel(models.LdaModel, sklearn_wrapper_gensim_basetopicmodel.SklearnWrapperBaseTopicModel, TransformerMixin, BaseEstimator):
+class SklearnWrapperLdaModel(models.LdaModel, base_sklearn_wrapper.BaseSklearnWrapper, TransformerMixin, BaseEstimator):
     """
     Base LDA module
     """
-
 
     def __init__(
             self, corpus=None, num_topics=100, id2word=None,
@@ -67,6 +66,12 @@ class SklearnWrapperLdaModel(models.LdaModel, sklearn_wrapper_gensim_basetopicmo
                 "offset": self.offset, "eval_every": self.eval_every, "iterations": self.iterations,
                 "gamma_threshold": self.gamma_threshold, "minimum_probability": self.minimum_probability,
                 "random_state": self.random_state}
+
+    def set_params(self, **parameters):
+        """
+        Set all parameters.
+        """
+        super(SklearnWrapperLdaModel, self).set_params(**parameters)
 
     def fit(self, X,  y=None):
         """

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_ldamodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_ldamodel.py
@@ -16,6 +16,7 @@ from gensim import matutils
 from scipy import sparse
 from sklearn.base import TransformerMixin, BaseEstimator
 
+
 class SklearnWrapperLdaModel(models.LdaModel, sklearn_wrapper_gensim_basetopicmodel.SklearnWrapperBaseTopicModel, TransformerMixin, BaseEstimator):
     """
     Base LDA module

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_ldamodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_ldamodel.py
@@ -73,7 +73,7 @@ class SklearnWrapperLdaModel(models.LdaModel, base_sklearn_wrapper.BaseSklearnWr
         """
         super(SklearnWrapperLdaModel, self).set_params(**parameters)
 
-    def fit(self, X,  y=None):
+    def fit(self, X, y=None):
         """
         For fitting corpus into the class object.
         Calls gensim.model.LdaModel:

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_ldamodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_ldamodel.py
@@ -9,10 +9,10 @@ Scikit learn interface for gensim for easy use of gensim with scikit-learn
 follows on scikit learn API conventions
 """
 import numpy as np
-import sklearn_wrapper_gensim_basetopicmodel
 
 from gensim import models
 from gensim import matutils
+from gensim.sklearn_integration import sklearn_wrapper_gensim_basetopicmodel
 from scipy import sparse
 from sklearn.base import TransformerMixin, BaseEstimator
 

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_ldamodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_ldamodel.py
@@ -21,6 +21,7 @@ class SklearnWrapperLdaModel(models.LdaModel, sklearn_wrapper_gensim_basetopicmo
     Base LDA module
     """
 
+
     def __init__(
             self, corpus=None, num_topics=100, id2word=None,
             chunksize=2000, passes=1, update_every=1,

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_lsimodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_lsimodel.py
@@ -9,10 +9,10 @@ Scikit learn interface for gensim for easy use of gensim with scikit-learn
 Follows scikit-learn API conventions
 """
 import numpy as np
-import sklearn_wrapper_gensim_basetopicmodel
 
 from gensim import models
 from gensim import matutils
+from gensim.sklearn_integration import sklearn_wrapper_gensim_basetopicmodel
 from scipy import sparse
 from sklearn.base import TransformerMixin, BaseEstimator
 

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_lsimodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_lsimodel.py
@@ -55,7 +55,7 @@ class SklearnWrapperLsiModel(models.LsiModel, base_sklearn_wrapper.BaseSklearnWr
         """
         super(SklearnWrapperLsiModel, self).set_params(**parameters)
 
-    def fit(self, X,  y=None):
+    def fit(self, X, y=None):
         """
         For fitting corpus into the class object.
         Calls gensim.model.LsiModel:

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_lsimodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_lsimodel.py
@@ -21,6 +21,7 @@ class SklearnWrapperLsiModel(models.LsiModel, sklearn_wrapper_gensim_basetopicmo
     Base LSI module
     """
 
+
     def __init__(self, corpus=None, num_topics=200, id2word=None, chunksize=20000,
                  decay=1.0, onepass=True, power_iters=2, extra_samples=100):
         """

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_lsimodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_lsimodel.py
@@ -16,6 +16,7 @@ from gensim import matutils
 from scipy import sparse
 from sklearn.base import TransformerMixin, BaseEstimator
 
+
 class SklearnWrapperLsiModel(models.LsiModel, sklearn_wrapper_gensim_basetopicmodel.SklearnWrapperBaseTopicModel, TransformerMixin, BaseEstimator):
     """
     Base LSI module

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_lsimodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_lsimodel.py
@@ -9,13 +9,14 @@ Scikit learn interface for gensim for easy use of gensim with scikit-learn
 Follows scikit-learn API conventions
 """
 import numpy as np
+import sklearn_wrapper_gensim_basetopicmodel
 
 from gensim import models
 from gensim import matutils
 from scipy import sparse
 from sklearn.base import TransformerMixin, BaseEstimator
 
-class SklearnWrapperLsiModel(models.LsiModel, TransformerMixin, BaseEstimator):
+class SklearnWrapperLsiModel(models.LsiModel, sklearn_wrapper_gensim_basetopicmodel.SklearnWrapperBaseTopicModel, TransformerMixin, BaseEstimator):
     """
     Base LSI module
     """
@@ -46,14 +47,6 @@ class SklearnWrapperLsiModel(models.LsiModel, TransformerMixin, BaseEstimator):
         return {"corpus": self.corpus, "num_topics": self.num_topics, "id2word": self.id2word,
                 "chunksize": self.chunksize, "decay": self.decay, "onepass": self.onepass,
                 "extra_samples": self.extra_samples, "power_iters": self.power_iters}
-
-    def set_params(self, **parameters):
-        """
-        Set all parameters.
-        """
-        for parameter, value in parameters.items():
-            self.parameter = value
-        return self
 
     def fit(self, X,  y=None):
         """

--- a/gensim/sklearn_integration/sklearn_wrapper_gensim_lsimodel.py
+++ b/gensim/sklearn_integration/sklearn_wrapper_gensim_lsimodel.py
@@ -12,16 +12,15 @@ import numpy as np
 
 from gensim import models
 from gensim import matutils
-from gensim.sklearn_integration import sklearn_wrapper_gensim_basetopicmodel
+from gensim.sklearn_integration import base_sklearn_wrapper
 from scipy import sparse
 from sklearn.base import TransformerMixin, BaseEstimator
 
 
-class SklearnWrapperLsiModel(models.LsiModel, sklearn_wrapper_gensim_basetopicmodel.SklearnWrapperBaseTopicModel, TransformerMixin, BaseEstimator):
+class SklearnWrapperLsiModel(models.LsiModel, base_sklearn_wrapper.BaseSklearnWrapper, TransformerMixin, BaseEstimator):
     """
     Base LSI module
     """
-
 
     def __init__(self, corpus=None, num_topics=200, id2word=None, chunksize=20000,
                  decay=1.0, onepass=True, power_iters=2, extra_samples=100):
@@ -49,6 +48,12 @@ class SklearnWrapperLsiModel(models.LsiModel, sklearn_wrapper_gensim_basetopicmo
         return {"corpus": self.corpus, "num_topics": self.num_topics, "id2word": self.id2word,
                 "chunksize": self.chunksize, "decay": self.decay, "onepass": self.onepass,
                 "extra_samples": self.extra_samples, "power_iters": self.power_iters}
+
+    def set_params(self, **parameters):
+        """
+        Set all parameters.
+        """
+        super(SklearnWrapperLsiModel, self).set_params(**parameters)
 
     def fit(self, X,  y=None):
         """

--- a/gensim/test/test_sklearn_integration.py
+++ b/gensim/test/test_sklearn_integration.py
@@ -121,7 +121,7 @@ class TestSklearnLDAWrapper(unittest.TestCase):
         self.assertEqual(model_params["num_topics"], 3)
 
         # updating multiple params
-        param_dict = {"eval_every" : 20 , "decay" : 0.7}
+        param_dict = {"eval_every": 20, "decay": 0.7}
         self.model.set_params(**param_dict)
         model_params = self.model.get_params()
         for key in param_dict.keys():
@@ -185,7 +185,7 @@ class TestSklearnLSIWrapper(unittest.TestCase):
         self.assertEqual(model_params["num_topics"], 3)
 
         # updating multiple params
-        param_dict = {"chunksize" : 10000 , "decay" : 0.9}
+        param_dict = {"chunksize": 10000, "decay": 0.9}
         self.model.set_params(**param_dict)
         model_params = self.model.get_params()
         for key in param_dict.keys():

--- a/gensim/test/test_sklearn_integration.py
+++ b/gensim/test/test_sklearn_integration.py
@@ -114,6 +114,19 @@ class TestSklearnLDAWrapper(unittest.TestCase):
         score = text_lda.score(corpus, data.target)
         self.assertGreater(score, 0.40)
 
+    def testSetGetParams(self):
+        # updating only one param
+        self.model.set_params(num_topics=3)
+        model_params = self.model.get_params()
+        self.assertEqual(model_params["num_topics"], 3)
+
+        # updating multiple params
+        param_dict = {"eval_every" : 20 , "decay" : 0.7}
+        self.model.set_params(**param_dict)
+        model_params = self.model.get_params()
+        for key in param_dict.keys():
+            self.assertEqual(model_params[key], param_dict[key])
+
 
 class TestSklearnLSIWrapper(unittest.TestCase):
     def setUp(self):
@@ -164,6 +177,20 @@ class TestSklearnLSIWrapper(unittest.TestCase):
         text_lda.fit(corpus, data.target)
         score = text_lda.score(corpus, data.target)
         self.assertGreater(score, 0.50)
+
+    def testSetGetParams(self):
+        # updating only one param
+        self.model.set_params(num_topics=3)
+        model_params = self.model.get_params()
+        self.assertEqual(model_params["num_topics"], 3)
+
+        # updating multiple params
+        param_dict = {"chunksize" : 10000 , "decay" : 0.9}
+        self.model.set_params(**param_dict)
+        model_params = self.model.get_params()
+        for key in param_dict.keys():
+            self.assertEqual(model_params[key], param_dict[key])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR does the following things: 
- Adds sklearn interface for `BaseTopicModel` class
- Refactors the code for the sklearn wrappers for LDA and LSI Models by using the sklearn interface for `BaseTopicModel` to avoid code duplication (due to the function `set_params`)