### PR TITLE
Check path to executable for `gensim.utils.check_output`. Fix #1485

### DIFF
--- a/gensim/test/test_fasttext_wrapper.py
+++ b/gensim/test/test_fasttext_wrapper.py
@@ -30,8 +30,7 @@ def testfile():
 
 class TestFastText(unittest.TestCase):
     def setUp(self):
-        ft_home = os.environ.get('FT_HOME', None)
-        self.ft_path = os.path.join(ft_home, 'fasttext') if ft_home else None
+        self.ft_path = os.environ.get('FT_HOME', None)
         self.corpus_file = datapath('lee_background.cor')
         self.test_model_file = datapath('lee_fasttext')
         self.test_new_model_file = datapath('lee_fasttext_new')

--- a/gensim/test/test_utils.py
+++ b/gensim/test/test_utils.py
@@ -83,6 +83,10 @@ class TestUtils(unittest.TestCase):
         expected = u'It\x92s the Year of the Horse. YES VIN DIESEL \U0001f64c \U0001f4af'
         self.assertEquals(utils.decode_htmlentities(body), expected)
 
+    def test_check_output(self):
+        self.assertTrue(utils.check_output(args=['/bin/sh', '-c', 'echo', '1']))
+        self.assertRaises(FileNotFoundError, utils.check_output, args=['nonexistentFile'])
+
 class TestSampleDict(unittest.TestCase):
     def test_sample_dict(self):
         d = {1:2,2:3,3:4,4:5}
@@ -182,4 +186,6 @@ class TestWindowing(unittest.TestCase):
 
 if __name__ == '__main__':
     logging.root.setLevel(logging.WARNING)
-    unittest.main()
+    t = TestUtils()
+    t.test_check_output()
+    #unittest.main()

--- a/gensim/test/test_utils.py
+++ b/gensim/test/test_utils.py
@@ -186,6 +186,4 @@ class TestWindowing(unittest.TestCase):
 
 if __name__ == '__main__':
     logging.root.setLevel(logging.WARNING)
-    t = TestUtils()
-    t.test_check_output()
-    #unittest.main()
+    unittest.main()

--- a/gensim/test/test_utils.py
+++ b/gensim/test/test_utils.py
@@ -16,6 +16,13 @@ from gensim import utils
 from six import iteritems
 import numpy as np
 
+try:
+    FileNotFoundError
+    PermissionError
+except NameError:
+    FileNotFoundError = IOError
+    PermissionError = OSError
+
 
 class TestIsCorpus(unittest.TestCase):
     def test_None(self):

--- a/gensim/test/test_utils.py
+++ b/gensim/test/test_utils.py
@@ -10,7 +10,8 @@ Automated tests for checking various utils functions.
 
 import logging
 import unittest
-
+import tempfile
+import os
 from gensim import utils
 from six import iteritems
 import numpy as np
@@ -84,8 +85,11 @@ class TestUtils(unittest.TestCase):
         self.assertEquals(utils.decode_htmlentities(body), expected)
 
     def test_check_output(self):
-        self.assertTrue(utils.check_output(args=['/bin/sh', '-c', 'echo', '1']))
-        self.assertRaises(FileNotFoundError, utils.check_output, args=['nonexistentFile'])
+        if os.name == 'posix':
+            self.assertTrue(utils.check_output(args=['/bin/sh', '-c', 'echo', '0']))
+            self.assertRaises(FileNotFoundError, utils.check_output, args=['nonexistentFile'])
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                self. assertRaises(FileNotFoundError, utils.check_output, args=[tmp_dir])
 
 class TestSampleDict(unittest.TestCase):
     def test_sample_dict(self):
@@ -186,4 +190,6 @@ class TestWindowing(unittest.TestCase):
 
 if __name__ == '__main__':
     logging.root.setLevel(logging.WARNING)
+    t  = TestUtils()
+    t.test_check_output()
     unittest.main()

--- a/gensim/test/test_utils.py
+++ b/gensim/test/test_utils.py
@@ -190,6 +190,4 @@ class TestWindowing(unittest.TestCase):
 
 if __name__ == '__main__':
     logging.root.setLevel(logging.WARNING)
-    t  = TestUtils()
-    t.test_check_output()
     unittest.main()

--- a/gensim/test/test_utils.py
+++ b/gensim/test/test_utils.py
@@ -10,7 +10,6 @@ Automated tests for checking various utils functions.
 
 import logging
 import unittest
-import tempfile
 import os
 from gensim import utils
 from six import iteritems

