### PR TITLE
Add functionality in TextCorpus to convert document text to index vectors

### DIFF
--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -176,8 +176,7 @@ class Dictionary(utils.SaveLoad, Mapping):
     def doc2idx(self, document, unknown_word_index=-1):
         """Convert `document` (a list of words) into a list of indexes = list of `token_id`.
 
-        Each word is assumed to be a **tokenized and normalized** string
-        (either unicode or utf8-encoded).
+        Each word is assumed to be a **tokenized and normalized** string (either unicode or utf8-encoded).
         No further preprocessing is done on the words in `document`; apply tokenization, stemming etc. before calling
         this method.
 
@@ -186,19 +185,26 @@ class Dictionary(utils.SaveLoad, Mapping):
 
         Notes
         -----
-            This function is `const`, aka read-only
+        This function is `const`, aka read-only
 
         Parameters
         ----------
-        document : list
-            List of words tokenized, normalized and preprocessed.
+        document : list of str
+            Tokenized, normalized and preprocessed words
         unknown_word_index : int, optional
             Index to use for words not in the dictionary.
 
         Returns
         -------
-        list
-            List of indexes in the dictionary for words in the `document`
+        list of int
+            Indexes in the dictionary for words in the `document` preserving the order of words
+
+        Examples
+        --------
+        >>> dictionary_obj = Dictionary()
+        >>> dictionary_obj.token2id = {'computer': 0, 'human': 1, 'response': 2, 'survey': 3}
+        >>> dictionary_obj.doc2idx(document=['human', 'computer', 'interface'], unknown_word_index=-1)
+        [1, 0, -1]
 
         """
         if isinstance(document, string_types):

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -173,6 +173,36 @@ class Dictionary(utils.SaveLoad, Mapping):
         else:
             return result
 
+    def doc2idx(self, document, unk_wrd_idx=0):
+        """
+        Convert `document` (a list of words) into a list of indexes = list
+        of `token_id`. Each word is assumed to be a **tokenized and normalized** string (either unicode or utf8-encoded)
+        No further preprocessing is done on the words in `document`; apply tokenization, stemming etc. before calling
+        this method.
+
+        Replace all unknown ie, words not in the dictionary presently with the index as set via `unk_wrd_idx`, defaults
+        to 0.
+
+        This function is `const`, aka read-only
+        """
+        if isinstance(document, string_types): 
+            raise TypeError("doc2idx expects an array of unicode tokens on input, not a single string") 
+ 
+        token2id = self.token2id
+
+        list_word_idx = list() 
+        for word in document: 
+            word = word if isinstance(word, unicode) else unicode(word, 'utf-8')
+ 
+            wrd_idx = token2id.get(word, None) 
+ 
+            if wrd_idx is not None: 
+                list_word_idx.append(wrd_idx)
+            else:
+                list_word_idx.append(unk_wrd_idx)
+
+        return list_word_idx 
+
     def filter_extremes(self, no_below=5, no_above=0.5, keep_n=100000, keep_tokens=None):
         """
         Filter out tokens that appear in

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -188,7 +188,7 @@ class Dictionary(utils.SaveLoad, Mapping):
         """
         if isinstance(document, string_types):
             raise TypeError("doc2idx expects an array of unicode tokens on input, not a single string")
- 
+
         token2id = self.token2id
 
         list_word_idx = list()

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -181,7 +181,8 @@ class Dictionary(utils.SaveLoad, Mapping):
         No further preprocessing is done on the words in `document`; apply tokenization, stemming etc. before calling
         this method.
 
-        Replace all unknown i.e, words not in the dictionary with the index as set via `unk_wrd_idx`, defaults to 0.
+        Replace all unknown words i.e, words not in the dictionary with the index as set via `unk_wrd_idx`, defaults to
+        0.
 
         This function is `const`, aka read-only
         """

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -176,12 +176,12 @@ class Dictionary(utils.SaveLoad, Mapping):
     def doc2idx(self, document, unk_wrd_idx=0):
         """
         Convert `document` (a list of words) into a list of indexes = list
