### PR TITLE
Fast object counting + Phrases

### DIFF
--- a/gensim/models/fast_counter.py
+++ b/gensim/models/fast_counter.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Radim Rehurek <me@radimrehurek.com>
+# Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
+
+"""
+Fast & memory efficient counting of things (and n-grams of things).
+
+This module is designed to count *item* and *document* frequencies over large, streamed corpora (lazy iteration).
+
+"""
+
+from collections import Counter
+import logging
+
+from six import iterkeys, iteritems
+
+logger = logging.getLogger(__name__)
+
+
+def iter_ngrams(document, ngrams):
+    assert ngrams[0] <= ngrams[1]
+
+    for n in range(ngrams[0], ngrams[1] + 1):
+        for ngram in zip(*[document[i:] for i in range(n)]):
+            logger.debug("yielding ngram %r", ngram)
+            yield ngram
+
+def iter_gram1(document):
+    return iter_ngrams(document, (1, 1))
+
+def iter_gram2(document):
+    return iter_ngrams(document, (2, 2))
+
+def iter_gram12(document):
+    return iter_ngrams(document, (1, 2))
+
+
+class FastCounter(object):
+    """
+    Fast counting of item frequency and document frequency across large, streamed iterables.
+    """
+
+    def __init__(self, doc2items=iter_gram1, collect_df=False):
+        self.doc2items = doc2items
+        self.collect_df = collect_df
+
+        self.item_counts = Counter()  # TODO replace by some GIL-free low-level struct
+        self.doc_counts = Counter()  # TODO replace by some GIL-free low-level struct
+
+    def hash(self, key):
+        return hash(key)
+
+    def update(self, documents):
+        """
+        Update the relevant ngram counters from the iterable `documents`.
+
+        If the memory structures get too large, clip them (then the internal counts may be only approximate).
+        """
+        for document in documents:
+            # TODO: release GIL, so we can run update() in parallel threads.
+            # Or maybe not needed, if we create multiple FastCounters from multiple input streams using
+            # multiprocessing, and only .merge() them at the end.
+            item_cnts = Counter(self.hash(ngram) for ngram in self.doc2items(document))
+            self.item_counts.update(item_cnts)
+            if self.collect_df:
+                # increment by 1 per unique key ("document frequency")
+                self.doc_counts.update(iterkeys(item_cnts))
+
+            # self.prune_vocab()
+
+        return self  # for easier chaining
+
+    def prune_vocab(self):
+        # Trim data structures to fit in memory, if too large.
+        # Or use a fixed-size data structure to start with (hyperloglog?)
+        raise NotImplementedError
+
+    def get(self, key, default=None):
+        """Return the item frequency of `key` (or `default` if key not present)."""
+        return self.item_counts.get(self.hash(key), default)
+
+    def merge(self, other):
+        """
+        Merge counts from other into self, in-place.
+        """
+        # rare operation, no need to optimize too much
+        raise NotImplementedError
+
+    def __len__(self):
+        return len(self.item_counts)
+
+    def __str__(self):
+        return "%s<%i items>" % (self.__class__.__name__, len(self))
+
+
+class Phrases(object):
+    def __init__(self, min_count=5, threshold=10.0, max_vocab_size=40000000):
+        self.threshold = threshold
+        self.min_count = min_count
+        self.max_vocab_size = max_vocab_size
+        self.counter = FastCounter(iter_gram12)
+
+    def add_documents(self, documents):
+        self.counter.update(documents)
+
+        return self  # for easier chaining
+
+    def export_phrases(self, document):
+        """
+        Yield all collocations (pairs of adjacent closely related tokens) from the
+        input `document`, as 2-tuples `(score, bigram)`.
+        """
+        if not self.counter:
+            return
+        norm = 1.0 * len(self.counter)
+        for bigram in iter_gram2(document):
+            pa, pb, pab = self.counter.get((bigram[0],)), self.counter.get((bigram[1],)), self.counter.get(bigram, 0)
+            if pa and pb:
+                score = norm / pa / pb * (pab - self.min_count)
+                if score > self.threshold:
+                    yield score, bigram

--- a/gensim/models/fast_counter.py
+++ b/gensim/models/fast_counter.py
@@ -48,8 +48,8 @@ class FastCounter(object):
         self.doc2items = doc2items
         self.hash2cnt = Counter()  # TODO replace by some GIL-free low-level struct
 
-    def hash(self, key):
-        return hash(key)
+    def hash(self, item):
+        return hash(item)
 
     def update(self, documents):
         """
@@ -72,9 +72,9 @@ class FastCounter(object):
         # Or use a fixed-size data structure to start with (hyperloglog?)
         raise NotImplementedError
 
-    def get(self, key, default=None):
-        """Return the item frequency of `key` (or `default` if key not present)."""
-        return self.hash2cnt.get(self.hash(key), default)
+    def get(self, item, default=None):
+        """Return the item frequency of `item` (or `default` if item not present)."""
+        return self.hash2cnt.get(self.hash(item), default)
 
     def merge(self, other):
         """

