### PR TITLE
Add `wv` property to KeyedVectors (for backward compatibility). Fix #1882

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -199,6 +199,11 @@ class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
         self.index2word = []
 
     @property
+    @deprecated("Attribute will be removed in 4.0.0, use self instead")
+    def wv(self):
+        return self
+
+    @property
     def index2entity(self):
         return self.index2word
 

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -149,6 +149,10 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
         self.assertEqual(self.vectors.rank('war', 'war'), 1)
         self.assertEqual(self.vectors.rank('war', 'terrorism'), 3)
 
+    def test_wv_property(self):
+        """Test that the deprecated `wv` property returns `self`. To be removed in v4.0.0."""
+        self.assertTrue(self.vectors is self.vectors.wv)
+
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)


### PR DESCRIPTION
This PR fixes #1882 issue.

- Adds back `wv` property (alias for `self`) to `KeyedVectors` for backward compatibility.
- Adds unittest case for the same.