### PR TITLE
Fix wordrank tests

### DIFF
--- a/gensim/test/test_wordrank_wrapper.py
+++ b/gensim/test/test_wordrank_wrapper.py
@@ -34,7 +34,7 @@ class TestWordrank(unittest.TestCase):
         self.wr_file = datapath('test_glove.txt')
         if not self.wr_path:
             return
-        self.test_model = wordrank.Wordrank.train(self.wr_path, self.corpus_file, self.out_name, iter=6, dump_period=5, period=5)
+        self.test_model = wordrank.Wordrank.train(self.wr_path, self.corpus_file, self.out_name, iter=6, dump_period=5, period=5, cleanup_files=True)
 
     def testLoadWordrankFormat(self):
         """Test model successfully loaded from Wordrank format file"""


### PR DESCRIPTION
PR https://github.com/RaRe-Technologies/gensim/pull/1378 changed default `cleanup_files` to False. It results in wordrank test failures, as `output_dir` already exists when training is done again. 

This sets `cleanup_files` to True for training in wordrank tests.