--- a/gensim/models/fast_counter_cython.pyx
+++ b/gensim/models/fast_counter_cython.pyx
@@ -9,7 +9,14 @@
 
 from collections import Counter
 
+from libc.stdint cimport int64_t, uint64_t
+
 cimport preshed.counter
+
+
+cdef uint64_t chash(obj):
+    # TODO use something faster, can assume string
+    return <uint64_t>hash(obj)
 
 
 class FastCounterCython(object):
@@ -21,7 +28,7 @@ class FastCounterCython(object):
         self.doc2items = doc2items
         self.max_size = max_size
         self.min_reduce = 0
-        self.hash2cnt = Counter()  # TODO replace by some GIL-free low-level struct
+        self.hash2cnt = Counter()
 
     def update(self, documents):
         """
@@ -29,16 +36,19 @@ class FastCounterCython(object):
 
         If the memory structures get too large, clip them (then the internal counts may be only approximate).
         """
+        cdef int idx, l
+        cdef uint64_t h1, h2
         hash2cnt = self.hash2cnt
         for document in documents:
-            # TODO: release GIL, so we can run update() in parallel threads.
-            # Or maybe not needed, if we create multiple FastCounters from multiple input streams using
-            # multiprocessing, and only .merge() them at the end.
-            if document:
-                hash2cnt[hash(document[0])] += 1
-                for idx in range(len(document) - 1):
-                    hash2cnt[hash(document[idx + 1])] += 1
-                    hash2cnt[hash((document[idx], document[idx + 1]))] += 1
+            l = len(document)
+            if l:
+                h1 = chash(document[0])
+                hash2cnt[h1] += 1
+                for idx in range(1, l):
+                    h2 = chash(document[idx])
+                    hash2cnt[h2] += 1
+                    hash2cnt[h1 ^ h2] += 1
+                    h1 = h2
 
             # FIXME: add optimized prune
 
@@ -51,7 +61,66 @@ class FastCounterCython(object):
 
     def get(self, item, default=None):
         """Return the item frequency of `item` (or `default` if item not present)."""
-        return self.hash2cnt.get(hash(item), default)
+        return self.hash2cnt.get(chash(item), default)
+
+    def merge(self, other):
+        """
+        Merge counts from another FastCounter into self, in-place.
+        """
+        self.hash2cnt.update(other.hash2cnt)
+        self.min_reduce = max(self.min_reduce, other.min_reduce)
+        self.prune_items()
+
+    def __len__(self):
+        return len(self.hash2cnt)
+
+    def __str__(self):
+        return "%s<%i items>" % (self.__class__.__name__, len(self))
+
+
+class FastCounterPreshed(object):
+    """
+    Fast counting of item frequency frequency across large, streamed iterables.
+    """
+
+    def __init__(self, doc2items=None, max_size=None):
+        self.doc2items = doc2items
+        self.max_size = max_size
+        self.min_reduce = 0
+        self.hash2cnt = preshed.counter.PreshCounter()  # TODO replace by some GIL-free low-level struct
+
+    def update(self, documents):
+        """
+        Update the relevant ngram counters from the iterable `documents`.
+
+        If the memory structures get too large, clip them (then the internal counts may be only approximate).
+        """
+        cdef int idx, l
+        cdef uint64_t h1, h2
+        cdef preshed.counter.PreshCounter hash2cnt = self.hash2cnt
+        for document in documents:
+            l = len(document)
+            if l:
+                h1 = chash(document[0])
+                hash2cnt.inc(h1, 1)
+                for idx in range(1, l):
+                    h2 = chash(document[idx])
+                    hash2cnt.inc(h2, 1)
+                    hash2cnt.inc(h1 ^ h2, 1)
+                    h1 = h2
+
+            # FIXME: add optimized prune
+
+        return self  # for easier chaining
+
+    def prune_items(self):
+        """Trim data structures to fit in memory, if too large."""
+        # XXX: Or use a fixed-size data structure to start with (hyperloglog?)
+        pass
+
+    def get(self, item, default=None):
+        """Return the item frequency of `item` (or `default` if item not present)."""
+        return self.hash2cnt.get(chash(item), default)
 
     def merge(self, other):
         """

--- a/gensim/models/fast_counter_cython.pyx
+++ b/gensim/models/fast_counter_cython.pyx
@@ -1,0 +1,68 @@
+#!/usr/bin/env cython
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: cdivision=True
+# coding: utf-8
+#
+# Copyright (C) 2017 Radim Rehurek <me@radimrehurek.com>
+# Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
+
+from collections import Counter
+
+cimport preshed.counter
+
+
+class FastCounterCython(object):
+    """
+    Fast counting of item frequency frequency across large, streamed iterables.
+    """
+
+    def __init__(self, doc2items=None, max_size=None):
+        self.doc2items = doc2items
+        self.max_size = max_size
+        self.min_reduce = 0
+        self.hash2cnt = Counter()  # TODO replace by some GIL-free low-level struct
+
+    def update(self, documents):
+        """
+        Update the relevant ngram counters from the iterable `documents`.
+
+        If the memory structures get too large, clip them (then the internal counts may be only approximate).
+        """
+        hash2cnt = self.hash2cnt
+        for document in documents:
+            # TODO: release GIL, so we can run update() in parallel threads.
+            # Or maybe not needed, if we create multiple FastCounters from multiple input streams using
+            # multiprocessing, and only .merge() them at the end.
+            if document:
+                hash2cnt[hash(document[0])] += 1
+                for idx in range(len(document) - 1):
+                    hash2cnt[hash(document[idx + 1])] += 1
+                    hash2cnt[hash((document[idx], document[idx + 1]))] += 1
+
+            # FIXME: add optimized prune
+
+        return self  # for easier chaining
+
+    def prune_items(self):
+        """Trim data structures to fit in memory, if too large."""
+        # XXX: Or use a fixed-size data structure to start with (hyperloglog?)
+        pass
+
+    def get(self, item, default=None):
+        """Return the item frequency of `item` (or `default` if item not present)."""
+        return self.hash2cnt.get(hash(item), default)
+
+    def merge(self, other):
+        """
+        Merge counts from another FastCounter into self, in-place.
+        """
+        self.hash2cnt.update(other.hash2cnt)
+        self.min_reduce = max(self.min_reduce, other.min_reduce)
+        self.prune_items()
+
+    def __len__(self):
+        return len(self.hash2cnt)
+
+    def __str__(self):
+        return "%s<%i items>" % (self.__class__.__name__, len(self))

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -163,7 +163,7 @@ class Phrases(interfaces.TransformationABC):
             if sentence_no % progress_per == 0:
                 logger.info("PROGRESS: at sentence #%i, processed %i words and %i word types" %
                             (sentence_no, total_words, len(vocab)))
-            sentence = [utils.any2utf8(w) for w in sentence]
+            # sentence = [utils.any2utf8(w) for w in sentence]
             for bigram in zip(sentence, sentence[1:]):
                 vocab[bigram[0]] += 1
                 vocab[delimiter.join(bigram)] += 1
@@ -388,7 +388,7 @@ class Phraser(interfaces.TransformationABC):
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(threadName)s : %(levelname)s : %(message)s', level=logging.INFO)
-    logging.info("running %s" % " ".join(sys.argv))
+    logger.info("running %s", " ".join(sys.argv))
 
     # check and process cmdline input
     program = os.path.basename(sys.argv[0])
@@ -402,6 +402,12 @@ if __name__ == '__main__':
     sentences = Text8Corpus(infile)
 
     # test_doc = LineSentence('test/test_data/testcorpus.txt')
+    logger.info("training phrases")
     bigram = Phrases(sentences, min_count=5, threshold=100)
-    for s in bigram[sentences]:
-        print(utils.to_utf8(u' '.join(s)))
+    print bigram
+    logger.info("finished training phrases")
+
+    # for s in bigram[sentences]:
+    #     print(utils.to_utf8(u' '.join(s)))
+
+    logger.info("finished running %s", " ".join(sys.argv))

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -134,12 +134,6 @@ class Phrases(interfaces.TransformationABC):
         should be a byte string (e.g. b'_').
 
         """
