### PR TITLE
Fix type issue in `gensim.matutils.unitvec`. Fix #1722

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -699,13 +699,17 @@ def unitvec(vec, norm='l2'):
             return vec
 
     if isinstance(vec, np.ndarray):
-        vec = np.asarray(vec, dtype=float)
+        vec = np.asarray(vec, dtype=vec.dtype)
         if norm == 'l1':
             veclen = np.sum(np.abs(vec))
         if norm == 'l2':
             veclen = blas_nrm2(vec)
         if veclen > 0.0:
-            return blas_scal(1.0 / veclen, vec)
+            if np.issubdtype(vec.dtype, np.int) == True:
+                vec = vec.astype(np.float)
+                return blas_scal(1.0 / veclen, vec).astype(vec.dtype)
+            else:
+                return blas_scal(1.0 / veclen, vec).astype(vec.dtype)
         else:
             return vec
 

--- a/gensim/test_unitvec
+++ b/gensim/test_unitvec
@@ -1,0 +1,33 @@
+import logging
+import unittest
+
+import numpy as np 
+
+from debug import unitvec 
+
+'''
+Testing edits.
+If input is np.float, check that output is np.float.
+If input is np.int, check that output is np.float.
+'''
+
+class TestMatutils(unittest.TestCase):
+	def test_unitvec(self):
+		input_vector = np.random.randint(100, size=(3, 3)).astype(np.float)
+		unit_vector = unitvec(input_vector)
+		if input_vector.dtype == np.int:
+			assert unit_vector.dtype == np.float
+		elif input_vector.dtype == np.float:
+			self.assertEqual(input_vector.dtype, unit_vector.dtype)
+
+		input_vector = np.random.randint(100, size=(3, 3)).astype(np.int)
+		unit_vector = unitvec(input_vector)
+		if input_vector.dtype == np.int:
+			assert unit_vector.dtype == np.float
+		elif input_vector.dtype == np.float:
+			self.assertEqual(input_vector.dtype, unit_vector.dtype)
+
+
+if __name__ == '__main__':
+	logging.root.setLevel(logging.WARNING)
+	unittest.main()


### PR DESCRIPTION
As requested, I have edited the fix to ignore dtype size. I use np.issubtype to check input type and handle appropriately before return to ensure non-integer output.