### PR TITLE
Fix deprecation warning for py3 from `inspect.getargspec`. Fix #1878 

### DIFF
--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -83,13 +83,17 @@ from collections import defaultdict
 import functools as ft
 import itertools as it
 from math import log
-from inspect import getargspec
 import pickle
 import six
 
-from six import iteritems, string_types, next
+from six import iteritems, string_types, PY2, next
 
 from gensim import utils, interfaces
+
+if PY2:
+    from inspect import getargspec
+else:
+    from inspect import getfullargspec as getargspec
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Here is the PR from the new fork.
Sorry for the inconvenience. I am still learning git.