### PR TITLE
Fix epsilon according to dtype in LdaModel

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -287,7 +287,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         """
         if dtype not in {np.float16, np.float32, np.float64}:
-            raise ValueError("Incorrect 'dtype', please choice one of numpy.float16, numpy.float32 or numpy.float64")
+            raise ValueError("Incorrect 'dtype', please choose one of numpy.float16, numpy.float32 or numpy.float64")
 
         self.dtype = dtype
 

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -294,7 +294,9 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         """
         if dtype not in DTYPE_TO_EPS:
-            raise ValueError("Incorrect 'dtype', please choose one of numpy.float16, numpy.float32 or numpy.float64")
+            raise ValueError(
+                "Incorrect 'dtype', please choose one of {}".format(
+                    ", ".join("numpy.{}".format(tp.__name__) for tp in sorted(DTYPE_TO_EPS))))
 
         self.dtype = dtype
 
@@ -507,7 +509,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
             # The optimal phi_{dwk} is proportional to expElogthetad_k * expElogbetad_w.
             # phinorm is the normalizer.
-            # TODO treat zeros explicitly, instead of adding eps?
+            # TODO treat zeros explicitly, instead of adding epsilon?
             eps = DTYPE_TO_EPS[self.dtype]
             phinorm = np.dot(expElogthetad, expElogbetad) + eps
 

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -501,7 +501,12 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             # The optimal phi_{dwk} is proportional to expElogthetad_k * expElogbetad_w.
             # phinorm is the normalizer.
             # TODO treat zeros explicitly, instead of adding 1e-100?
-            eps = 1e-100 if self.dtype == np.float64 else (1e-35 if self.dtype == np.float32 else 1e-5)
+            dtype_to_eps = {
+                np.float16: 1e-5,
+                np.float32: 1e-35,
+                np.float64: 1e-100,
+            }
+            eps = dtype_to_eps[self.dtype]
             phinorm = np.dot(expElogthetad, expElogbetad) + eps
 
             # Iterate between gamma and phi until convergence


### PR DESCRIPTION
That's small fix for #1656, big thanks @rmalouf for catch this potential bug https://github.com/RaRe-Technologies/gensim/pull/1656#issuecomment-345473831

What's done:
- limit number of types (only `numpy.float16`, `numpy.float32`, `numpy.float64`)
- add adoptive `eps` depends on `dtype` (instead of hardcoded `1e-100`)

CC: @piskvorky