### PR TITLE
Update logic to set 'updatetype' variable in LdaModel.py

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -595,7 +595,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         if update_every:
             updatetype = "online"
-            if passes ==1:
+            if passes == 1:
                 updatetype += " (single-pass)"
             else:
                 updatetype += " (multi-pass)"

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -595,6 +595,10 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         if update_every:
             updatetype = "online"
+            if passes ==1:
+                updatetype += " (single-pass)"
+            else:
+                updatetype += " (multi-pass)"
             updateafter = min(lencorpus, update_every * self.numworkers * chunksize)
         else:
             updatetype = "batch"


### PR DESCRIPTION
This PR updates the logic to set `updatetype` variable used in `ldamodel.py`. Now, we have 3 modes for training the model : `online (single-pass)`, `online (multi-pass)` and `batch`.