### PR TITLE
Retain the raw vocabulary when you feed several data respectively

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -663,7 +663,8 @@ class Word2Vec(utils.SaveLoad):
         
     def reset_raw_vocab(self):
         """
-        After building vocabulary, Delete the raw vocabulary to free up RAM
+        Delete the raw vocabulary to free up RAM after building vocabulary completely
+        if `keep_raw_vocab` is set.
         """
         if hasattr(self, 'raw_vocab'):
             self.raw_vocab = defaultdict(int)

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -627,7 +627,10 @@ class Word2Vec(utils.SaveLoad):
         sentence_no = -1
         total_words = 0
         min_reduce = 1
-        vocab = defaultdict(int)
+        if not hasattr(self, 'raw_vocab'):
+            vocab = defaultdict(int)
+        else:
+            vocab = self.raw_vocab
         checked_string_types = 0
         for sentence_no, sentence in enumerate(sentences):
             if not checked_string_types:

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -660,6 +660,13 @@ class Word2Vec(utils.SaveLoad):
         )
         self.corpus_count = sentence_no + 1
         self.raw_vocab = vocab
+        
+    def reset_raw_vocab(self):
+        """
+        After building vocabulary, Delete the raw vocabulary to free up RAM
+        """
+        if hasattr(self, 'raw_vocab'):
+            self.raw_vocab = defaultdict(int)
 
     def scale_vocab(self, min_count=None, sample=None, dry_run=False,
                     keep_raw_vocab=False, trim_rule=None, update=False):


### PR DESCRIPTION
When you have several data the sizes of which are so large, it is difficult to feed all the data to the model at the same time.

If you feed several data respectively, it is needed to retain the raw vocabulary to see if the number of occurrences of each infrequent word which is included in data is larger than `min_count`.

Thus, I sent this pull request.

If these commits are added, we can do this operation without discarding infrequent words the sizes of which are larger than `min_count` globally but smaller locally.

```python
from gensim.models import word2vec
model = word2vec.Word2Vec(window=1, min_count=1)

def load(file):
    ~
    hoge
    ~
    return sentences

files=["data0.txt", "data1.txt", "data2.txt", ...]
update=False
for file in files:
    sentences = load(file)
    model.build_vocab(sentences, update=update)
    update=True
for file in files:
    sentences = load(file)
    model.train(sentences, total_examples=len(sentences),
                epochs=model.iter)
```