### PR TITLE
Reduce distributive size. Fix #1698

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,4 @@
 recursive-include gensim/test/test_data *
-recursive-exclude . *.sh
-prune docs/src*
-prune docs/notebooks/datasets
 include README.md
 include CHANGELOG.md
 include COPYING
@@ -13,4 +10,3 @@ include gensim/models/word2vec_inner.pyx
 include gensim/models/word2vec_inner.pxd
 include gensim/models/doc2vec_inner.c
 include gensim/models/doc2vec_inner.pyx
-prune docs/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 recursive-include docs *
 recursive-include gensim/test/test_data *
-recursive-include . *.sh
+recursive-exclude . *.sh
 prune docs/src*
 prune docs/notebooks/datasets
 include README.md
@@ -14,3 +14,4 @@ include gensim/models/word2vec_inner.pyx
 include gensim/models/word2vec_inner.pxd
 include gensim/models/doc2vec_inner.c
 include gensim/models/doc2vec_inner.pyx
+prune docs/notebooks/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-recursive-include docs *
 recursive-include gensim/test/test_data *
 recursive-exclude . *.sh
 prune docs/src*
@@ -14,4 +13,4 @@ include gensim/models/word2vec_inner.pyx
 include gensim/models/word2vec_inner.pxd
 include gensim/models/doc2vec_inner.c
 include gensim/models/doc2vec_inner.pyx
-prune docs/notebooks/
+prune docs/


### PR DESCRIPTION
What's done:
- removed `docker/`
- removed `continious_integration/`
- removed `docs/`

Result: `63MB -> 14MB` for `tar.gz`

Last large part is distrib is `gensim/test/test_data`, biggest file is:
- `large_tag_doc_10_iter50` - `4.8MB`
- `small_tag_doc_5_iter50` - `2.3MB`
- `head500.noblanks.cor` - `2.3MB`
- `pang_lee_polarity_fasttext.vec` - `1.8MB`
- `enwiki-latest-pages-articles1.xml-p000000010p000030302-shortened.bz2` - `1.7MB`
- `lee_fasttext` - `1.1MB`

But I think that we no needed to replace it & fix tests, wdyt @piskvorky?