-        if min_count <= 0:
-            raise ValueError("min_count should be at least 1")
-
-        if threshold <= 0:
-            raise ValueError("threshold should be positive")
-
         self.min_count = min_count
         self.threshold = threshold
         self.max_vocab_size = max_vocab_size

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1121,8 +1121,9 @@ def prune_vocab(vocab, min_reduce, trim_rule=None):
         if not keep_vocab_item(w, vocab[w], min_reduce, trim_rule):  # vocab[w] <= min_reduce:
             result += vocab[w]
             del vocab[w]
-    logger.info("pruned out %i tokens with count <=%i (before %i, after %i)",
-                old_len - len(vocab), min_reduce, old_len, len(vocab))
+    logger.info(
+        "pruned out %i tokens with count <=%i (before %i, after %i)",
+        old_len - len(vocab), min_reduce, old_len, len(vocab))
     return result
 
 

--- a/setup.py
+++ b/setup.py
@@ -249,7 +249,10 @@ setup(
             include_dirs=[model_dir]),
         Extension('gensim.models.doc2vec_inner',
             sources=['./gensim/models/doc2vec_inner.c'],
-            include_dirs=[model_dir])
+            include_dirs=[model_dir]),
+        Extension('gensim.models.fast_counter_cython',
+            sources=['./gensim/models/fast_counter_cython.c'],
+            include_dirs=[model_dir]),
     ],
     cmdclass=cmdclass,
     packages=find_packages(),


### PR DESCRIPTION
Create a new class for fast, memory-efficient object counting (bounded RAM footprint, even for super large corpora).

To be used in Phrases, Dictionary, Word2vec etc. Basically everywhere where a vocabulary larger than RAM can be expected (long tail, Zipf's law).

Perhaps we can release this as a separate, stand-alone Python library (widely useful even outside of gensim)?

* [x] design APIs
* [ ] choose efficient algorithms and data structures
* [ ] implement reference implementation in raw Python (slow but correct)
* [ ] optimize hotspots in C/Cython
* [ ] parallelize, if necessary
* [ ] implement Dictionary, Phrases, Word2vec, Doc2vec using this new counter