-        of `token_id`. Each word is assumed to be a **tokenized and normalized** string (either unicode or utf8-encoded)
+        of `token_id`. Each word is assumed to be a **tokenized and normalized** string
+        (either unicode or utf8-encoded).
         No further preprocessing is done on the words in `document`; apply tokenization, stemming etc. before calling
         this method.
 
-        Replace all unknown ie, words not in the dictionary presently with the index as set via `unk_wrd_idx`, defaults
-        to 0.
+        Replace all unknown i.e, words not in the dictionary with the index as set via `unk_wrd_idx`, defaults to 0.
 
         This function is `const`, aka read-only
         """

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -173,36 +173,39 @@ class Dictionary(utils.SaveLoad, Mapping):
         else:
             return result
 
-    def doc2idx(self, document, unk_wrd_idx=0):
-        """
-        Convert `document` (a list of words) into a list of indexes = list
-        of `token_id`. Each word is assumed to be a **tokenized and normalized** string
+    def doc2idx(self, document, unknown_word_index=-1):
+        """Convert `document` (a list of words) into a list of indexes = list of `token_id`.
+
+        Each word is assumed to be a **tokenized and normalized** string
         (either unicode or utf8-encoded).
         No further preprocessing is done on the words in `document`; apply tokenization, stemming etc. before calling
         this method.
 
-        Replace all unknown words i.e, words not in the dictionary with the index as set via `unk_wrd_idx`, defaults to
-        0.
+        Replace all unknown words i.e, words not in the dictionary with the index as set via `unknown_word_index`,
+        defaults to -1.
 
-        This function is `const`, aka read-only
+        Notes
+        -----
+            This function is `const`, aka read-only
+
+        Parameters
+        ----------
+        document : list
+            List of words tokenized, normalized and preprocessed.
+        unknown_word_index : int, optional
+            Index to use for words not in the dictionary.
+
+        Returns
+        -------
+        list
+            List of indexes in the dictionary for words in the `document`
+
         """
         if isinstance(document, string_types):
             raise TypeError("doc2idx expects an array of unicode tokens on input, not a single string")
 
-        token2id = self.token2id
-
-        list_word_idx = list()
-        for word in document:
-            word = word if isinstance(word, unicode) else unicode(word, 'utf-8')
-
-            wrd_idx = token2id.get(word, None)
-
-            if wrd_idx is not None:
-                list_word_idx.append(wrd_idx)
-            else:
-                list_word_idx.append(unk_wrd_idx)
-
-        return list_word_idx
+        document = [word if isinstance(word, unicode) else unicode(word, 'utf-8') for word in document]
+        return [self.token2id.get(word, unknown_word_index) for word in document]
 
     def filter_extremes(self, no_below=5, no_above=0.5, keep_n=100000, keep_tokens=None):
         """

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -186,23 +186,23 @@ class Dictionary(utils.SaveLoad, Mapping):
 
         This function is `const`, aka read-only
         """
-        if isinstance(document, string_types): 
-            raise TypeError("doc2idx expects an array of unicode tokens on input, not a single string") 
+        if isinstance(document, string_types):
+            raise TypeError("doc2idx expects an array of unicode tokens on input, not a single string")
  
         token2id = self.token2id
 
-        list_word_idx = list() 
-        for word in document: 
+        list_word_idx = list()
+        for word in document:
             word = word if isinstance(word, unicode) else unicode(word, 'utf-8')
- 
-            wrd_idx = token2id.get(word, None) 
- 
-            if wrd_idx is not None: 
+
+            wrd_idx = token2id.get(word, None)
+
+            if wrd_idx is not None:
                 list_word_idx.append(wrd_idx)
             else:
                 list_word_idx.append(unk_wrd_idx)
 
-        return list_word_idx 
+        return list_word_idx
 
     def filter_extremes(self, no_below=5, no_above=0.5, keep_n=100000, keep_tokens=None):
         """

--- a/gensim/corpora/textcorpus.py
+++ b/gensim/corpora/textcorpus.py
@@ -114,10 +114,8 @@ class TextCorpus(interfaces.CorpusABC):
     6.  remove stopwords; see `gensim.parsing.preprocessing` for the list of stopwords
 
     """
