### PR TITLE
returning non-zero array with np.int input in matutils.unitvec 

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -705,15 +705,8 @@ def unitvec(vec, norm='l2'):
         if norm == 'l2':
             veclen = blas_nrm2(vec)
         if veclen > 0.0:
-            '''EDIT: included .astype(vec.dtype)'''
-            if vec.dtype == 'int16':
-                vec = vec.astype(np.float16)
-                return blas_scal(1.0 / veclen, vec).astype(vec.dtype)
-            elif vec.dtype == 'int32':
-                vec = vec.astype(np.float32)
-                return blas_scal(1.0 / veclen, vec).astype(vec.dtype)
-            elif vec.dtype == 'int64':
-                vec = vec.astype(np.float64)
+            if np.issubdtype(vec.dtype, np.int) == True:
+                vec = vec.astype(np.float)
                 return blas_scal(1.0 / veclen, vec).astype(vec.dtype)
             else:
                 return blas_scal(1.0 / veclen, vec).astype(vec.dtype)

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -699,13 +699,24 @@ def unitvec(vec, norm='l2'):
             return vec
 
     if isinstance(vec, np.ndarray):
-        vec = np.asarray(vec, dtype=float)
+        vec = np.asarray(vec, dtype=vec.dtype)
         if norm == 'l1':
             veclen = np.sum(np.abs(vec))
         if norm == 'l2':
             veclen = blas_nrm2(vec)
         if veclen > 0.0:
-            return blas_scal(1.0 / veclen, vec)
+            '''EDIT: included .astype(vec.dtype)'''
+            if vec.dtype == 'int16':
+                vec = vec.astype(np.float16)
+                return blas_scal(1.0 / veclen, vec).astype(vec.dtype)
+            elif vec.dtype == 'int32':
+                vec = vec.astype(np.float32)
+                return blas_scal(1.0 / veclen, vec).astype(vec.dtype)
+            elif vec.dtype == 'int64':
+                vec = vec.astype(np.float64)
+                return blas_scal(1.0 / veclen, vec).astype(vec.dtype)
+            else:
+                return blas_scal(1.0 / veclen, vec).astype(vec.dtype)
         else:
             return vec
 

--- a/gensim/test/test_unitvec
+++ b/gensim/test/test_unitvec
@@ -1,0 +1,33 @@
+import logging
+import unittest
+
+import numpy as np 
+
+from debug import unitvec 
+
+'''
+Testing edits.
+If input is np.float, check that output is np.float.
+If input is np.int, check that output is np.float.
+'''
+
+class TestMatutils(unittest.TestCase):
+	def test_unitvec(self):
+		input_vector = np.random.randint(100, size=(3, 3)).astype(np.float)
+		unit_vector = unitvec(input_vector)
+		if input_vector.dtype == np.int:
+			assert unit_vector.dtype == np.float
+		elif input_vector.dtype == np.float:
+			self.assertEqual(input_vector.dtype, unit_vector.dtype)
+
+		input_vector = np.random.randint(100, size=(3, 3)).astype(np.int)
+		unit_vector = unitvec(input_vector)
+		if input_vector.dtype == np.int:
+			assert unit_vector.dtype == np.float
+		elif input_vector.dtype == np.float:
+			self.assertEqual(input_vector.dtype, unit_vector.dtype)
+
+
+if __name__ == '__main__':
+	logging.root.setLevel(logging.WARNING)
+	unittest.main()


### PR DESCRIPTION
The zeros matrix is coming from the fact that, by nature, a unit vector is going to be less than one, so using vec.dtypes causes use of numpy.int, which rounds all values in the unit vector down to zero. It seems that the only way to stop this from happening (and at the same time maintaining the original bug fix for numpy.float dtypes) is casting before return in order to handle numpy.int types as and when is appropriate, which I have done here. What do you think? (This is my first time using git hub, so please excuse me if I've done something I'm not supposed to do.)