### PR TITLE
Make token2id mapping reproducible

### DIFF
--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -149,7 +149,7 @@ class Dictionary(utils.SaveLoad, Mapping):
         token2id = self.token2id
         if allow_update or return_missing:
             missing = {w: freq for w, freq in iteritems(counter) if w not in token2id}
-            missing = OrderedDict(sorted(missing.items(), key=lambda x: (x[1], x[0])))
+            missing = OrderedDict(sorted(iteritems(missing), key=lambda x: (x[1], x[0])))
             if allow_update:
                 for w in missing:
                     # new id = number of ids made so far;
@@ -249,15 +249,15 @@ class Dictionary(utils.SaveLoad, Mapping):
         if bad_ids is not None:
             bad_ids = set(bad_ids)
             token2id = {token: tokenid for token, tokenid in iteritems(self.token2id) if tokenid not in bad_ids}
-            self.token2id = OrderedDict(sorted(token2id.items(), key=lambda x: (x[1], x[0])))
+            self.token2id = OrderedDict(sorted(iteritems(token2id), key=lambda x: (x[1], x[0])))
             dfs = {tokenid: freq for tokenid, freq in iteritems(self.dfs) if tokenid not in bad_ids}
-            self.dfs = OrderedDict(sorted(dfs.items(), key=lambda x: (x[0], x[1])))
+            self.dfs = OrderedDict(sorted(iteritems(dfs), key=lambda x: (x[0], x[1])))
         if good_ids is not None:
             good_ids = set(good_ids)
             token2id = {token: tokenid for token, tokenid in iteritems(self.token2id) if tokenid in good_ids}
-            self.token2id = OrderedDict(sorted(token2id.items(), key=lambda x: (x[1], x[0])))
+            self.token2id = OrderedDict(sorted(iteritems(token2id), key=lambda x: (x[1], x[0])))
             dfs = {tokenid: freq for tokenid, freq in iteritems(self.dfs) if tokenid in good_ids}
-            self.dfs = OrderedDict(sorted(dfs.items(), key=lambda x: (x[0], x[1])))
+            self.dfs = OrderedDict(sorted(iteritems(dfs), key=lambda x: (x[0], x[1])))
 
         self.compactify()
 
@@ -276,10 +276,10 @@ class Dictionary(utils.SaveLoad, Mapping):
 
         # reassign mappings to new ids
         token2id = {token: idmap[tokenid] for token, tokenid in iteritems(self.token2id)}
-        self.token2id = OrderedDict(sorted(token2id.items(), key=lambda x: (x[1], x[0])))
+        self.token2id = OrderedDict(sorted(iteritems(token2id), key=lambda x: (x[1], x[0])))
         self.id2token = {}
         dfs = {idmap[tokenid]: freq for tokenid, freq in iteritems(self.dfs)}
-        self.dfs = OrderedDict(sorted(dfs.items(), key=lambda x: (x[0], x[1])))
+        self.dfs = OrderedDict(sorted(iteritems(dfs), key=lambda x: (x[0], x[1])))
 
     def save_as_text(self, fname, sort_by_word=True):
         """

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -148,7 +148,7 @@ class Dictionary(utils.SaveLoad, Mapping):
 
         token2id = self.token2id
         if allow_update or return_missing:
-            missing = sorted((x for x in iteritems(counter) if x[0] not in token2id), key=lambda x: x[0])
+            missing = sorted(x for x in iteritems(counter) if x[0] not in token2id)
             if allow_update:
                 for w, _ in missing:
                     # new id = number of ids made so far;

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -148,7 +148,7 @@ class Dictionary(utils.SaveLoad, Mapping):
 
         token2id = self.token2id
         if allow_update or return_missing:
-            missing = sorted((x for x in iteritems(counter) if x[0] not in token2id), key=lambda x: (x[1], x[0]))
+            missing = sorted((x for x in iteritems(counter) if x[0] not in token2id), key=lambda x: x[0])
             if allow_update:
                 for w, _ in missing:
                     # new id = number of ids made so far;


### PR DESCRIPTION
This change modifies the attributes `token2id` and `dfs` of the `gensim.corpora.Dictionary` class to be `OrderedDict`s rather than `dict`s. This ensures deterministic order of elements for consecutive executions regardless of Python version.

Between Python versions 3.3 and 3.6, the order of iteration for sets and dictionaries is randomised before each execution by default (see [link](https://www.python.org/download/releases/3.3.0/)). In prior versions, hash randomisation is disabled by default (see [link](https://mail.python.org/pipermail/python-announce-list/2012-March/009394.html)). As of 3.6, the order of set and dictionary iteration reflects the order in which elements were added, but this is an implementation detail not to be relied upon (see [link](https://docs.python.org/3/whatsnew/3.6.html#whatsnew36-compactdict)). The changes in this PR resolve this issue by ensuring that the mapping behaviour of `gensim.corpora.Dictionary` is consistent across all modern versions of Python and between executions.

Note that unit testing this functionality is not possible because of the quirks of the various Python versions. The problem only manifests between executions, which undermines the reproducibility of experiments using `gensim.corpora.Dictionary`. A minimal working example that demonstrates the problem follows (compare the output between the runs for versions of Python that use hash seed randomisation; 3.5, for example):

```
import gensim.corpora
import sys

print(sys.version)


def extract_words(documents):
    return [[word for word in document.lower().split()
            if word not in stoplist]
            for document in documents]


def main():
    documents = ["Human machine interface for lab abc computer applications",
                 "A survey of user opinion of computer system response time",
                 "The EPS user interface management system",
                 "System and human system engineering testing of EPS",
                 "Relation of user perceived response time to error measurement",
                 "The generation of random binary unordered trees"]

    documents_add = ["The intersection graph of paths in trees",
                     "Graph minors IV Widths of trees and well quasi ordering",
                     "Graph minors A survey"]

    stoplist = set('for a of the and to in'.split())

    texts = extract_words(documents)
    texts_add = extract_words(documents_add)

    dictionary = gensim.corpora.Dictionary(texts)
    dictionary.add_documents(texts_add)

    dictionary.filter_extremes(no_below=1, no_above=0.9)
    dictionary.compactify()

    dictionary.save("dict_test.dict")
    dictionary.load("dict_test.dict")

    result = dictionary.iteritems()
    result = sorted(result, key=lambda x: x[0])

    print(result[:5])
    print(result[-5:])


main()
```

Example output:

```
$ python3.5 ...
Python 3.5.2 (...)
[(0, 'generation'), (1, 'well'), (2, 'intersection'), (3, 'human'), (4, 'response')]
[(30, 'graph'), (31, 'eps'), (32, 'applications'), (33, 'engineering'), (34, 'lab')]

$ python3.5 ...
Python 3.5.2 (...)
[(0, 'computer'), (1, 'paths'), (2, 'testing'), (3, 'machine'), (4, 'minors')]
[(30, 'time'), (31, 'abc'), (32, 'unordered'), (33, 'ordering'), (34, 'relation')]
```