### PR TITLE
Fix scipy logsumexp deprecation warning

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -48,7 +48,7 @@ from gensim.models import basemodel, CoherenceModel
 from gensim.models.callbacks import Callback
 
 # log(sum(exp(x))) that tries to avoid overflow
-from scipy.misc import logsumexp
+from scipy.special import logsumexp
 
 
 logger = logging.getLogger('gensim.models.ldamodel')

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -48,7 +48,10 @@ from gensim.models import basemodel, CoherenceModel
 from gensim.models.callbacks import Callback
 
 # log(sum(exp(x))) that tries to avoid overflow
-from scipy.special import logsumexp
+try:
+    from scipy.special import logsumexp
+except ImportError:
+    from scipy.misc import logsumexp
 
 
 logger = logging.getLogger('gensim.models.ldamodel')


### PR DESCRIPTION
**Problem**
I noticed that when training LDA model with the latest version of scipy I get a deprecation warning.

```python
>>> ldamodel = LdaModel(corpus, num_topics=4, id2word=dictionary, passes=20, alpha=‘auto’, eval_every=5)
gensim/models/ldamodel.py:776: DeprecationWarning: `logsumexp` is deprecated!
```

**Reason**
I dug into the problem and found that scipy 1.0.0 has been released recently.
https://scipy.github.io/devdocs/release.1.0.0.html

In the release they deprecated a number of functions from `scipy.misc`, and `logsumexp` is one of them. The link below is the corresponding commit.
https://github.com/scipy/scipy/pull/7246

**Solution**
I fixed the warning by making `logsumexp` to be imported from `scipy.special`, as they recommend.
Also I checked that, except in LdaModel, `logsumexp` is not used in any other places in gensim .