### PR TITLE
Fix deprecated parameters in `D2VTransformer` and `W2VTransformer`. Fix #1937

### DIFF
--- a/gensim/sklearn_api/d2vmodel.py
+++ b/gensim/sklearn_api/d2vmodel.py
@@ -9,6 +9,7 @@ Scikit learn interface for gensim for easy use of gensim with scikit-learn
 Follows scikit-learn API conventions
 """
 
+import warnings
 import numpy as np
 from six import string_types
 from sklearn.base import TransformerMixin, BaseEstimator

--- a/gensim/sklearn_api/d2vmodel.py
+++ b/gensim/sklearn_api/d2vmodel.py
@@ -24,12 +24,21 @@ class D2VTransformer(TransformerMixin, BaseEstimator):
     """
 
     def __init__(self, dm_mean=None, dm=1, dbow_words=0, dm_concat=0, dm_tag_count=1, docvecs=None,
-                 docvecs_mapfile=None, comment=None, trim_rule=None, size=100, alpha=0.025, window=5, min_count=5,
-                 max_vocab_size=None, sample=1e-3, seed=1, workers=3, min_alpha=0.0001, hs=0, negative=5, cbow_mean=1,
-                 hashfxn=hash, iter=5, sorted_vocab=1, batch_words=10000):
+                 docvecs_mapfile=None, comment=None, trim_rule=None, vector_size=100, alpha=0.025, window=5,
+                 min_count=5, max_vocab_size=None, sample=1e-3, seed=1, workers=3, min_alpha=0.0001,
+                 hs=0, negative=5, cbow_mean=1, hashfxn=hash, epochs=5, sorted_vocab=1,
+                 batch_words=10000, size=None, iter=None):
         """
         Sklearn api for Doc2Vec model. See gensim.models.Doc2Vec and gensim.models.Word2Vec for parameter details.
         """
+
+        if size is not None:
+            warnings.warn("The parameter `size` is deprecated, will be removed in 4.0.0, use `vector_size` instead.")
+            vector_size = size
+        if iter is not None:
+            warnings.warn("The parameter `iter` is deprecated, will be removed in 4.0.0, use `epochs` instead.")
+            epochs = iter
+
         self.gensim_model = None
         self.dm_mean = dm_mean
         self.dm = dm
@@ -42,7 +51,7 @@ class D2VTransformer(TransformerMixin, BaseEstimator):
         self.trim_rule = trim_rule
 
         # attributes associated with gensim.models.Word2Vec
-        self.size = size
+        self.vector_size = vector_size
         self.alpha = alpha
         self.window = window
         self.min_count = min_count
@@ -55,7 +64,7 @@ class D2VTransformer(TransformerMixin, BaseEstimator):
         self.negative = negative
         self.cbow_mean = int(cbow_mean)
         self.hashfxn = hashfxn
-        self.iter = iter
+        self.epochs = epochs
         self.sorted_vocab = sorted_vocab
         self.batch_words = batch_words
 
@@ -72,11 +81,11 @@ class D2VTransformer(TransformerMixin, BaseEstimator):
             documents=d2v_sentences, dm_mean=self.dm_mean, dm=self.dm,
             dbow_words=self.dbow_words, dm_concat=self.dm_concat, dm_tag_count=self.dm_tag_count,
             docvecs=self.docvecs, docvecs_mapfile=self.docvecs_mapfile, comment=self.comment,
-            trim_rule=self.trim_rule, size=self.size, alpha=self.alpha, window=self.window,
+            trim_rule=self.trim_rule, vector_size=self.vector_size, alpha=self.alpha, window=self.window,
             min_count=self.min_count, max_vocab_size=self.max_vocab_size, sample=self.sample,
             seed=self.seed, workers=self.workers, min_alpha=self.min_alpha, hs=self.hs,
             negative=self.negative, cbow_mean=self.cbow_mean, hashfxn=self.hashfxn,
-            iter=self.iter, sorted_vocab=self.sorted_vocab, batch_words=self.batch_words
+            epochs=self.epochs, sorted_vocab=self.sorted_vocab, batch_words=self.batch_words
         )
         return self
 

