### PR TITLE
Change docs build command

### DIFF
--- a/docs/src/Makefile
+++ b/docs/src/Makefile
@@ -6,7 +6,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = PYTHONPATH=../..:$(PYTHONPATH) sphinx-build
 PAPER         =
 BUILDDIR      = _build
 


### PR DESCRIPTION
Add gensim source code path to `${PYTHONPATH}` bash variable before running `sphinx-build`.
This allows Sphinx to use `.py` files from `../..` instead of the `.py` files from the virtual environment or
system-wide installed version of gensim.

Previously, you needed to run:
`python3 setup.py install`
whenever you wanted to build the docs from the current version of docstrings.
Now, you don't need to do it. Sphinx automatically extracts docstrings from the
gensim source code in `../..`. This makes debugging of docstrings formating in
sphinx documentation a lot easier. Just run `make html`. SymPy is also using
this trick with changing the `${PYTHONPATH}`.