### PR TITLE
Fix Keyedvectors.get_embedding_layer

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -832,5 +832,8 @@ class KeyedVectors(utils.SaveLoad):
         if not KERAS_INSTALLED:
             raise ImportError("Please install Keras to use this function")
         weights = self.syn0
-        layer = Embedding(input_dim=weights.shape[0], output_dim=weights.shape[1], weights=[weights])  # No extra mem usage here as `Embedding` layer doesn't create any new matrix for weights
+
+        # set `trainable` as `False` to use the pretrained word embedding
+        # No extra mem usage here as `Embedding` layer doesn't create any new matrix for weights
+        layer = Embedding(input_dim=weights.shape[0], output_dim=weights.shape[1], weights=[weights], trainable=train_embeddings)
         return layer


### PR DESCRIPTION
Issue https://github.com/RaRe-Technologies/gensim/issues/1557

When moved get_embedding_layer function to keyedvectors ( commit https://github.com/RaRe-Technologies/gensim/commit/b7c3e2d7c00dc50fc40059c98f46ae7bc4a360ce )

`train_embeddings` is missing.

So I add argument `trainable` on `Embedding`