### PR TITLE
Fix tox.ini/setup.cfg configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [wheelhouse_uploader]
 artifact_indexes=
     # all wheels builded in gensim-wheels repo: https://github.com/MacPython/gensim-wheels
-    http://b153eb958f4da6029aca-3f9dff7fe564350f10153d8c7bfc5ab6.r54.cf2.rackcdn.com/index.html
+    http://b153eb958f4da6029aca-3f9dff7fe564350f10153d8c7bfc5ab6.r54.cf2.rackcdn.com/

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ builtins = get_ipython
 
 
 [pytest]
-addopts = -rfxEXs --durations=20 --showlocals --rerun 3
+addopts = -rfxEXs --durations=20 --showlocals --reruns 3 --reruns-delay 1
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -76,14 +76,13 @@ commands =
 
 
 [testenv:upload-wheels]
-deps = wheelhouse_uploader
+deps = twine
 
-commands = python setup.py register sdist upload
+commands = twine upload dist/*
 
 
 [testenv:test-pypi]
-deps = wheelhouse_uploader
-       twine
+deps = twine
 whitelist_externals = rm
 
 commands =


### PR DESCRIPTION
Small configuration fixes, according to
- some "lessons" from the previous release
- new `pytest_benchmark` version (failed commit in `develop` - a76915cca2019f1c23a2307ec5dcf36c665d73b1)