### PR TITLE
mutable args  changed None to empty tuple

### DIFF
--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -423,7 +423,7 @@ class DocvecsArray(utils.SaveLoad):
                     self.doctag_syn0norm = empty(self.doctag_syn0.shape, dtype=REAL)
                 np_divide(self.doctag_syn0, sqrt((self.doctag_syn0 ** 2).sum(-1))[..., newaxis], self.doctag_syn0norm)
 
-    def most_similar(self, positive=None, negative=None, topn=10, clip_start=0, clip_end=None, indexer=None):
+    def most_similar(self, positive=(), negative=(), topn=10, clip_start=0, clip_end=None, indexer=None):
         """
         Find the top-N most similar docvecs known from training. Positive docs contribute
         positively towards the similarity, negative docs negatively.
@@ -437,10 +437,6 @@ class DocvecsArray(utils.SaveLoad):
         range of the underlying doctag_syn0norm vectors. (This may be useful if the ordering
         there was chosen to be significant, such as more popular tag IDs in lower indexes.)
         """
-        if positive is None:
-            positive = []
-        if negative is None:
-            negative = []
 
         self.init_sims()
         clip_end = clip_end or len(self.doctag_syn0norm)

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -288,7 +288,7 @@ class KeyedVectors(utils.SaveLoad):
         else:
             raise KeyError("word '%s' not in vocabulary" % word)
 
-    def most_similar(self, positive=None, negative=None, topn=10, restrict_vocab=None, indexer=None):
+    def most_similar(self, positive=(), negative=(), topn=10, restrict_vocab=None, indexer=None):
         """
         Find the top-N most similar words. Positive words contribute positively towards the
         similarity, negative words negatively.
@@ -311,10 +311,6 @@ class KeyedVectors(utils.SaveLoad):
           [('queen', 0.50882536), ...]
 
         """
-        if positive is None:
-            positive = []
-        if negative is None:
-            negative = []
 
         self.init_sims()
 
@@ -448,7 +444,7 @@ class KeyedVectors(utils.SaveLoad):
         # Compute WMD.
         return emd(d1, d2, distance_matrix)
 
-    def most_similar_cosmul(self, positive=None, negative=None, topn=10):
+    def most_similar_cosmul(self, positive=(), negative=(), topn=10):
         """
         Find the top-N most similar words, using the multiplicative combination objective
         proposed by Omer Levy and Yoav Goldberg in [4]_. Positive words still contribute
@@ -470,10 +466,6 @@ class KeyedVectors(utils.SaveLoad):
         .. [4] Omer Levy and Yoav Goldberg. Linguistic Regularities in Sparse and Explicit Word Representations, 2014.
 
         """
-        if positive is None:
-            positive = []
-        if negative is None:
-            negative = []
 
         self.init_sims()
 

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1228,7 +1228,7 @@ class Word2Vec(utils.SaveLoad):
                         self.syn0_lockf[self.wv.vocab[word].index] = lockf  # lock-factor: 0.0 stops further changes
         logger.info("merged %d vectors into %s matrix from %s" % (overlap_count, self.wv.syn0.shape, fname))
 
-    def most_similar(self, positive=None, negative=None, topn=10, restrict_vocab=None, indexer=None):
+    def most_similar(self, positive=(), negative=(), topn=10, restrict_vocab=None, indexer=None):
         """
         Deprecated. Use self.wv.most_similar() instead.
         Refer to the documentation for `gensim.models.KeyedVectors.most_similar`
@@ -1242,7 +1242,7 @@ class Word2Vec(utils.SaveLoad):
         """
         return self.wv.wmdistance(document1, document2)
 
-    def most_similar_cosmul(self, positive=None, negative=None, topn=10):
+    def most_similar_cosmul(self, positive=(), negative=(), topn=10):
         """
         Deprecated. Use self.wv.most_similar_cosmul() instead.
         Refer to the documentation for `gensim.models.KeyedVectors.most_similar_cosmul`


### PR DESCRIPTION
@gojomo 
Issue(Closed) https://github.com/RaRe-Technologies/gensim/issues/1561
PR (Merged) https://github.com/RaRe-Technologies/gensim/pull/1562

In PR #1562, I changed empty list in default arguments to `None` and add check None
e.g) 
```
def foo( arg=None):
    if arg is None:
        arg = []
```

But I requested under the comment

>gojomo 5 hours ago Member
Making these defaults empty tuples – () – could enforce the immutability, and eliminate the later None-check/assignments.

So I change None to empty tuple `()` excepts `graph.py`.

In `graph.py`, can't apply these change.