-    def __init__(
-            self, input=None, dictionary=None, metadata=False, character_filters=None, tokenizer=None,
-            token_filters=None, bow_format=True, unk_wrd_idx=0
-    ):
+    def __init__(self, input=None, dictionary=None, metadata=False, character_filters=None, tokenizer=None,
+                 token_filters=None, bow_format=True, unknown_word_index=-1):
         """
         Args:
             input (str): path to top-level directory to traverse for corpus documents.
@@ -141,7 +139,8 @@ class TextCorpus(interfaces.CorpusABC):
                 in `gensim.parsing.preprocessing.STOPWORDS`.
             bow_format (bool): True to return BoW format (default) else return index vector as per
                 the `dictionary` if False
-            unk_wrd_idx (int): index to represent unknown words, i.e, words not in the `dictionary`
+            unknown_word_index (int): index to represent unknown words (default -1), i.e, words not
+                in the `dictionary`
         """
         self.input = input
         self.metadata = metadata
@@ -163,7 +162,7 @@ class TextCorpus(interfaces.CorpusABC):
         self.init_dictionary(dictionary)
 
         self.bow_format = bow_format
-        self.unk_wrd_idx = unk_wrd_idx
+        self.unknown_word_index = unknown_word_index
 
     def init_dictionary(self, dictionary):
         """If `dictionary` is None, initialize to an empty Dictionary, and then if there
@@ -193,13 +192,13 @@ class TextCorpus(interfaces.CorpusABC):
                 if self.bow_format:
                     yield self.dictionary.doc2bow(text, allow_update=False), metadata
                 else:
-                    yield self.dictionary.doc2idx(text, unk_wrd_idx=self.unk_wrd_idx), metadata
+                    yield self.dictionary.doc2idx(text, unknown_word_index=self.unknown_word_index), metadata
         else:
             for text in self.get_texts():
                 if self.bow_format:
                     yield self.dictionary.doc2bow(text, allow_update=False)
                 else:
-                    yield self.dictionary.doc2idx(text, unk_wrd_idx=self.unk_wrd_idx)
+                    yield self.dictionary.doc2idx(text, unknown_word_index=self.unknown_word_index)
 
     def getstream(self):
         """Yield documents from the underlying plain text collection (of one or more files).

--- a/gensim/corpora/textcorpus.py
+++ b/gensim/corpora/textcorpus.py
@@ -65,7 +65,7 @@ def strip_multiple_whitespaces(s):
 
 class TextCorpus(interfaces.CorpusABC):
     """Helper class to simplify the pipeline of getting bag-of-words vectors (= a
-    gensim corpus) or an index vector from plain text.
+    gensim corpus) from plain text.
 
     This is an abstract base class: override the `get_texts()` and `__len__()`
     methods to match your particular input.
@@ -76,9 +76,7 @@ class TextCorpus(interfaces.CorpusABC):
     this class via subclassing or by construction with different preprocessing arguments.
 
     The `iter` method converts the lists of tokens produced by `get_texts` to BoW format
-    if `bow_format` is set to True (default) using `Dictionary.doc2bow` or to an index vector
-    if `bow_format` is set to False using `Dictionary.doc2idx`.
-    `get_texts` does the following:
+    using `Dictionary.doc2bow`. `get_texts` does the following:
 
     1.  Calls `getstream` to get a generator over the texts. It yields each document in
         turn from the underlying text file or files.
@@ -115,7 +113,7 @@ class TextCorpus(interfaces.CorpusABC):
 
     """
     def __init__(self, input=None, dictionary=None, metadata=False, character_filters=None, tokenizer=None,
-                 token_filters=None, bow_format=True, unknown_word_index=-1):
+                 token_filters=None):
         """
         Args:
             input (str): path to top-level directory to traverse for corpus documents.
@@ -137,10 +135,6 @@ class TextCorpus(interfaces.CorpusABC):
                 remove, or replace tokens, or do nothing at all. The default token filters
                 remove tokens less than 3 characters long and remove stopwords using the list
                 in `gensim.parsing.preprocessing.STOPWORDS`.
-            bow_format (bool): True to return BoW format (default) else return index vector as per
-                the `dictionary` if False
-            unknown_word_index (int): index to represent unknown words (default -1), i.e, words not
-                in the `dictionary`
         """
         self.input = input
         self.metadata = metadata
