### PR TITLE
Fix for `TextDirectoryCorpus` test; windows path compatibility.

### DIFF
--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -525,6 +525,7 @@ class TestTextDirectoryCorpus(unittest.TestCase):
             'b_folder/3.txt',
             'b_folder/c_folder/4.txt'
         ]
+        expected = [os.path.normpath(path) for path in expected]
         self.assertEqual(expected, base_names)
 
         corpus.max_depth = 1


### PR DESCRIPTION
@menshikh-iv -- short PR with fix for windows test failure, as requested. I have not tested it on Windows yet, but I believe this will resolve the issue. Thanks for the SO link!