### PR TITLE
Add napolean sphinx extension to allow parsing docstrings in various formats

### DIFF
--- a/docs/src/Makefile
+++ b/docs/src/Makefile
@@ -1,5 +1,8 @@
 # Makefile for Sphinx documentation
 #
+# In order to compile this documentation you need to have sphinx
+# and sphinxcontrib-napoleon. You can install them using:
+# pip3 install sphinx sphinxcontrib-napoleon
 
 # You can set these variables from the command line.
 SPHINXOPTS    =

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -24,7 +24,7 @@ html_theme = 'gensim_theme'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc']
+extensions = ['sphinx.ext.autodoc', 'sphinxcontrib.napoleon']
 autoclass_content = "both"
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
See the discussion on mailinglist:
<https://groups.google.com/forum/#!topic/gensim/M0N4mBgi9TY>

I also updated wiki:
<https://github.com/RaRe-Technologies/gensim/wiki/Developer-page#documentation>

If you want to see what has changed then take a look at the documentation of `gensim.models.atmodel.AuthorTopicModel.update` . The docstring is written in a Google style but not really properly that's the reason why it looks a bit weird. Gensim is full of docstrings in various custom made docstring formats.