### PR TITLE
Fix positional params used for `gensim.models.CoherenceModel` in `gensim.models.callbacks`

### DIFF
--- a/gensim/models/callbacks.py
+++ b/gensim/models/callbacks.py
@@ -98,10 +98,10 @@ class CoherenceMetric(Metric):
         self.model = None
         self.topics = None
         super(CoherenceMetric, self).set_parameters(**kwargs)
-        
+
         cm = gensim.models.CoherenceModel(
             model=self.model, topics=self.topics, texts=self.texts, corpus=self.corpus,
-            dictionary=self.dictionary, window_size=self.window_size, 
+            dictionary=self.dictionary, window_size=self.window_size,
             coherence=self.coherence, topn=self.topn
         )
 

--- a/gensim/models/callbacks.py
+++ b/gensim/models/callbacks.py
@@ -98,10 +98,13 @@ class CoherenceMetric(Metric):
         self.model = None
         self.topics = None
         super(CoherenceMetric, self).set_parameters(**kwargs)
+        
         cm = gensim.models.CoherenceModel(
-            self.model, self.topics, self.texts, self.corpus, self.dictionary,
-            self.window_size, self.coherence, self.topn
+            model=self.model, topics=self.topics, texts=self.texts, corpus=self.corpus,
+            dictionary=self.dictionary, window_size=self.window_size, 
+            coherence=self.coherence, topn=self.topn
         )
+
         return cm.get_coherence()
 
 


### PR DESCRIPTION
Add keyword params in the call to gensim.models.CoherenceModel in callbacks.py as the current positional arguments are incorrect. 

The __init__ for CoherenceModel is as follows, including a param for keyed_vectors:
    def __init__(self, model=None, topics=None, texts=None, corpus=None, dictionary=None,
                 window_size=None, keyed_vectors=None, coherence='c_v', topn=20, processes=-1):

In callbacks.py the CoherenceModel is called using positional params, but incorrectly misses the param for keyed_vectors:
        cm = gensim.models.CoherenceModel(
            self.model, self.topics, self.texts, self.corpus, self.dictionary, self.window_size, 
            self.coherence, self.topn)

I noticed the issue when running the Training_visualizations.ipynb in the docs:
https://github.com/RaRe-Technologies/gensim/blob/develop/docs/notebooks/Training_visualizations.ipynb
