### PR TITLE
Fix `Doc2Vec.infer_vector` after loading old `Doc2Vec` (`gensim<=3.2`). Fix #1952

### DIFF
--- a/gensim/models/deprecated/doc2vec.py
+++ b/gensim/models/deprecated/doc2vec.py
@@ -88,7 +88,6 @@ def load_old_doc2vec(*args, **kwargs):
         'dbow_words': old_model.dbow_words,
         'dm_concat': old_model.dm_concat,
         'dm_tag_count': old_model.dm_tag_count,
-        'docvecs': old_model.__dict__.get('docvecs', None),
         'docvecs_mapfile': old_model.__dict__.get('docvecs_mapfile', None),
         'comment': old_model.__dict__.get('comment', None),
         'size': old_model.vector_size,

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -1514,7 +1514,7 @@ class Doc2VecKeyedVectors(BaseKeyedVectors):
         """Return string key for given i_index, if available. Otherwise return raw int doctag (same int)."""
         candidate_offset = i_index - self.max_rawint - 1
         if 0 <= candidate_offset < len(self.offset2doctag):
-            return self.ffset2doctag[candidate_offset]
+            return self.offset2doctag[candidate_offset]
         else:
             return i_index
 

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -103,6 +103,8 @@ class TestDoc2VecModel(unittest.TestCase):
         self.assertTrue(model.docvecs.max_rawint == 299)
         self.assertTrue(model.docvecs.count == 300)
 
+        self.model_sanity(model)
+
         # Model stored in multiple files
         model_file = 'doc2vec_old_sep'
         model = doc2vec.Doc2Vec.load(datapath(model_file))
@@ -117,6 +119,8 @@ class TestDoc2VecModel(unittest.TestCase):
         self.assertTrue(model.trainables.vectors_docs_lockf.shape == (300, ))
         self.assertTrue(model.docvecs.max_rawint == 299)
         self.assertTrue(model.docvecs.count == 300)
+
+        self.model_sanity(model)
 
     def test_unicode_in_doctag(self):
         """Test storing document vectors of a model with unicode titles."""


### PR DESCRIPTION
Fixes #1952.