### PR TITLE
Fix slowdown of CI, remove pytest-cov

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,6 @@ distributed_env = ['Pyro4 >= 4.27']
 win_testenv = [
     'pytest',
     'pytest-rerunfailures',
-    'pytest-cov',
     'cython',
     'pyemd',
     'testfixtures',

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ builtins = get_ipython
 
 
 [pytest]
-addopts = -rfxEXs --durations=20 --showlocals --rerun 3 --cov=gensim --cov-report term
+addopts = -rfxEXs --durations=20 --showlocals --rerun 3
 
 
 [testenv]


### PR DESCRIPTION
Fix problem produced by #1721. 
All works fine, but CI slowdown twice, problem with `pytest-cov` plugin (module `coverage`), this is buggy and gives x2 overhead for testing by time.

What's done:
- [x] Removed `pytest-cov` plugin
- [x] Archived previous time for CI (21-32 minutes for Travis (vs 40-48), 11-16 minutes for Appveyor (vs 20-25))