### PR TITLE
[MRG] Improve segment_wiki script

### DIFF
--- a/gensim/scripts/segment_wiki.py
+++ b/gensim/scripts/segment_wiki.py
@@ -19,10 +19,10 @@ Examples
 
   python -m gensim.scripts.segment_wiki -f enwiki-latest-pages-articles.xml.bz2 -o enwiki-latest.json.gz
 
-Processing the entire English Wikipedia dump (13.5 GB, https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2) \
-takes about 2.5 hours (about 3 million articles per hour, on i7-6700HQ, SSD).
+Processing the entire English Wikipedia dump (14 GB, https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2) \
+takes 2 hours (about 2.5 million articles per hour, on 8 core Intel Xeon E3-1275@3.60GHz).
 
-You can then read the created output with:
+You can then read the created output (~6.1 GB gzipped) with:
 
 >>> # iterate over the plain text file we just created
 >>> for line in smart_open('enwiki-latest.json.gz'):

--- a/gensim/scripts/segment_wiki.py
+++ b/gensim/scripts/segment_wiki.py
@@ -5,30 +5,25 @@
 # Copyright (C) 2016 RaRe Technologies
 
 """
-Construct a corpus from a Wikipedia (or other MediaWiki-based) database dump (typical filename
-is <LANG>wiki-<YYYYMMDD>-pages-articles.xml.bz2 or <LANG>wiki-latest-pages-articles.xml.bz2),
-extract titles, section names, section content and save to json-line format,
-that contains 3 fields ::
+CLI script for processing a raw Wikipedia dump (the xml.bz2 format provided by MediaWiki).
 
-    'title' (str) - title of article,
-    'section_titles' (list) - list of titles of sections,
-    'section_texts' (list) - list of content from sections.
-
-English Wikipedia dump available
-`here <https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2>`_. Approximate time
-for processing is 2.5 hours (i7-6700HQ, SSD).
+It streams through all the XML articles and extracts their plain text. For each article,
+it prints its title, section names and section contents, in json-line format.
 
 Examples
 --------
 
-Convert wiki to json-lines format:
-`python -m gensim.scripts.segment_wiki -f enwiki-latest-pages-articles.xml.bz2 | gzip > enwiki-latest.json.gz`
+The English Wikipedia dump is available
+`here <https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2>`_.
+Its approximate time for processing is 2.5 hours (about 3 million articles per hour, on i7-6700HQ, SSD):
 
-Read json-lines dump
+  python -m gensim.scripts.segment_wiki -f enwiki-latest-pages-articles.xml.bz2 -o enwiki-latest.json.gz
+
+You can then read the created output with:
 
 >>> # iterate over the plain text file we just created
 >>> for line in smart_open('enwiki-latest.json.gz'):
->>>    # decode JSON into a Python object
+>>>    # decode each JSON line into a Python dictionary object
 >>>    article = json.loads(line)
 >>>
 >>>    # each article has a "title", "section_titles" and "section_texts" fields
@@ -36,7 +31,6 @@ Read json-lines dump
 >>>    for section_title, section_text in zip(article['section_titles'], article['section_texts']):
 >>>        print("Section title: %s" % section_title)
 >>>        print("Section text: %s" % section_text)
-
 """
 
 import argparse

--- a/gensim/scripts/segment_wiki.py
+++ b/gensim/scripts/segment_wiki.py
@@ -24,7 +24,7 @@ takes 2 hours (about 2.5 million articles per hour, on 8 core Intel Xeon E3-1275
 
 You can then read the created output (~6.1 GB gzipped) with:
 
->>> # iterate over the plain text file we just created
+>>> # iterate over the plain text data we just created
 >>> for line in smart_open('enwiki-latest.json.gz'):
 >>>    # decode each JSON line into a Python dictionary object
 >>>    article = json.loads(line)
@@ -293,19 +293,20 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter, description=globals()['__doc__'])
     default_workers = max(1, multiprocessing.cpu_count() - 1)
-    parser.add_argument('-f', '--file', help='Path to MediaWiki database dump', required=True)
-    parser.add_argument('-o', '--output', help='Path to output file (stdout if not specified)')
+    parser.add_argument('-f', '--file', help='Path to MediaWiki database dump (read-only).', required=True)
+    parser.add_argument(
+        '-o', '--output',
+        help='Path to output file (stdout if not specified). If ends in .gz or .bz2, '
+             'the output file will be automatically compressed (recommended!).')
     parser.add_argument(
         '-w', '--workers',
-        help='Number of parallel workers for multi-core systems (default: %i)' % default_workers,
+        help='Number of parallel workers for multi-core systems. Default: %(default)s.',
         type=int,
         default=default_workers
     )
     parser.add_argument(
         '-m', '--min-article-character',
-        help="Minimal number of character for article (except titles and leading gaps), "
-             "if article contains less characters that this value, "
-             "article will be filtered (will not be in the output file), default: %(default)s",
+        help="Ignore articles with fewer characters than this (article stubs). Default: %(default)s.",
         default=200
     )
     args = parser.parse_args()

