### PR TITLE
Inferring topics over a new author in the author-topic model

### DIFF
--- a/gensim/models/atmodel.py
+++ b/gensim/models/atmodel.py
@@ -33,6 +33,8 @@ A tutorial can be found at https://github.com/RaRe-Technologies/gensim/tree/deve
 # are included in the code where this is the case, for example in the log_perplexity
 # and do_estep methods.
 
+# TODO: allow inferring topics over an new/unseen author.
+
 import logging
 import numpy as np  # for arrays, array broadcasting etc.
 from copy import deepcopy


### PR DESCRIPTION
At the moment, it is not possible to get a topic representation of a new author in the author-topic model in Gensim. Users are interested in this capability, for example in [this question](https://groups.google.com/forum/#!topic/gensim/HYcLC82ZK78) on Gensim's Google group. Typically, users want this functionality to be able to predict the author of the input documents, which can be achieved using a similarity query.

Because of the apparent interest, I'm going to look into this. Since it has been some time since I worked on the author-topic model, I first must assess what needs to be done. 