### PR TITLE
Optimize segment_wiki script

### DIFF
--- a/gensim/scripts/segment_wiki.py
+++ b/gensim/scripts/segment_wiki.py
@@ -270,7 +270,7 @@ class _WikiSectionsCorpus(WikiCorpus):
         skipped_namespace, skipped_length, skipped_redirect = 0, 0, 0
         total_articles, total_sections = 0, 0
         page_xmls = extract_page_xmls(self.fileobj)
-        pool = multiprocessing.Pool(self.processes)            
+        pool = multiprocessing.Pool(self.processes)
         for article_title, sections in pool.imap_unordered(segment, page_xmls, chunksize=10):
             # article redirects are pruned here
             if any(article_title.startswith(ignore + ':') for ignore in IGNORED_NAMESPACES):  # filter non-articles

--- a/gensim/scripts/segment_wiki.py
+++ b/gensim/scripts/segment_wiki.py
@@ -50,11 +50,6 @@ from xml.etree import cElementTree
 from gensim.corpora.wikicorpus import IGNORED_NAMESPACES, WikiCorpus, filter_wiki, get_namespace, utils
 from smart_open import smart_open
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-
 logger = logging.getLogger(__name__)
 
 
@@ -155,9 +150,7 @@ def extract_page_xmls(f):
 
     for _, elem in elems:
         if elem.tag == page_tag:
-            # Pickle object explicitly to send it to the children
-            # as elem.clear() will be called earlier than implicitly serialization of elem
-            yield pickle.dumps(elem)
+            yield cElementTree.tostring(elem)
             # Prune the element tree, as per
             # http://www.ibm.com/developerworks/xml/library/x-hiperfparse/
             # except that we don't need to prune backlinks from the parent
@@ -182,8 +175,7 @@ def segment(page_xml):
         Structure contains (title, [(section_heading, section_content)]).
 
     """
-    # Unpickling object should be faster then creation from string (via cElementTree.fromstring(page_xml))
-    elem = pickle.loads(page_xml)
+    elem = cElementTree.fromstring(page_xml)
     filter_namespaces = ('0',)
     namespace = get_namespace(elem.tag)
     ns_mapping = {"ns": namespace}


### PR DESCRIPTION
In previous scheme the main process and workers worked in parallel but not concurrently. Actually work are executed or worker processes (parsing and search sections) or main process (parsing xml and collecting results) but not at the same time. Oops. I try to fix it via imap and constant strain on the workers.

Actually I've checked on small part of wiki (~400 мб) but processing time decreased from 7 min to 3min 40-50s.