@@ -160,9 +154,6 @@ class TextCorpus(interfaces.CorpusABC):
         self.length = None
         self.dictionary = None
         self.init_dictionary(dictionary)
-
-        self.bow_format = bow_format
-        self.unknown_word_index = unknown_word_index
 
     def init_dictionary(self, dictionary):
         """If `dictionary` is None, initialize to an empty Dictionary, and then if there
@@ -189,16 +180,10 @@ class TextCorpus(interfaces.CorpusABC):
         """
         if self.metadata:
             for text, metadata in self.get_texts():
-                if self.bow_format:
-                    yield self.dictionary.doc2bow(text, allow_update=False), metadata
-                else:
-                    yield self.dictionary.doc2idx(text, unknown_word_index=self.unknown_word_index), metadata
+                yield self.dictionary.doc2bow(text, allow_update=False), metadata
         else:
             for text in self.get_texts():
-                if self.bow_format:
-                    yield self.dictionary.doc2bow(text, allow_update=False)
-                else:
-                    yield self.dictionary.doc2idx(text, unknown_word_index=self.unknown_word_index)
+                yield self.dictionary.doc2bow(text, allow_update=False)
 
     def getstream(self):
         """Yield documents from the underlying plain text collection (of one or more files).

--- a/gensim/corpora/textcorpus.py
+++ b/gensim/corpora/textcorpus.py
@@ -76,8 +76,8 @@ class TextCorpus(interfaces.CorpusABC):
     this class via subclassing or by construction with different preprocessing arguments.
 
     The `iter` method converts the lists of tokens produced by `get_texts` to BoW format
-    if `bow_format` is set to True or to an index vector if `bow_format` is set to False using
-    `Dictionary.doc2bow`.
+    if `bow_format` is set to True (default) using `Dictionary.doc2bow` or to an index vector
+    if `bow_format` is set to False using `Dictionary.doc2idx`.
     `get_texts` does the following:
 
     1.  Calls `getstream` to get a generator over the texts. It yields each document in

--- a/gensim/corpora/textcorpus.py
+++ b/gensim/corpora/textcorpus.py
@@ -139,7 +139,8 @@ class TextCorpus(interfaces.CorpusABC):
                 remove, or replace tokens, or do nothing at all. The default token filters
                 remove tokens less than 3 characters long and remove stopwords using the list
                 in `gensim.parsing.preprocessing.STOPWORDS`.
-            mode (bool): True to return BoW format (default) else return index vector as per the `dictionary` if False
+            bow_format (bool): True to return BoW format (default) else return index vector as per
+                the `dictionary` if False
             unk_wrd_idx (int): index to represent unknown words, i.e, words not in the `dictionary`
         """
         self.input = input

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -20,7 +20,7 @@ import unittest
 import numpy as np
 
 from gensim.corpora import (bleicorpus, mmcorpus, lowcorpus, svmlightcorpus,
-                            ucicorpus, malletcorpus, textcorpus, indexedcorpus)
+                            ucicorpus, malletcorpus, textcorpus, indexedcorpus, dictionary)
 from gensim.interfaces import TransformedCorpus
 from gensim.utils import to_unicode
 from gensim.test.utils import datapath, get_tmpfile
@@ -322,6 +322,23 @@ class TestTextCorpus(CorpusTestCase):
         for i, docmeta in enumerate(docs):
             doc, metadata = docmeta
             self.assertEqual(metadata[0], i)
