### PR TITLE
bm25 scoring function updated , fixes #1828

### DIFF
--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -122,7 +122,7 @@ class BM25(object):
                 continue
             idf = self.idf[word] if self.idf[word] >= 0 else EPSILON * average_idf
             score += (idf * self.f[index][word] * (PARAM_K1 + 1)
-                      / (self.f[index][word] + PARAM_K1 * (1 - PARAM_B + PARAM_B * len(document) / self.avgdl)))
+                      / (self.f[index][word] + PARAM_K1 * (1 - PARAM_B + PARAM_B * len(corpus[index]) / self.avgdl)))
         return score
 
     def get_scores(self, document, average_idf):


### PR DESCRIPTION
len(document) was changes to len(corpus[index]) so that the scoring function uses length of index document.