### PR TITLE
inline logsumexp()

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update \
     python-pip=8.1.1-2ubuntu0.4 \
     python-setuptools=20.7.0-1 \
     unzip=6.0-20ubuntu1 \
-    wget=1.17.1-1ubuntu1.1 \
-    subversion=1.9.3-2ubuntu1 \
+    wget=1.17.1-1ubuntu1.3 \
+    subversion=1.9.3-2ubuntu1.1 \
     locales=2.23-0ubuntu9 \
     libopenblas-dev=0.2.18-1ubuntu1 \
     libboost-program-options-dev=1.58.0.1ubuntu1 \

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -47,14 +47,26 @@ from gensim.matutils import kullback_leibler, hellinger, jaccard_distance, jense
 from gensim.models import basemodel, CoherenceModel
 from gensim.models.callbacks import Callback
 
-# log(sum(exp(x))) that tries to avoid overflow
-try:
-    from scipy.special import logsumexp
-except ImportError:
-    from scipy.misc import logsumexp
-
 
 logger = logging.getLogger('gensim.models.ldamodel')
+
+
+def logsumexp(x):
+    """
+    barebones log-sum-exp that tries to avoid overflows
+
+    Args:
+        x: 1d ndarray
+
+    Note:
+        does not support NaNs
+
+    """
+    x_max = np.max(x)
+    x = np.log(np.sum(np.exp(x - x_max)))
+    x += x_max
+
+    return x
 
 
 def update_dir_prior(prior, N, logphat, rho):


### PR DESCRIPTION
scipy's logsumexp performs some robustness checks that are likely not necessary for ldamodel.  Inlining a barebones version of logsumexp speeds up ldamodel by 20-40%