### PR TITLE
Downgrade scipy/numpy requirements. Fix #1450

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ before_install:
   - export PATH=/home/travis/miniconda2/bin:$PATH
   - conda update --yes conda
 install:
-  - conda create --yes -n gensim-test python=$TRAVIS_PYTHON_VERSION pip atlas numpy scipy
+  - conda create --yes -n gensim-test python=$TRAVIS_PYTHON_VERSION pip atlas numpy==1.11.3 scipy==0.18.1
   - source activate gensim-test
-  - pip install numpy==1.11.3 scipy==0.16.0
   - python setup.py install
   - pip install .[test]
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 install:
   - conda create --yes -n gensim-test python=$TRAVIS_PYTHON_VERSION pip atlas numpy scipy
   - source activate gensim-test
-  - pip install numpy==1.11.3 scipy==0.14.0
+  - pip install numpy==1.11.3 scipy==0.16.0
   - python setup.py install
   - pip install .[test]
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - python setup.py install
   - pip install .[test]
 script:
+  - pip freeze
   - python setup.py test
   - pip install flake8
   - continuous_integration/travis/flake8_diff.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 install:
   - conda create --yes -n gensim-test python=$TRAVIS_PYTHON_VERSION pip atlas numpy scipy
   - source activate gensim-test
+  - pip install numpy==1.11.3 scipy==0.14.0
   - python setup.py install
   - pip install .[test]
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,7 @@ test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
   - "pip install pyemd testfixtures unittest2 sklearn Morfessor==2.0.2a4"
-
+  - "pip freeze"
   - "python -c \"import nose; nose.main()\" -s -v gensim"
   # Move back to the project folder
   - "cd .."

--- a/continuous_integration/appveyor/requirements.txt
+++ b/continuous_integration/appveyor/requirements.txt
@@ -8,7 +8,7 @@
 # of the rackspace folder instead of trying to install from more recent
 # source tarball published on PyPI
 numpy==1.11.3
-scipy==0.16.0
+scipy==0.18.1
 cython
 six >= 1.5.0
 smart_open >= 1.2.1

--- a/continuous_integration/appveyor/requirements.txt
+++ b/continuous_integration/appveyor/requirements.txt
@@ -8,7 +8,7 @@
 # of the rackspace folder instead of trying to install from more recent
 # source tarball published on PyPI
 numpy==1.11.3
-scipy==0.14.0
+scipy==0.16.0
 cython
 six >= 1.5.0
 smart_open >= 1.2.1

--- a/continuous_integration/appveyor/requirements.txt
+++ b/continuous_integration/appveyor/requirements.txt
@@ -8,7 +8,7 @@
 # of the rackspace folder instead of trying to install from more recent
 # source tarball published on PyPI
 numpy==1.11.3
-scipy==0.19.0
+scipy==0.14.0
 cython
 six >= 1.5.0
 smart_open >= 1.2.1

--- a/setup.py
+++ b/setup.py
@@ -289,7 +289,7 @@ setup(
     ],
     install_requires=[
         'numpy >= 1.11.3',
-        'scipy >= 0.14.0',
+        'scipy >= 0.16.0',
         'six >= 1.5.0',
         'smart_open >= 1.2.1',
     ],

--- a/setup.py
+++ b/setup.py
@@ -289,7 +289,7 @@ setup(
     ],
     install_requires=[
         'numpy >= 1.11.3',
-        'scipy >= 0.16.0',
+        'scipy >= 0.18.1',
         'six >= 1.5.0',
         'smart_open >= 1.2.1',
     ],

--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,7 @@ Copyright (c) 2009-now Radim Rehurek
 test_env = [
     'testfixtures',
     'unittest2',
-    'Morfessor==2.0.2a4',
+    'Morfessor == 2.0.2a4',
     'scikit-learn',
     'pyemd',
     'annoy',
@@ -289,7 +289,7 @@ setup(
     ],
     install_requires=[
         'numpy >= 1.11.3',
-        'scipy >= 0.19.0',
+        'scipy >= 0.14.0',
         'six >= 1.5.0',
         'smart_open >= 1.2.1',
     ],


### PR DESCRIPTION
We should to minimize numpy/scipy version
For test/build we need numpy/scipy wheels, 
Minimal wheels version for linux from PyPI

| *   | numpy  | scipy  |
|-----|--------|--------|
| 2.7 | 1.6.0  | 0.9.0  |
| 3.5 | 1.9.0  | 0.16.0 |
| 3.6 | 1.11.3 | 0.18.1 |