### PR TITLE
Add NLPub to the list of adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Adopters
 | Amazon     |  <img src="http://g-ec2.images-amazon.com/images/G/01/social/api-share/amazon_logo_500500._V323939215_.png" width="100"> | [amazon.com](http://www.amazon.com/)                                  |  Document similarity|
 | SiteGround Hosting     |  <img src="https://www.siteground.com/img/knox/logos/siteground.png" width="100"> | [siteground.com](https://www.siteground.com/)                                  | An ensemble search engine which uses different embeddings models and similarities, including word2vec, WMD, and LDA. |
 | Juju  | <img src="https://d5k1a84rm5hwo.cloudfront.net/img/juju_home_logo.png" width="100">   | [www.juju.com](http://www.juju.com/) | Provide non-obvious related job suggestions. |
+| NLPub | <img src="https://nlpub.org/images/thumb/a/aa/NLPub.svg/240px-NLPub.svg.png" width="100"> | [nlpub.org](https://nlpub.org/) | Distributional semantic models including word2vec. |
 
 -------
 


### PR DESCRIPTION
We actively use Gensim for developing distributional semantic models and their applications to lexical semantics.

* EACL 2017 Short Paper : <http://aclweb.org/anthology/E/E17/E17-2087.pdf>
* ACL 2017 Full Paper: <https://arxiv.org/abs/1704.07157>

It would be great for us to be added to the list of adopters.