### PR TITLE
Fix inheritance chain for `load_word2vec_format` (return correct class in case when you create an child class based on kv)

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -1115,7 +1115,7 @@ class Word2VecKeyedVectors(WordEmbeddingsKeyedVectors):
         """
         # from gensim.models.word2vec import load_word2vec_format
         return _load_word2vec_format(
-            Word2VecKeyedVectors, fname, fvocab=fvocab, binary=binary, encoding=encoding, unicode_errors=unicode_errors,
+            cls, fname, fvocab=fvocab, binary=binary, encoding=encoding, unicode_errors=unicode_errors,
             limit=limit, datatype=datatype)
 
     def get_keras_embedding(self, train_embeddings=False):

--- a/gensim/models/poincare.py
+++ b/gensim/models/poincare.py
@@ -869,7 +869,7 @@ class PoincareKeyedVectors(BaseKeyedVectors):
 
         """
         return _load_word2vec_format(
-            PoincareKeyedVectors, fname, fvocab=fvocab, binary=binary, encoding=encoding, unicode_errors=unicode_errors,
+            cls, fname, fvocab=fvocab, binary=binary, encoding=encoding, unicode_errors=unicode_errors,
             limit=limit, datatype=datatype)
 
     @staticmethod


### PR DESCRIPTION
If I create a child class from Word2VecKeyedVectors/KeyedVector this method will always return a instance of its parent class, which is not correct