--- a/gensim/test/test_utils.py
+++ b/gensim/test/test_utils.py
@@ -95,8 +95,6 @@ class TestUtils(unittest.TestCase):
         if os.name == 'posix':
             self.assertTrue(utils.check_output(args=['/bin/sh', '-c', 'echo', '0']))
             self.assertRaises(FileNotFoundError, utils.check_output, args=['nonexistentFile'])
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                self. assertRaises(FileNotFoundError, utils.check_output, args=[tmp_dir])
 
 class TestSampleDict(unittest.TestCase):
     def test_sample_dict(self):

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -26,8 +26,10 @@ except ImportError:
 
 try:
     FileNotFoundError
+    PermissionError
 except NameError:
     FileNotFoundError = IOError
+    PermissionError = OSError
 
 import re
 import unicodedata

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1170,7 +1170,8 @@ def check_output(stdout=subprocess.PIPE, *popenargs, **kwargs):
     """
     logger.debug("COMMAND: %s %s", popenargs, kwargs)
     command = kwargs.get('args')[0]
-    if not os.path.exists(command):
+    usr_bin_alias = '/usr/bin/' + command
+    if not os.path.exists(command) and not os.path.exists(usr_bin_alias):
         raise FileNotFoundError('Path [%s] does not exists ' % command)
     if os.path.isdir(command):
         raise FileNotFoundError('Path [%s] is path to a folder not to a file. Please specify path to executable ' % command)

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1168,22 +1168,23 @@ def check_output(stdout=subprocess.PIPE, *popenargs, **kwargs):
     Python 2.6.2
     Added extra KeyboardInterrupt handling
     """
-    try:
-        logger.debug("COMMAND: %s %s", popenargs, kwargs)
-        process = subprocess.Popen(stdout=stdout, *popenargs, **kwargs)
-        output, unused_err = process.communicate()
-        retcode = process.poll()
-        if retcode:
-            cmd = kwargs.get("args")
-            if cmd is None:
-                cmd = popenargs[0]
-            error = subprocess.CalledProcessError(retcode, cmd)
-            error.output = output
-            raise error
-        return output
-    except KeyboardInterrupt:
-        process.terminate()
-        raise
+    logger.debug("COMMAND: %s %s", popenargs, kwargs)
+    command = kwargs.get('args')[0]
+    if not os.path.isfile(command):
+        raise FileNotFoundError('Path [%s] is path to folder, please specify path to executable ' % command)
+    if not os.access(command, os.X_OK):
+        raise PermissionError('Executable [%s] does not have sufficient permission. ' % command)
+    process = subprocess.Popen(stdout=stdout, **kwargs)
+    output, unused_err = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = popenargs[0]
+        error = subprocess.CalledProcessError(retcode, cmd)
+        error.output = output
+        raise error
+    return output
 
 
 def sample_dict(d, n=10, use_random=True):

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1170,8 +1170,10 @@ def check_output(stdout=subprocess.PIPE, *popenargs, **kwargs):
     """
     logger.debug("COMMAND: %s %s", popenargs, kwargs)
     command = kwargs.get('args')[0]
-    if not os.path.isfile(command):
-        raise FileNotFoundError('Path [%s] is path to folder, please specify path to executable ' % command)
+    if not os.path.exists(command):
+        raise FileNotFoundError('Path [%s] does not exists ' % command)
+    if os.path.isdir(command):
+        raise FileNotFoundError('Path [%s] is path to a folder not to a file. Please specify path to executable ' % command)
     if not os.access(command, os.X_OK):
         raise PermissionError('Executable [%s] does not have sufficient permission. ' % command)
     process = subprocess.Popen(stdout=stdout, **kwargs)

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1171,7 +1171,9 @@ def check_output(stdout=subprocess.PIPE, *popenargs, **kwargs):
     logger.debug("COMMAND: %s %s", popenargs, kwargs)
     command = kwargs.get('args')[0]
     usr_bin_alias = '/usr/bin/' + command
-    if not os.path.exists(command) and not os.path.exists(usr_bin_alias):
+    if not os.path.exists(command) and os.path.exists(usr_bin_alias) and os.path.isfile(usr_bin_alias):
+        command = usr_bin_alias
+    if not os.path.exists(command):
         raise FileNotFoundError('Path [%s] does not exists ' % command)
     if os.path.isdir(command):
         raise FileNotFoundError('Path [%s] is path to a folder not to a file. Please specify path to executable ' % command)

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -24,6 +24,11 @@ try:
 except ImportError:
     import pickle as _pickle
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 import re
 import unicodedata
 import os


### PR DESCRIPTION
Add checks for kwargs, removed wrong Popen call. 
