### PR TITLE
Add flag for hiding outdated data for gensim.downloader.info

### DIFF
--- a/gensim/downloader.py
+++ b/gensim/downloader.py
@@ -154,14 +154,14 @@ def _calculate_md5_checksum(fname):
     return hash_md5.hexdigest()
 
 
-def info(name=None, actual=True):
+def info(name=None, show_only_latest=True):
     """Provide the information related to model/dataset.
 
     Parameters
     ----------
     name : str, optional
         Name of model/dataset.  If not set - shows all available data.
-    actual : bool, optional
+    show_only_latest : bool, optional
         If storage contains different versions for one data/model, this flag allow to hide outdated versions.
         Affects only if `name` is None.
 
@@ -202,12 +202,12 @@ def info(name=None, actual=True):
         else:
             raise ValueError("Incorrect model/corpus name")
 
-    if not actual:
+    if not show_only_latest:
         return information
 
     return {
-        "corpora": {name: data for (name, data) in information['corpora'].items() if data.get("actual", True)},
-        "models": {name: data for (name, data) in information['models'].items() if data.get("actual", True)}
+        "corpora": {name: data for (name, data) in information['corpora'].items() if data.get("latest", True)},
+        "models": {name: data for (name, data) in information['models'].items() if data.get("latest", True)}
     }
 
 

--- a/gensim/downloader.py
+++ b/gensim/downloader.py
@@ -206,8 +206,8 @@ def info(name=None, actual=True):
         return information
 
     return {
-        "corpora": [dataset for dataset in information['corpora'] if dataset.get("actual", True)],
-        "models": [model for model in information['models'] if model.get("actual", True)]
+        "corpora": {name: data for (name, data) in information['corpora'].items() if data.get("actual", True)},
+        "models": {name: data for (name, data) in information['models'].items() if data.get("actual", True)}
     }
 
 

--- a/gensim/downloader.py
+++ b/gensim/downloader.py
@@ -154,13 +154,16 @@ def _calculate_md5_checksum(fname):
     return hash_md5.hexdigest()
 
 
-def info(name=None):
+def info(name=None, actual=True):
     """Provide the information related to model/dataset.
 
     Parameters
     ----------
     name : str, optional
-        Name of model/dataset.
+        Name of model/dataset.  If not set - shows all available data.
+    actual : bool, optional
+        If storage contains different versions for one data/model, this flag allow to hide outdated versions.
+        Affects only if `name` is None.
 
     Returns
     -------
@@ -198,8 +201,14 @@ def info(name=None):
             return information['models'][name]
         else:
             raise ValueError("Incorrect model/corpus name")
-    else:
+
+    if not actual:
         return information
+
+    return {
+        "corpora": [dataset for dataset in information['corpora'] if dataset.get("actual", True)],
+        "models": [model for model in information['models'] if model.get("actual", True)]
+    }
 
 
 def _get_checksum(name, part=None):


### PR DESCRIPTION
We want to have "immutable" data in [gensim-data](https://github.com/RaRe-Technologies/gensim-data) repository (i.e. `api.load("anyname")` **must** return always exactly same data), but some dataset/models periodically updated and we want to support new versions (for example - wikipedia).

For this reason, I added `show_only_latest` flag to `info` function, this allows showing only latest version of datasets (for example, if we have `wiki-english-20170101` and `wiki-english-20170201` in storage, only `wiki-english-20170201` will be showed). 
Besides, the old version will be showed if `show_only_latest==False` and can be loaded always (by name).