### PR TITLE
Pin sklearn version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,7 @@ Copyright (c) 2009-now Radim Rehurek
 test_env = [
     'testfixtures',
     'Morfessor == 2.0.2a4',
-    'scikit-learn',
+    'scikit-learn == 0.18.2',
     'pyemd',
     'annoy',
     'tensorflow >= 1.1.0',


### PR DESCRIPTION
This PR pins scikit-learn version to 0.18.2 to pass unit-tests which use sklearn's `Pipeline`.