### PR TITLE
Create local random generator for sample_text & add lenght

### DIFF
--- a/gensim/corpora/textcorpus.py
+++ b/gensim/corpora/textcorpus.py
@@ -100,24 +100,25 @@ class TextCorpus(interfaces.CorpusABC):
 
     def sample_texts(self, n, seed=None, length=None):
         """
-        Yields n random documents from the corpus without replacement.
+        Yield n random documents from the corpus without replacement.
 
-        Given the number of remaining documents in corpus, we need to choose n elements.
-        The probability for current element to be chosen is n/remaining.
+        Given the number of remaining documents in a corpus, we need to choose n elements.
+        The probability for the current element to be chosen is n/remaining.
         If we choose it, we just decreese the n and move to the next element.
-        Computing corpus length may be a costly operation so you can use optional paramter
-        length instead.
+        Computing the corpus length may be a costly operation so you can use the optional
+        parameter `length` instead.
 
         Args:
             n (int): number of documents we want to sample.
             seed (int|None): if specified, use it as a seed for local random generator.
-            length (int|None): if specified, use it as guess of corpus length.
+            length (int|None): if specified, use it as a guess of corpus length.
+                It must be positive and not greater than actual corpus length.
 
         Yeilds:
-            list[str]: document represented as list of tokens. See get_texts method.
+            list[str]: document represented as a list of tokens. See get_texts method.
 
         Raises:
-            ValueError: then n is invalid or length was set incorrectly.
+            ValueError: when n is invalid or length was set incorrectly.
         """
         random_generator = None
         if seed is None:

--- a/gensim/corpora/textcorpus.py
+++ b/gensim/corpora/textcorpus.py
@@ -144,8 +144,9 @@ class TextCorpus(interfaces.CorpusABC):
                 yield sample
 
         if n != 0:
-            # This means that length was set to be smaller than number of items in stream.
-            raise ValueError("length smaller than number of documents in stream")
+            # This means that length was set to be greater than number of items in corpus
+            # and we were not able to sample enough documents before the stream ended.
+            raise ValueError("length greater than number of documents in corpus")
 
     def __len__(self):
         if not hasattr(self, 'length'):

--- a/gensim/corpora/textcorpus.py
+++ b/gensim/corpora/textcorpus.py
@@ -104,7 +104,7 @@ class TextCorpus(interfaces.CorpusABC):
 
         Given the number of remaining documents in a corpus, we need to choose n elements.
         The probability for the current element to be chosen is n/remaining.
-        If we choose it, we just decreese the n and move to the next element.
+        If we choose it, we just decrease the n and move to the next element.
         Computing the corpus length may be a costly operation so you can use the optional
         parameter `length` instead.
 
@@ -114,7 +114,7 @@ class TextCorpus(interfaces.CorpusABC):
             length (int|None): if specified, use it as a guess of corpus length.
                 It must be positive and not greater than actual corpus length.
 
-        Yeilds:
+        Yields:
             list[str]: document represented as a list of tokens. See get_texts method.
 
         Raises:
@@ -144,7 +144,7 @@ class TextCorpus(interfaces.CorpusABC):
                 yield sample
 
         if n != 0:
-            # This means that length was set to be smaller than nuber of items in stream.
+            # This means that length was set to be smaller than number of items in stream.
             raise ValueError("length smaller than number of documents in stream")
 
     def __len__(self):

--- a/gensim/test/test_textcorpus.py
+++ b/gensim/test/test_textcorpus.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 class TestTextCorpus(unittest.TestCase):
     # TODO add tests for other methods
 
-    class DumyTextCorpus(TextCorpus):
+    class DummyTextCorpus(TextCorpus):
         def __init__(self):
             self.size = 10
             self.data = [["document%s" % i] for i in range(self.size)]
@@ -31,7 +31,7 @@ class TestTextCorpus(unittest.TestCase):
                 yield document
 
     def test_sample_text(self):
-        corpus = self.DumyTextCorpus()
+        corpus = self.DummyTextCorpus()
 
         sample1 = list(corpus.sample_texts(1))
         self.assertEqual(len(sample1), 1)
@@ -49,7 +49,7 @@ class TestTextCorpus(unittest.TestCase):
             list(corpus.sample_texts(-1))
 
     def test_sample_text_length(self):
-        corpus = self.DumyTextCorpus()
+        corpus = self.DummyTextCorpus()
         sample1 = list(corpus.sample_texts(1, length=1))
         self.assertEqual(sample1[0], ["document0"])
 
@@ -58,7 +58,7 @@ class TestTextCorpus(unittest.TestCase):
         self.assertEqual(sample2[1], ["document1"])
 
     def test_sample_text_seed(self):
-        corpus = self.DumyTextCorpus()
+        corpus = self.DummyTextCorpus()
         sample1 = list(corpus.sample_texts(5, seed=42))
         sample2 = list(corpus.sample_texts(5, seed=42))
         self.assertEqual(sample1, sample2)

--- a/gensim/test/test_textcorpus.py
+++ b/gensim/test/test_textcorpus.py
@@ -21,33 +21,47 @@ logger = logging.getLogger(__name__)
 class TestTextCorpus(unittest.TestCase):
     # TODO add tests for other methods
 
+    class DumyTextCorpus(TextCorpus):
+        def __init__(self):
+            self.size = 10
+            self.data = [["document%s" % i] for i in range(self.size)]
+
+        def get_texts(self):
+            for document in self.data:
+                yield document
+
     def test_sample_text(self):
-        class TestTextCorpus(TextCorpus):
-            def __init__(self):
-                self.data = [["document1"], ["document2"]]
-
-            def get_texts(self):
-                for document in self.data:
-                    yield document
-
-        corpus = TestTextCorpus()
+        corpus = self.DumyTextCorpus()
 
         sample1 = list(corpus.sample_texts(1))
         self.assertEqual(len(sample1), 1)
-        document1 = sample1[0] == ["document1"]
-        document2 = sample1[0] == ["document2"]
-        self.assertTrue(document1 or document2)
+        self.assertIn(sample1[0], corpus.data)
 
-        sample2 = list(corpus.sample_texts(2))
-        self.assertEqual(len(sample2), 2)
-        self.assertEqual(sample2[0], ["document1"])
-        self.assertEqual(sample2[1], ["document2"])
+        sample2 = list(corpus.sample_texts(corpus.size))
+        self.assertEqual(len(sample2), corpus.size)
+        for i in range(corpus.size):
+            self.assertEqual(sample2[i], ["document%s" % i])
 
         with self.assertRaises(ValueError):
-            list(corpus.sample_texts(3))
+            list(corpus.sample_texts(corpus.size + 1))
 
         with self.assertRaises(ValueError):
             list(corpus.sample_texts(-1))
+
+    def test_sample_text_length(self):
+        corpus = self.DumyTextCorpus()
+        sample1 = list(corpus.sample_texts(1, length=1))
+        self.assertEqual(sample1[0], ["document0"])
+
+        sample2 = list(corpus.sample_texts(2, length=2))
+        self.assertEqual(sample2[0], ["document0"])
+        self.assertEqual(sample2[1], ["document1"])
+
+    def test_sample_text_seed(self):
+        corpus = self.DumyTextCorpus()
+        sample1 = list(corpus.sample_texts(5, seed=42))
+        sample2 = list(corpus.sample_texts(5, seed=42))
+        self.assertEqual(sample1, sample2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes regarding @gojomo comments at  #308 .  Add option to use local random and option to tell the function how long is the corpus (without running __len__  and going through the whoe corpus).