### PR TITLE
Fix PyPI long description rendering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,7 @@ When `citing gensim in academic papers and theses <https://scholar.google.cz/cit
 
   @inproceedings{rehurek_lrec,
         title = {{Software Framework for Topic Modelling with Large Corpora}},
-        author = {Radim {\v R}eh{\r u}{\v r}ek and Petr Sojka},
+        author = {Radim {\\v R}eh{\\r u}{\\v r}ek and Petr Sojka},
         booktitle = {{Proceedings of the LREC 2010 Workshop on New
              Challenges for NLP Frameworks}},
         pages = {45--50},


### PR DESCRIPTION
Currently the rendering of gensim's reStructuredText description on PyPI
is broken[[1]](https://pypi.python.org/pypi/gensim/3.1.0/)[[2]](https://pypi.org/project/gensim/3.1.0/), because some characters aren't escaped properly[[3]](http://docutils.sourceforge.net/docs/user/rst/quickref.html#escaping):

>reStructuredText uses backslashes ("\") to override the special meaning
>given to markup characters and get the literal characters themselves.
>To get a literal backslash, use an escaped backslash ("\\").