### PR TITLE
Description of sg parameter in FastText mixed up

### DIFF
--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -188,7 +188,7 @@ class FastText(Word2Vec):
             If you don't supply `sentences`, the model is left uninitialized -- use if you plan to initialize it
             in some other way.
         sg : int {1, 0}
-            Defines the training algorithm. If 1, CBOW is used, otherwise, skip-gram is employed.
+            Defines the training algorithm. If 1, skip-gram is used, otherwise, CBOW is employed.
         size : int
             Dimensionality of the feature vectors.
         window : int


### PR DESCRIPTION
It was erroneously stated that when sg=1, CBOW is used, otherwise skip-gram is used.
In fact, it is vice versa (quite logically, as sg=SkipGram).
Thus, the description should be fixed.