### PR TITLE
inline a barebones version of logsumexp for improved performance

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -52,16 +52,25 @@ logger = logging.getLogger('gensim.models.ldamodel')
 
 
 def logsumexp(x):
+    """Log of sum of exponentials
+
+    Parameters
+    ----------
+    x : array_like
+        Input data
+
+    Returns
+    -------
+    float
+        log of sum of exponentials of elements in `x`
+
+    Notes
+    -----
+        for performance, does not support NaNs or > 1d arrays like 
+        scipy.special.logsumexp()
+
     """
-    barebones log-sum-exp that tries to avoid overflows
 
-    Args:
-        x: 1d ndarray
-
-    Note:
-        does not support NaNs
-
-    """
     x_max = np.max(x)
     x = np.log(np.sum(np.exp(x - x_max)))
     x += x_max

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -66,7 +66,7 @@ def logsumexp(x):
 
     Notes
     -----
-        for performance, does not support NaNs or > 1d arrays like 
+        for performance, does not support NaNs or > 1d arrays like
         scipy.special.logsumexp()
 
     """

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -47,14 +47,26 @@ from gensim.matutils import kullback_leibler, hellinger, jaccard_distance, jense
 from gensim.models import basemodel, CoherenceModel
 from gensim.models.callbacks import Callback
 
-# log(sum(exp(x))) that tries to avoid overflow
-try:
-    from scipy.special import logsumexp
-except ImportError:
-    from scipy.misc import logsumexp
-
 
 logger = logging.getLogger('gensim.models.ldamodel')
+
+
+def logsumexp(x):
+    """
+    barebones log-sum-exp that tries to avoid overflows
+
+    Args:
+        x: 1d ndarray
+
+    Note:
+        does not support NaNs
+
+    """
+    x_max = np.max(x)
+    x = np.log(np.sum(np.exp(x - x_max)))
+    x += x_max
+
+    return x
 
 
 def update_dir_prior(prior, N, logphat, rho):


### PR DESCRIPTION
logsumexp accounts for 50% of the run time of ldamodel.  Much
of this time is spent by "robustness" checks performed by
scipy's logsumexp (eg, _asarray_validated, checks for NaNs, etc.).

Removing these checks greatly improves the overall performance
of ldamodel.  Eg, run time when fitting a lda model on the
enron dataset (from UCI) decreases from 20-40%.