### PR TITLE
[MRG] Fixes incorrect vectors learned during online training for `FastText` models

### DIFF
--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -228,7 +228,7 @@ class FastText(Word2Vec):
 
     def get_vocab_word_vecs(self):
         for w, v in self.wv.vocab.items():
-            word_vec = self.wv.syn0_vocab[v.index]
+            word_vec = np.copy(self.wv.syn0_vocab[v.index])
             ngrams = self.wv.ngrams_word[w]
             ngram_weights = self.wv.syn0_ngrams
             for ngram in ngrams:

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -419,6 +419,8 @@ class TestFastTextModel(unittest.TestCase):
         self.assertTrue(all(['terrorism' not in l for l in others]))
         model.build_vocab(others)
         model.train(others, total_examples=model.corpus_count, epochs=model.iter)
+        # checks that `syn0` is different from `syn0_vocab`
+        self.assertFalse(np.all(np.equal(model.wv.syn0, model.wv.syn0_vocab)))
         self.assertFalse('terrorism' in model.wv.vocab)
         self.assertFalse('orism>' in model.wv.ngrams)
         model.build_vocab(terro, update=True)  # update vocab

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -457,6 +457,13 @@ class TestFastTextModel(unittest.TestCase):
         )
         self.online_sanity(model)
 
+    def test_get_vocab_word_vecs(self):
+        model = FT_gensim(size=10, min_count=1, seed=42)
+        model.build_vocab(sentences)
+        original_syn0_vocab = np.copy(model.wv.syn0_vocab)
+        model.get_vocab_word_vecs()
+        self.assertTrue(np.all(np.equal(model.wv.syn0_vocab, original_syn0_vocab)))
+
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)


### PR DESCRIPTION
This PR addresses #1752. This bug was caused by incorrect assignment of vectors to `syn0` after training a `FastText` model.