### PR TITLE
Fixes change in dtype of `model.wv.syn0_vocab` on updating `vocab` of a `FastText` model

### DIFF
--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -173,12 +173,12 @@ class FastText(Word2Vec):
             new_vocab_rows = rand_obj.uniform(
                 -1.0 / self.vector_size, 1.0 / self.vector_size,
                 (len(self.wv.vocab) - self.old_vocab_len, self.vector_size)
-            )
+            ).astype(REAL)
             new_vocab_lockf_rows = ones((len(self.wv.vocab) - self.old_vocab_len, self.vector_size), dtype=REAL)
             new_ngram_rows = rand_obj.uniform(
                 -1.0 / self.vector_size, 1.0 / self.vector_size,
                 (len(self.wv.hash2index) - self.old_hash2index_len, self.vector_size)
-            )
+            ).astype(REAL)
             new_ngram_lockf_rows = ones(
                 (len(self.wv.hash2index) - self.old_hash2index_len, self.vector_size), dtype=REAL
             )
@@ -194,11 +194,11 @@ class FastText(Word2Vec):
         for index in range(len(self.wv.vocab)):
             self.wv.syn0_vocab[index] = rand_obj.uniform(
                 -1.0 / self.vector_size, 1.0 / self.vector_size, self.vector_size
-            )
+            ).astype(REAL)
         for index in range(len(self.wv.hash2index)):
             self.wv.syn0_ngrams[index] = rand_obj.uniform(
                 -1.0 / self.vector_size, 1.0 / self.vector_size, self.vector_size
-            )
+            ).astype(REAL)
 
     def _do_train_job(self, sentences, alpha, inits):
         work, neu1 = inits

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -422,6 +422,7 @@ class TestFastTextModel(unittest.TestCase):
         self.assertFalse('terrorism' in model.wv.vocab)
         self.assertFalse('orism>' in model.wv.ngrams)
         model.build_vocab(terro, update=True)  # update vocab
+        self.assertTrue(model.wv.syn0_ngrams.dtype == 'float32')
         self.assertTrue('terrorism' in model.wv.vocab)
         self.assertTrue('orism>' in model.wv.ngrams)
         orig0_all = np.copy(model.wv.syn0_ngrams)


### PR DESCRIPTION
Addresses #1759 by casting numpy array returned by `numpy.random.uniform` to `float32`.