--- a/gensim/sklearn_api/w2vmodel.py
+++ b/gensim/sklearn_api/w2vmodel.py
@@ -23,14 +23,22 @@ class W2VTransformer(TransformerMixin, BaseEstimator):
     Base Word2Vec module
     """
 
-    def __init__(self, size=100, alpha=0.025, window=5, min_count=5, max_vocab_size=None, sample=1e-3, seed=1,
-                 workers=3, min_alpha=0.0001, sg=0, hs=0, negative=5, cbow_mean=1, hashfxn=hash, iter=5, null_word=0,
-                 trim_rule=None, sorted_vocab=1, batch_words=10000):
+    def __init__(self, vector_size=100, alpha=0.025, window=5, min_count=5, max_vocab_size=None, sample=1e-3, seed=1,
+                 workers=3, min_alpha=0.0001, sg=0, hs=0, negative=5, cbow_mean=1, hashfxn=hash, epochs=5, null_word=0,
+                 trim_rule=None, sorted_vocab=1, batch_words=10000, size=None, iter=None):
         """
         Sklearn wrapper for Word2Vec model. See gensim.models.Word2Vec for parameter details.
         """
+
+        if size is not None:
+            warnings.warn("The parameter `size` is deprecated, will be removed in 4.0.0, use `vector_size` instead.")
+            vector_size = size
+        if iter is not None:
+            warnings.warn("The parameter `iter` is deprecated, will be removed in 4.0.0, use `epochs` instead.")
+            epochs = iter
+
         self.gensim_model = None
-        self.size = size
+        self.vector_size = vector_size
         self.alpha = alpha
         self.window = window
         self.min_count = min_count
@@ -44,7 +52,7 @@ class W2VTransformer(TransformerMixin, BaseEstimator):
         self.negative = negative
         self.cbow_mean = int(cbow_mean)
         self.hashfxn = hashfxn
-        self.iter = iter
+        self.epochs = epochs
         self.null_word = null_word
         self.trim_rule = trim_rule
         self.sorted_vocab = sorted_vocab
@@ -56,11 +64,11 @@ class W2VTransformer(TransformerMixin, BaseEstimator):
         Calls gensim.models.Word2Vec
         """
         self.gensim_model = models.Word2Vec(
-            sentences=X, size=self.size, alpha=self.alpha,
+            sentences=X, vector_size=self.vector_size, alpha=self.alpha,
             window=self.window, min_count=self.min_count, max_vocab_size=self.max_vocab_size,
             sample=self.sample, seed=self.seed, workers=self.workers, min_alpha=self.min_alpha,
             sg=self.sg, hs=self.hs, negative=self.negative, cbow_mean=self.cbow_mean,
-            hashfxn=self.hashfxn, iter=self.iter, null_word=self.null_word, trim_rule=self.trim_rule,
+            hashfxn=self.hashfxn, epochs=self.epochs, null_word=self.null_word, trim_rule=self.trim_rule,
             sorted_vocab=self.sorted_vocab, batch_words=self.batch_words
         )
         return self
@@ -78,7 +86,7 @@ class W2VTransformer(TransformerMixin, BaseEstimator):
         if isinstance(words, six.string_types):
             words = [words]
         vectors = [self.gensim_model[word] for word in words]
-        return np.reshape(np.array(vectors), (len(words), self.size))
+        return np.reshape(np.array(vectors), (len(words), self.vector_size))
 
     def partial_fit(self, X):
         raise NotImplementedError(

--- a/gensim/sklearn_api/w2vmodel.py
+++ b/gensim/sklearn_api/w2vmodel.py
@@ -10,6 +10,7 @@ Scikit learn interface for gensim for easy use of gensim with scikit-learn
 Follows scikit-learn API conventions
 """
 
+import warnings
 import numpy as np
 import six
 from sklearn.base import TransformerMixin, BaseEstimator


### PR DESCRIPTION
Fixes #1937

Renamed `iter` and `size` arguments to `epochs` and `vector_size` in the following two wrappers: `gensim.sklearn_api.d2vmodel` and `gensim.sklearn_api.w2vmodel`.

Added deprecation warnings for use of `iter` and `size`.