### PR TITLE
Force python2.7 for building documentation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands = flake8 gensim/
 
 
 [testenv:docs]
-basepython = python2.7
+basepython = python2
 recreate = True
 whitelist_externals = make
 deps = .[docs]

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ commands = flake8 gensim/
 
 
 [testenv:docs]
+basepython = python2.7
 recreate = True
 whitelist_externals = make
 deps = .[docs]


### PR DESCRIPTION
**Introduction**
-----
This problem discovered by @CLearERR  and @anotherbugmaster when they runs `tox -e docs`, i.e. build documentation from sources on the linux system. After it, they received error

```
Collecting pattern (from gensim==3.2.0)
  Using cached pattern-2.6.zip
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-w_xt55t1/pattern/setup.py", line 40
        print n
              ^
    SyntaxError: Missing parentheses in call to 'print'. Did you mean print(int n)?
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-w_xt55t1/pattern/
ERROR: could not install deps [.[docs]]; v = InvocationError("'/home/ivan/release/gensim/.tox/docs/bin/pip install --timeout=60 --trusted-host 28daf2247a33ed269873-7b1aad3fab3cc330e1fd9d109892382a.r6.cf2.rackcdn.com --find-links http://28daf2247a33ed269873-7b1aad3fab3cc330e1fd9d109892382a.r6.cf2.rackcdn.com/ numpy==1.11.3 scipy==0.18.1 .[docs]'", 1)
docs finish: getenv after 51.83 seconds

```

**What happens and why**
------

Obviously, that we see the problem with python3 incompatible code (thanks "pattern") and python3 as the backend for tox. 
This happens because I added `pattern` to dependencies for documentation (this is really needed to install all stuff for build full documentation) 
https://github.com/RaRe-Technologies/gensim/pull/1797/files#diff-2eeaed663bd0d25b7e608891384b7298R310

Also, sphinx **strongly recommend** to use python2 for documentation building (not related with this problem, but we want to follow this recommendation)

**Solution**
-------
Pin python version explicitly to 2. 