### PR TITLE
Fix example block for `gensim.models.Word2Vec`

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -36,14 +36,14 @@ This separates the read-only word vector lookup operations in KeyedVectors from 
   array([-0.00449447, -0.00310097,  0.02421786, ...], dtype=float32)
 
 The word vectors can also be instantiated from an existing file on disk in the word2vec C format
-as a KeyedVectors instance::
+as a KeyedVectors instance.
 
-    NOTE: It is impossible to continue training the vectors loaded from the C format because hidden weights,
-    vocabulary frequency and the binary tree is missing::
+NOTE: It is impossible to continue training the vectors loaded from the C format because hidden weights,
+vocabulary frequency and the binary tree is missing::
 
-        >>> from gensim.models import KeyedVectors
-        >>> word_vectors = KeyedVectors.load_word2vec_format('/tmp/vectors.txt', binary=False)  # C text format
-        >>> word_vectors = KeyedVectors.load_word2vec_format('/tmp/vectors.bin', binary=True)  # C binary format
+    >>> from gensim.models import KeyedVectors
+    >>> word_vectors = KeyedVectors.load_word2vec_format('/tmp/vectors.txt', binary=False)  # C text format
+    >>> word_vectors = KeyedVectors.load_word2vec_format('/tmp/vectors.bin', binary=True)  # C binary format
 
 
 You can perform various NLP word tasks with the model. Some of them


### PR DESCRIPTION
Current docstring in `models.word2vec.py` seems to be a little bit strange for me, because the code block is nested and includes no python code.
So I remove `::` to avoid being nested code block, then I fix indents.

Before
![2018-02-03 19 02 18](https://user-images.githubusercontent.com/7121753/35766105-cdfcc338-0914-11e8-9be2-d1513e095dd5.png)

After
![2018-02-03 18 59 07](https://user-images.githubusercontent.com/7121753/35766104-c81b0d3a-0914-11e8-9291-772a4945ad4e.png)
