### PR TITLE
Add __getitem__ method to Sparse2Corpus to allow direct queries

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -342,6 +342,11 @@ class Sparse2Corpus(object):
     def __len__(self):
         return self.sparse.shape[1]
 
+    def __getitem__(self, item):
+        indprev = self.sparse.indptr[item]
+        indnow = self.sparse.indptr[item+1]
+        return list(zip(self.sparse.indices[indprev:indnow], self.sparse.data[indprev:indnow]))
+
 
 def veclen(vec):
     if len(vec) == 0:

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -344,7 +344,7 @@ class Sparse2Corpus(object):
 
     def __getitem__(self, item):
         indprev = self.sparse.indptr[item]
-        indnow = self.sparse.indptr[item+1]
+        indnow = self.sparse.indptr[item + 1]
         return list(zip(self.sparse.indices[indprev:indnow], self.sparse.data[indprev:indnow]))
 
 

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -342,9 +342,12 @@ class Sparse2Corpus(object):
     def __len__(self):
         return self.sparse.shape[1]
 
-    def __getitem__(self, item):
-        indprev = self.sparse.indptr[item]
-        indnow = self.sparse.indptr[item + 1]
+    def __getitem__(self, document_index):
+        """
+        Return a single document in the corpus by its index (between 0 and `len(self)-1`).
+        """
+        indprev = self.sparse.indptr[document_index]
+        indnow = self.sparse.indptr[document_index + 1]
         return list(zip(self.sparse.indices[indprev:indnow], self.sparse.data[indprev:indnow]))
 
 


### PR DESCRIPTION
@piskvorky @janpom @menshikh-iv 

Adds `__getitem__` method to Sparse2Corpus to enable direct doc querying.
Was necessary so that the CSC corpus could be used for similarity computation, and looks overall useful.