### PR TITLE
Remove unnecessary assert blocking direct usage of CSC for LSI

### DIFF
--- a/gensim/models/lsimodel.py
+++ b/gensim/models/lsimodel.py
@@ -407,7 +407,6 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
                 self.docs_processed += doc_no
         else:
             assert not self.dispatcher, "must be in serial mode to receive jobs"
-            assert self.onepass, "distributed two-pass algo not supported yet"
             update = Projection(
                 self.num_terms, self.num_topics, corpus.tocsc(), extra_dims=self.extra_samples,
                 power_iters=self.power_iters


### PR DESCRIPTION
@piskvorky @janpom @menshikh-iv 

Removes the assert which is blocking usage of CSC directly as corpus for LsiModel with multiple power iterations.
I could not figure out why the assert was there in the first place: it doesn't make sense to me: The code path handles CSC exclusively but I don't see why CSC would require a single pass only. It works just fine with multiple power iterations.