### PR TITLE
Improve speed of FastTextKeyedVectors __contains__

### DIFF
--- a/gensim/models/wrappers/fasttext.py
+++ b/gensim/models/wrappers/fasttext.py
@@ -123,11 +123,8 @@ class FastTextKeyedVectors(KeyedVectors):
         if word in self.vocab:
             return True
         else:
-            word_ngrams = set(FastText.compute_ngrams(word, self.min_n, self.max_n))
-            if len(word_ngrams & set(self.ngrams.keys())):
-                return True
-            else:
-                return False
+            word_ngrams = FastText.compute_ngrams(word, self.min_n, self.max_n)
+            return bool(any(ng in self.ngrams for ng in word_ngrams))
 
 
 class FastText(Word2Vec):

--- a/gensim/models/wrappers/fasttext.py
+++ b/gensim/models/wrappers/fasttext.py
@@ -116,15 +116,14 @@ class FastTextKeyedVectors(KeyedVectors):
 
     def __contains__(self, word):
         """
-        Check if word is present in the vocabulary, or if any word ngrams are present. A vector for the word is
-        guaranteed to exist if `__contains__` returns True.
-
+        Check if `word` or any character ngrams in `word` are present in the vocabulary.
+        A vector for the word is guaranteed to exist if `__contains__` returns True.
         """
         if word in self.vocab:
             return True
         else:
-            word_ngrams = FastText.compute_ngrams(word, self.min_n, self.max_n)
-            return any(ng in self.ngrams for ng in word_ngrams)
+            char_ngrams = FastText.compute_ngrams(word, self.min_n, self.max_n)
+            return any(ng in self.ngrams for ng in char_ngrams)
 
 
 class FastText(Word2Vec):

--- a/gensim/models/wrappers/fasttext.py
+++ b/gensim/models/wrappers/fasttext.py
@@ -124,7 +124,7 @@ class FastTextKeyedVectors(KeyedVectors):
             return True
         else:
             word_ngrams = FastText.compute_ngrams(word, self.min_n, self.max_n)
-            return bool(any(ng in self.ngrams for ng in word_ngrams))
+            return any(ng in self.ngrams for ng in word_ngrams)
 
 
 class FastText(Word2Vec):


### PR DESCRIPTION
The current implementation of `__contains__` in FastTextKeyedVectors is `O(n*m)` where `n` is the number of character ngrams in the query word and `m` is the size of the vocabulary.  This is very slow for large
corpora.  The new implementation is `O(n)`.

I was working with the Wikipedia-trained vectors provided by Facebook, which have a vocabulary of a few million, and it was extremely slow to create averaged vectors from sentences.  I looked into the code and found that `__contains__` was implemented inefficiently and I replaced it with an implementation that is faster algorithmically and will short-circuit to give good average complexity.

**Testing**
- No new tests were required to test this implementation change
- All tests in `test_fasttext_wrapper.py` pass when run from Pycharm