### PR TITLE
Warn the user if the corpus for LDA/LSI is plain list

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -579,6 +579,15 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         if gamma_threshold is None:
             gamma_threshold = self.gamma_threshold
 
+        if isinstance(corpus, list):
+            logger.warning(
+                "taking plain list as a corpus for LDA;"
+                "we strongly recommend you to use corpus streaming instead of lists;"
+                "LDA is processing the corpus in batches and"
+                "it only loads one batch of documents into memory at once;"
+                "please take a look at the tutorial on corpus streaming: "
+                "https://radimrehurek.com/gensim/tut1.html#corpus-streaming-one-document-at-a-time")
+
         try:
             lencorpus = len(corpus)
         except:

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -581,10 +581,10 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         if isinstance(corpus, list):
             logger.warning(
-                "Taking plain list as a corpus for LDA."
+                "Taking plain list as a corpus for LDA. "
                 "We strongly recommend you to use corpus streaming instead of lists. "
                 "LDA is processing the corpus in batches and "
-                "it only loads one batch of documents into memory at once."
+                "it only loads one batch of documents into memory at once. "
                 "Please take a look at the tutorial on corpus streaming: "
                 "https://radimrehurek.com/gensim/tut1.html#corpus-streaming-one-document-at-a-time")
 

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -581,11 +581,11 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         if isinstance(corpus, list):
             logger.warning(
-                "taking plain list as a corpus for LDA;"
-                "we strongly recommend you to use corpus streaming instead of lists;"
-                "LDA is processing the corpus in batches and"
-                "it only loads one batch of documents into memory at once;"
-                "please take a look at the tutorial on corpus streaming: "
+                "Taking plain list as a corpus for LDA.\n"
+                "We strongly recommend you to use corpus streaming instead of lists. "
+                "LDA is processing the corpus in batches and "
+                "it only loads one batch of documents into memory at once.\n"
+                "Please take a look at the tutorial on corpus streaming: "
                 "https://radimrehurek.com/gensim/tut1.html#corpus-streaming-one-document-at-a-time")
 
         try:

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -581,10 +581,10 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         if isinstance(corpus, list):
             logger.warning(
-                "Taking plain list as a corpus for LDA.\n"
+                "Taking plain list as a corpus for LDA."
                 "We strongly recommend you to use corpus streaming instead of lists. "
                 "LDA is processing the corpus in batches and "
-                "it only loads one batch of documents into memory at once.\n"
+                "it only loads one batch of documents into memory at once."
                 "Please take a look at the tutorial on corpus streaming: "
                 "https://radimrehurek.com/gensim/tut1.html#corpus-streaming-one-document-at-a-time")
 

--- a/gensim/models/lsimodel.py
+++ b/gensim/models/lsimodel.py
@@ -350,10 +350,10 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         if isinstance(corpus, list):
             logger.warning(
-                "Taking plain list as a corpus for LSI.\n"
+                "Taking plain list as a corpus for LSI."
                 "We strongly recommend you to use corpus streaming instead of lists. "
                 "LSI is processing the corpus in batches and "
-                "it only loads one batch of documents into memory at once.\n"
+                "it only loads one batch of documents into memory at once."
                 "Please take a look at the tutorial on corpus streaming: "
                 "https://radimrehurek.com/gensim/tut1.html#corpus-streaming-one-document-at-a-time")
 

--- a/gensim/models/lsimodel.py
+++ b/gensim/models/lsimodel.py
@@ -350,10 +350,10 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         if isinstance(corpus, list):
             logger.warning(
-                "Taking plain list as a corpus for LSI."
+                "Taking plain list as a corpus for LSI. "
                 "We strongly recommend you to use corpus streaming instead of lists. "
                 "LSI is processing the corpus in batches and "
-                "it only loads one batch of documents into memory at once."
+                "it only loads one batch of documents into memory at once. "
                 "Please take a look at the tutorial on corpus streaming: "
                 "https://radimrehurek.com/gensim/tut1.html#corpus-streaming-one-document-at-a-time")
 

--- a/gensim/models/lsimodel.py
+++ b/gensim/models/lsimodel.py
@@ -350,11 +350,11 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         if isinstance(corpus, list):
             logger.warning(
-                "taking plain list as a corpus for LSI;"
-                "we strongly recommend you to use corpus streaming instead of lists;"
-                "LSI is processing the corpus in batches and"
-                "it only loads one batch of documents into memory at once"
-                "please take a look at the tutorial on corpus streaming: "
+                "Taking plain list as a corpus for LSI.\n"
+                "We strongly recommend you to use corpus streaming instead of lists. "
+                "LSI is processing the corpus in batches and "
+                "it only loads one batch of documents into memory at once.\n"
+                "Please take a look at the tutorial on corpus streaming: "
                 "https://radimrehurek.com/gensim/tut1.html#corpus-streaming-one-document-at-a-time")
 
         # get computation parameters; if not specified, use the ones from constructor

--- a/gensim/models/lsimodel.py
+++ b/gensim/models/lsimodel.py
@@ -348,6 +348,15 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         """
         logger.info("updating model with new documents")
 
+        if isinstance(corpus, list):
+            logger.warning(
+                "taking plain list as a corpus for LSI;"
+                "we strongly recommend you to use corpus streaming instead of lists;"
+                "LSI is processing the corpus in batches and"
+                "it only loads one batch of documents into memory at once"
+                "please take a look at the tutorial on corpus streaming: "
+                "https://radimrehurek.com/gensim/tut1.html#corpus-streaming-one-document-at-a-time")
+
         # get computation parameters; if not specified, use the ones from constructor
         if chunksize is None:
             chunksize = self.chunksize


### PR DESCRIPTION
Encourage the user to use the memory-friendly generator interface
presented in the tutorial on corpus streaming. See the issue #74 .

I have decided to move the warning ldamodel.update and lsimodel.add_documents since both of the methods are called by constructors.