### PR TITLE
Add flag for skip network-related tests

### DIFF
--- a/gensim/test/test_api.py
+++ b/gensim/test/test_api.py
@@ -7,6 +7,10 @@ import shutil
 import numpy as np
 
 
+@unittest.skipIf(
+    os.environ.get("SKIP_NETWORK_TESTS", False) == "1",
+    "Skip network-related tests (probably SSL problems on this CI/OS)"
+)
 class TestApi(unittest.TestCase):
     def test_base_dir_creation(self):
         if os.path.isdir(base_dir):

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ setenv =
     VOWPAL_WABBIT_PATH={env:VOWPAL_WABBIT_PATH:}
     DTM_PATH={env:DTM_PATH:}
     MALLET_HOME={env:MALLET_HOME:}
+    SKIP_NETWORK_TESTS={env:SKIP_NETWORK_TESTS:}
 
 commands =
     python -c "from gensim.models.word2vec import FAST_VERSION; print(FAST_VERSION)"


### PR DESCRIPTION
What's done:
- Added `SKIP_NETWORK_TESTS` flag for network-related test-cases
- Added `SKIP_NETWORK_TESTS` to `tox.ini`  (for visibility + possibility to activate it with `tox`)