--- a/gensim/scripts/segment_wiki.py
+++ b/gensim/scripts/segment_wiki.py
@@ -5,10 +5,10 @@
 # Copyright (C) 2016 RaRe Technologies
 
 """
-CLI script for processing a raw Wikipedia dump (the xml.bz2 format provided by MediaWiki).
+CLI script for extracting plain text out of a raw Wikipedia dump (the xml.bz2 format provided by MediaWiki).
 
-It streams through all the XML articles, decompressing on the fly and extracting plain text
-sections from each article.
+It streams through all the XML articles using multiple cores (#cores - 1, by default), \
+decompressing on the fly and extracting plain text article sections from each article.
 
 For each article, it prints its title, section names and section contents, in json-line format.
 
@@ -63,8 +63,8 @@ def segment_all_articles(file_path, min_article_character=200, workers=None):
     min_article_character : int, optional
         Minimal number of character for article (except titles and leading gaps).
 
-    workers: int, optional
-        Number of parallel workers for multi-core processing (default: number of cores - 1)
+    workers: int or None
+        Number of parallel workers, max(1, multiprocessing.cpu_count() - 1) if None.
 
     Yields
     ------
@@ -102,8 +102,8 @@ def segment_and_write_all_articles(file_path, output_file, min_article_character
     min_article_character : int, optional
         Minimal number of character for article (except titles and leading gaps).
 
-    workers: int, optional
-        Number of parallel workers for multi-core processing (default: number of cores - 1)
+    workers: int or None
+        Number of parallel workers, max(1, multiprocessing.cpu_count() - 1) if None.
 
     """
     if output_file is None:

--- a/gensim/scripts/segment_wiki.py
+++ b/gensim/scripts/segment_wiki.py
@@ -119,7 +119,7 @@ def segment_and_write_all_articles(file_path, output_file, min_article_character
                 output_data["section_titles"].append(section_heading)
                 output_data["section_texts"].append(section_content)
             if (idx + 1) % 100000 == 0:
-                logger.info("Processed #%d articles", idx + 1)
+                logger.info("processed #%d articles (at %r now)", idx + 1, article_title)
             outfile.write(json.dumps(output_data) + "\n")
     finally:
         outfile.close()

--- a/gensim/scripts/segment_wiki.py
+++ b/gensim/scripts/segment_wiki.py
@@ -5,7 +5,9 @@
 # Copyright (C) 2016 RaRe Technologies
 
 """
-CLI script for extracting plain text out of a raw Wikipedia dump (the xml.bz2 format provided by MediaWiki).
+CLI script for extracting plain text out of a raw Wikipedia dump. This is a xml.bz2 file provided by MediaWiki \
+and looks like <LANG>wiki-<YYYYMMDD>-pages-articles.xml.bz2 or <LANG>wiki-latest-pages-articles.xml.bz2 \
+(e.g. 14 GB: https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2).
 
 It streams through all the XML articles using multiple cores (#cores - 1, by default), \
 decompressing on the fly and extracting plain text article sections from each article.
@@ -19,8 +21,8 @@ Examples
 
   python -m gensim.scripts.segment_wiki -f enwiki-latest-pages-articles.xml.bz2 -o enwiki-latest.json.gz
 
-Processing the entire English Wikipedia dump (14 GB, https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2) \
-takes 2 hours (about 2.5 million articles per hour, on 8 core Intel Xeon E3-1275@3.60GHz).
+Processing the entire English Wikipedia dump takes 2 hours (about 2.5 million articles \
+per hour, on 8 core Intel Xeon E3-1275@3.60GHz).
 
 You can then read the created output (~6.1 GB gzipped) with:
 


### PR DESCRIPTION
This PR cleans up the documentation of the `segment_wiki.py` script, continuing from #1694.

I also added a new `-w` option to the script, letting users control the number of workers.

I also fixed some broken formatting in the [release notes](https://github.com/RaRe-Technologies/gensim/releases/tag/3.1.0) in the section on segment_wiki.

