### PR TITLE
Fix several coding errors in the doc2vec-lee examples

### DIFF
--- a/docs/notebooks/doc2vec-lee.ipynb
+++ b/docs/notebooks/doc2vec-lee.ipynb
@@ -553,7 +553,7 @@
    ],
    "source": [
     "# Pick a random document from the test corpus and infer a vector from the model\n",
-    "doc_id = random.randint(0, len(train_corpus))\n",
+    "doc_id = random.randint(0, len(train_corpus) - 1)\n",
     "\n",
     "# Compare and print the most/median/least similar documents from the train corpus\n",
     "print('Train Document ({}): «{}»\\n'.format(doc_id, ' '.join(train_corpus[doc_id].words)))\n",
@@ -609,12 +609,12 @@
    ],
    "source": [
     "# Pick a random document from the test corpus and infer a vector from the model\n",
-    "doc_id = random.randint(0, len(test_corpus))\n",
-    "inferred_vector = model.infer_vector(test_corpus[doc_id])\n",
+    "doc_id = random.randint(0, len(test_corpus) - 1)\n",
+    "inferred_vector = model.infer_vector(test_corpus[doc_id].words)\n",
     "sims = model.docvecs.most_similar([inferred_vector], topn=len(model.docvecs))\n",
     "\n",
     "# Compare and print the most/median/least similar documents from the train corpus\n",
-    "print('Test Document ({}): «{}»\\n'.format(doc_id, ' '.join(test_corpus[doc_id])))\n",
+    "print('Test Document ({}): «{}»\\n'.format(doc_id, ' '.join(test_corpus[doc_id].words)))\n",
     "print(u'SIMILAR/DISSIMILAR DOCS PER MODEL %s:\\n' % model)\n",
     "for label, index in [('MOST', 0), ('MEDIAN', len(sims)//2), ('LEAST', len(sims) - 1)]:\n",
     "    print(u'%s %s: «%s»\\n' % (label, sims[index], ' '.join(train_corpus[sims[index][0]].words)))"


### PR DESCRIPTION
This change fixes a couple different coding errors found in the code snippets included in the doc2vec-lee tutorial, including array index out-of-bounds selection and passing test document words to vector inferencing.