+
+    def test_load_with_index_vector_mode(self):
+        dictionary_obj = dictionary.Dictionary()
+        dictionary_obj.token2id = {
+            '<UNK>': 0, 'computer': 1, 'human': 2, 'response': 3, 'survey': 4,
+            'system': 5, 'time': 6, 'user': 7, 'graph': 8, 'eps': 9, 'trees': 10,
+            'minors': 11
+        }
+        fname = datapath('testcorpus.' + self.file_extension.lstrip('.'))
+        corpus = self.corpus_class(
+            fname, dictionary=dictionary_obj, token_filters=[], bow_format=False, unk_wrd_idx=0
+        )
+
+        docs = list(corpus)
+        first_doc, last_doc = docs[0], docs[-1]
+        self.assertEqual(first_doc, [1, 2, 0])
+        self.assertEqual(last_doc, [4, 8, 11])
 
     def test_default_preprocessing(self):
         lines = [

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -20,7 +20,7 @@ import unittest
 import numpy as np
 
 from gensim.corpora import (bleicorpus, mmcorpus, lowcorpus, svmlightcorpus,
-                            ucicorpus, malletcorpus, textcorpus, indexedcorpus, dictionary)
+                            ucicorpus, malletcorpus, textcorpus, indexedcorpus)
 from gensim.interfaces import TransformedCorpus
 from gensim.utils import to_unicode
 from gensim.test.utils import datapath, get_tmpfile
@@ -322,23 +322,6 @@ class TestTextCorpus(CorpusTestCase):
         for i, docmeta in enumerate(docs):
             doc, metadata = docmeta
             self.assertEqual(metadata[0], i)
-
-    def test_load_with_index_vector_mode(self):
-        dictionary_obj = dictionary.Dictionary()
-        dictionary_obj.token2id = {
-            'word': 0, 'computer': 1, 'human': 2, 'response': 3, 'survey': 4,
-            'system': 5, 'time': 6, 'user': 7, 'graph': 8, 'eps': 9, 'trees': 10,
-            'minors': 11
-        }
-        fname = datapath('testcorpus.' + self.file_extension.lstrip('.'))
-        corpus = self.corpus_class(
-            fname, dictionary=dictionary_obj, token_filters=[], bow_format=False, unknown_word_index=-1
-        )
-
-        docs = list(corpus)
-        first_doc, last_doc = docs[0], docs[-1]
-        self.assertEqual(first_doc, [1, 2, -1])
-        self.assertEqual(last_doc, [4, 8, 11])
 
     def test_default_preprocessing(self):
         lines = [

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -326,18 +326,18 @@ class TestTextCorpus(CorpusTestCase):
     def test_load_with_index_vector_mode(self):
         dictionary_obj = dictionary.Dictionary()
         dictionary_obj.token2id = {
-            '<UNK>': 0, 'computer': 1, 'human': 2, 'response': 3, 'survey': 4,
+            'word': 0, 'computer': 1, 'human': 2, 'response': 3, 'survey': 4,
             'system': 5, 'time': 6, 'user': 7, 'graph': 8, 'eps': 9, 'trees': 10,
             'minors': 11
         }
         fname = datapath('testcorpus.' + self.file_extension.lstrip('.'))
         corpus = self.corpus_class(
-            fname, dictionary=dictionary_obj, token_filters=[], bow_format=False, unk_wrd_idx=0
+            fname, dictionary=dictionary_obj, token_filters=[], bow_format=False, unknown_word_index=-1
         )
 
         docs = list(corpus)
         first_doc, last_doc = docs[0], docs[-1]
-        self.assertEqual(first_doc, [1, 2, 0])
+        self.assertEqual(first_doc, [1, 2, -1])
         self.assertEqual(last_doc, [4, 8, 11])
 
     def test_default_preprocessing(self):


### PR DESCRIPTION
TextCorpus doesn't provide a way to convert document text to index vector as needed for say DL NLP models.
Adding a 'doc2idx' to Dictionary object and creating modes in TextCorpus to leverage this functionality.
Referencing issue #1634