### PR TITLE
Add pep8 exceptions for flake8 in setup.cfg

### DIFF
--- a/continuous_integration/travis/flake8_diff.sh
+++ b/continuous_integration/travis/flake8_diff.sh
@@ -20,6 +20,7 @@ set -o pipefail
 
 PROJECT=RaRe-Technologies/gensim
 PROJECT_URL=https://github.com/${PROJECT}.git
+FLAKE_CONFIG_FILE=setup.cfg
 
 # Find the remote with the project name (upstream in most cases)
 REMOTE=$(git remote -v | grep ${PROJECT} | cut -f1 | head -1 || echo '')
@@ -133,14 +134,14 @@ check_files() {
     if [ -n "$files" ]; then
         # Conservative approach: diff without context (--unified=0) so that code
         # that was not changed does not create failures
-        git diff --unified=0 ${COMMIT_RANGE} -- ${files} | flake8 --diff --show-source ${options}
+        git diff --unified=0 ${COMMIT_RANGE} -- ${files} | flake8 --config ${FLAKE_CONFIG_FILE} --diff --show-source ${options}
     fi
 }
 
 if [[ "$MODIFIED_PY_FILES" == "no_match" ]]; then
     echo "No .py files has been modified"
 else
-    check_files "$(echo "$MODIFIED_PY_FILES" )" "--ignore=E501,E731,E12,W503"
+    check_files "$(echo "$MODIFIED_PY_FILES" )"
 fi
 echo -e "No problem detected by flake8\n"
 
@@ -150,7 +151,7 @@ else
     for fname in ${MODIFIED_IPYNB_FILES}
     do
         echo "File: $fname"
-        jupyter nbconvert --to script --stdout ${fname} | flake8 - --show-source --ignore=E501,E731,E12,W503,E402 --builtins=get_ipython || true
+        jupyter nbconvert --to script --stdout ${fname} | flake8 --config ${FLAKE_CONFIG_FILE} --show-source --builtins=get_ipython || true
     done
 fi
 

--- a/gensim/test/test_lsimodel.py
+++ b/gensim/test/test_lsimodel.py
@@ -91,7 +91,6 @@ class TestLsiModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         expected = np.array([-0.6594664, 0.142115444])  # scaled LSI version
         self.assertTrue(np.allclose(abs(vec), abs(expected), atol=1.e-5))  # transformed entries must be equal up to sign
 
-
     def testCorpusTransform(self):
         """Test lsi[corpus] transformation."""
         model = self.model

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,8 @@ artifact_indexes=
     # https://github.com/MacPython/scikit-learn-wheels
     http://wheels.scipy.org
     # Windows wheels buit by:
-    # https://ci.appveyor.com/project/piskvorky/gensim 
+    # https://ci.appveyor.com/project/piskvorky/gensim
     http://17a25141cb7f75c18ee4-676a79255544e7711e0dd8bccdcdd1cb.r23.cf2.rackcdn.com
+
+[flake8]
+ignore = E501,E731,E12,W503,E402


### PR DESCRIPTION
#10 suggests that the code style of `gensim` should ignore flake8's `E501,E731,E12,W503,E402`

This PR adds the rules to `setup.cfg` so they're documented and used by default.
 