### PR TITLE
setup.py was missing the license field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -269,7 +269,7 @@ setup(
     url='http://radimrehurek.com/gensim',
     download_url='http://pypi.python.org/pypi/gensim',
     
-    license='LGPL-2.1',
+    license='LGPLv2.1',
 
     keywords='Singular Value Decomposition, SVD, Latent Semantic Indexing, '
         'LSA, LSI, Latent Dirichlet Allocation, LDA, '

--- a/setup.py
+++ b/setup.py
@@ -268,6 +268,8 @@ setup(
 
     url='http://radimrehurek.com/gensim',
     download_url='http://pypi.python.org/pypi/gensim',
+    
+    license='LGPL-2.1',
 
     keywords='Singular Value Decomposition, SVD, Latent Semantic Indexing, '
         'LSA, LSI, Latent Dirichlet Allocation, LDA, '


### PR DESCRIPTION
While it has no effect on the actual license or the usability of this library, it hinders the use of tools like `pip-licenses`.