### PR TITLE
Fix logger message typo in lsi_dispatcher

### DIFF
--- a/gensim/models/lsi_dispatcher.py
+++ b/gensim/models/lsi_dispatcher.py
@@ -124,7 +124,7 @@ class Dispatcher(object):
         # and not `workers - 1` merges!
         # but merging only takes place once, after all input data has been processed,
         # so the overall effect would be small... compared to the amount of coding :-)
-        logger.info("merging states from %i workers", self.workers)
+        logger.info("merging states from %i workers", len(self.workers))
         workers = list(self.workers.items())
         result = workers[0][1].getstate()
         for workerid, worker in workers[1:]:

--- a/gensim/models/lsi_dispatcher.py
+++ b/gensim/models/lsi_dispatcher.py
@@ -175,7 +175,6 @@ class Dispatcher(object):
             worker.exit()
         logger.info("terminating dispatcher")
         os._exit(0)  # exit the whole process (not just this thread ala sys.exit())
-# endclass Dispatcher
 
 
 def main():


### PR DESCRIPTION
Fixes a minor typo in the lsi_dispatcher.

Here's the encountered error:
```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.4/logging/__init__.py", line 978, in emit
    msg = self.format(record)
  File "/usr/lib/python3.4/logging/__init__.py", line 828, in format
    return fmt.format(record)
  File "/usr/lib/python3.4/logging/__init__.py", line 565, in format
    record.message = record.getMessage()
  File "/usr/lib/python3.4/logging/__init__.py", line 328, in getMessage
    msg = msg % self.args
TypeError: %i format: a number is required, not dict
Call stack:
  File "/usr/lib/python3.4/threading.py", line 888, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.4/dist-packages/Pyro4/socketserver/threadpool.py", line 44, in run
    self.job()
  File "/usr/local/lib/python3.4/dist-packages/Pyro4/socketserver/threadpoolserver.py", line 40, in __call__
    self.daemon.handleRequest(self.csock)
  File "/usr/local/lib/python3.4/dist-packages/Pyro4/core.py", line 1356, in handleRequest
    data = method(*vargs, **kwargs)  # this is the actual method call to the Pyro object
  File "/usr/local/lib/python3.4/dist-packages/gensim/models/lsi_dispatcher.py", line 127, in getstate
    logger.info("merging states from %i workers", self.workers)
Message: 'merging states from %i workers'
Arguments: {0: <Pyro4.core.Proxy at 0x7f31340407b8; connected IPv4; for PYRO:gensim.lsi_worker.14743b@172.17.0.2:51772>, 1: <Pyro4.core.Proxy at 0x7f3134040ba8; connected IPv4; for PYRO:gensim.lsi_worker.f324c2@172.17.0.2:53614>}
```