### PR TITLE
Newlines are now ignored while splitting by sentences in summarizing. Fix #1575.

### DIFF
--- a/gensim/summarization/textcleaner.py
+++ b/gensim/summarization/textcleaner.py
@@ -22,7 +22,7 @@ except ImportError:
 
 
 SEPARATOR = r"@"
-RE_SENTENCE = re.compile('(\S.+?[.!?])(?=\s+|$)|(\S.+?)(?=[\n]|$)', re.UNICODE)  # backup (\S.+?[.!?])(?=\s+|$)|(\S.+?)(?=[\n]|$)
+RE_SENTENCE = re.compile('(\S.+?[.!?])(?=\s+|$)|(\S.+?)(?=[\n]|$)', re.UNICODE | re.DOTALL)
 AB_SENIOR = re.compile("([A-Z][a-z]{1,2}\.)\s(\w)", re.UNICODE)
 AB_ACRONYM = re.compile("(\.[a-zA-Z]\.)\s(\w)", re.UNICODE)
 AB_ACRONYM_LETTERS = re.compile("([a-zA-Z])\.([a-zA-Z])\.", re.UNICODE)

--- a/gensim/test/test_data/mihalcea_tarau.txt
+++ b/gensim/test/test_data/mihalcea_tarau.txt
@@ -1,11 +1,11 @@
-AP880911-0016
-AP-NR-09-11-88 0423EDT r i
-BC-HurricaneGilbert 09-11 0339
-BC-Hurricane Gilbert,0348
-Hurricane Gilbert Heads Toward Dominican Coast
-By RUDDY GONZALEZ
-Associated Press Writer
-SANTO DOMINGO, Dominican Republic (AP)
+AP880911-0016.
+AP-NR-09-11-88 0423EDT r i.
+BC-HurricaneGilbert 09-11 0339-
+BC-Hurricane Gilbert,0348.
+Hurricane Gilbert Heads Toward Dominican Coast.
+By RUDDY GONZALEZ.
+Associated Press Writer.
+SANTO DOMINGO, Dominican Republic (AP).
 Hurricane Gilbert swept toward the Dominican Republic Sunday, and the Civil Defense alerted its heavily populated south coast to prepare for high winds, heavy rains and high seas.
 The storm was approaching from the southeast with sustained winds of 75 mph gusting to 92 mph.
 ``There is no need for alarm,'' Civil Defense Director Eugenio Cabral said in a television alert shortly before midnight Saturday.

--- a/gensim/test/test_data/mihalcea_tarau_multiline.summ.txt
+++ b/gensim/test/test_data/mihalcea_tarau_multiline.summ.txt
@@ -1,0 +1,11 @@
+Hurricane Gilbert swept toward the Dominican Republic Sunday, and the Civil
+Defense alerted its heavily populated south coast to prepare for high winds,
+heavy rains and high seas.
+The National Hurricane Center in Miami reported its position at 2 a.m. Sunday
+at latitude 16.1 north, longitude 67.5 west, about 140 miles south of Ponce,
+Puerto Rico, and 200 miles southeast of Santo Domingo.
+The National Weather Service in San Juan, Puerto Rico, said Gilbert was moving
+westward at 15 mph with a ``broad area of cloudiness and heavy weather''
+rotating around the center of the storm.
+Strong winds associated with the Gilbert brought coastal flooding, strong
+southeast winds and up to 12 feet feet to Puerto Rico's south coast.

--- a/gensim/test/test_data/mihalcea_tarau_multiline.txt
+++ b/gensim/test/test_data/mihalcea_tarau_multiline.txt
@@ -1,0 +1,42 @@
+AP880911-0016.
+AP-NR-09-11-88 0423EDT r i.
+BC-HurricaneGilbert 09-11 0339.
+BC-Hurricane Gilbert,0348.
+Hurricane Gilbert Heads Toward Dominican Coast.
+By RUDDY GONZALEZ.
+Associated Press Writer.
+SANTO DOMINGO, Dominican Republic (AP).
+Hurricane Gilbert swept toward the Dominican Republic Sunday, and the Civil
+Defense alerted its heavily populated south coast to prepare for high winds,
+heavy rains and high seas.
+The storm was approaching from the southeast with sustained winds of 75 mph
+gusting to 92 mph.
+``There is no need for alarm,'' Civil Defense Director Eugenio Cabral said in
+a television alert shortly before midnight Saturday.
+Cabral said residents of the province of Barahona should closely follow
+Gilbert's movement.
+An estimated 100,000 people live in the province, including 70,000 in the city
+of Barahona, about 125 miles west of Santo Domingo.
+Tropical Storm Gilbert formed in the eastern Caribbean and strengthened into a
+hurricane Saturday night.
+The National Hurricane Center in Miami reported its position at 2 a.m. Sunday
+at latitude 16.1 north, longitude 67.5 west, about 140 miles south of Ponce,
+Puerto Rico, and 200 miles southeast of Santo Domingo.
+The National Weather Service in San Juan, Puerto Rico, said Gilbert was moving
+westward at 15 mph with a ``broad area of cloudiness and heavy weather''
+rotating around the center of the storm.
+The weather service issued a flash flood watch for Puerto Rico and the Virgin
+Islands until at least 6 p.m. Sunday.
+Strong winds associated with the Gilbert brought coastal flooding, strong
+southeast winds and up to 12 feet feet to Puerto Rico's south coast.
+There were no reports of casualties.
+San Juan, on the north coast, had heavy rains and gusts Saturday, but they
+subsided during the night.
+On Saturday, Hurricane Florence was downgraded to a tropical storm and its
+remnants pushed inland from the U.S. Gulf Coast.
+Residents returned home, happy to find little damage from 80 mph winds and
+sheets of rain.
+Florence, the sixth named storm of the 1988 Atlantic storm season, was the
+second hurricane.
+The first, Debby, reached minimal hurricane strength briefly before hitting the
+Mexican coast last month.

--- a/gensim/test/test_summarization.py
+++ b/gensim/test/test_summarization.py
@@ -38,6 +38,22 @@ class TestSummarizationTest(unittest.TestCase):
 
         self.assertEqual(generated_summary, summary)
 
+    def test_text_summarization_multiline(self):
+        """This tests that the newlines don't affect the result of the summarization."""
+        pre_path = os.path.join(os.path.dirname(__file__), 'test_data')
+
+        with utils.smart_open(os.path.join(pre_path, "mihalcea_tarau_multiline.txt"), mode="r") as f:
+            text = f.read()
+
+        # Makes a summary of the text.
+        generated_summary = summarize(text)
+
+        # To be compared to the method reference.
+        with utils.smart_open(os.path.join(pre_path, "mihalcea_tarau_multiline.summ.txt"), mode="r") as f:
+            summary = f.read()
+
+        self.assertEqual(generated_summary, summary)
+
     def test_corpus_summarization(self):
         pre_path = os.path.join(os.path.dirname(__file__), 'test_data')
 


### PR DESCRIPTION
This is an improvement over #1577 for fixing #1575, as this doesn't need to process all text at once for removing newlines.