### PR TITLE
Fix tests for `EuclideanKeyedVectors.similarity_matrix`. Fix #1961

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -511,6 +511,7 @@ class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
             if w1 not in self.vocab:
                 num_skipped += 1
                 continue  # A word from the dictionary is not present in the word2vec model.
+
             # Traverse upper triangle columns.
             if matrix_order <= nonzero_limit + 1:  # Traverse all columns.
                 columns = (

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -497,7 +497,8 @@ class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
         else:
             assert max(tfidf.idfs) < matrix_order
             word_indices = [
-                index for index, _ in sorted(tfidf.idfs.items(), key=lambda x: x[1], reverse=True)
+                index for index, _
+                in sorted(tfidf.idfs.items(), key=lambda x: (x[1], -x[0]), reverse=True)
             ]
 
         # Traverse rows.

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -27,19 +27,19 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
         self.vectors = EuclideanKeyedVectors.load_word2vec_format(
             datapath('euclidean_vectors.bin'), binary=True, datatype=np.float64)
 
-    # TODO: These tests are not currently being run
     def test_similarity_matrix(self):
         """Test similarity_matrix returns expected results."""
 
-        corpus = [["government", "denied", "holiday"], ["holiday", "slowing", "hollingworth"]]
-        dictionary = Dictionary(corpus)
-        corpus = [dictionary.doc2bow(document) for document in corpus]
+        documents = [["government", "denied", "holiday"],
+                  ["holiday", "slowing", "hollingworth"]]
+        dictionary = Dictionary(documents)
 
         # checking symmetry and the existence of ones on the diagonal
         similarity_matrix = self.vectors.similarity_matrix(dictionary).todense()
         self.assertTrue((similarity_matrix.T == similarity_matrix).all())
-        # TODO: Nonsense. How is this testing for ones on the diagonal?
-        # self.assertTrue((np.diag(similarity_matrix) == similarity_matrix).all())
+        self.assertTrue(
+            (np.diag(similarity_matrix) ==
+             np.ones(similarity_matrix.shape[0])).all())
 
         # checking that thresholding works as expected
         similarity_matrix = self.vectors.similarity_matrix(dictionary, threshold=0.45).todense()
@@ -55,6 +55,8 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
 
         similarity_matrix = self.vectors.similarity_matrix(dictionary, nonzero_limit=3).todense()
         self.assertEquals(20, np.sum(similarity_matrix == 0))
+
+        # TODO: Add unit test to check that supplied tfidf has desired effect
 
     def test_most_similar(self):
         """Test most_similar returns expected results."""

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -47,7 +47,7 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
 
         # checking that exponent works as expected
         similarity_matrix = self.vectors.similarity_matrix(dictionary, exponent=1.0).todense()
-        self.assertAlmostEqual(9.5788956, np.sum(similarity_matrix))
+        self.assertAlmostEqual(9.5788956, np.sum(similarity_matrix), places=5)
 
         # checking that nonzero_limit works as expected
         similarity_matrix = self.vectors.similarity_matrix(dictionary, nonzero_limit=4).todense()

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -27,7 +27,8 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
         self.vectors = EuclideanKeyedVectors.load_word2vec_format(
             datapath('euclidean_vectors.bin'), binary=True, datatype=np.float64)
 
-    def similarity_matrix(self):
+    # TODO: These tests are not currently being run
+    def test_similarity_matrix(self):
         """Test similarity_matrix returns expected results."""
 
         corpus = [["government", "denied", "holiday"], ["holiday", "slowing", "hollingworth"]]
@@ -35,23 +36,24 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
         corpus = [dictionary.doc2bow(document) for document in corpus]
 
         # checking symmetry and the existence of ones on the diagonal
-        similarity_matrix = self.similarity_matrix(corpus, dictionary).todense()
+        similarity_matrix = self.vectors.similarity_matrix(dictionary).todense()
         self.assertTrue((similarity_matrix.T == similarity_matrix).all())
-        self.assertTrue((np.diag(similarity_matrix) == similarity_matrix).all())
+        # TODO: Nonsense. How is this testing for ones on the diagonal?
+        # self.assertTrue((np.diag(similarity_matrix) == similarity_matrix).all())
 
         # checking that thresholding works as expected
-        similarity_matrix = self.similarity_matrix(corpus, dictionary, threshold=0.45).todense()
+        similarity_matrix = self.vectors.similarity_matrix(dictionary, threshold=0.45).todense()
         self.assertEquals(18, np.sum(similarity_matrix == 0))
 
         # checking that exponent works as expected
-        similarity_matrix = self.similarity_matrix(corpus, dictionary, exponent=1.0).todense()
+        similarity_matrix = self.vectors.similarity_matrix(dictionary, exponent=1.0).todense()
         self.assertAlmostEqual(9.5788956, np.sum(similarity_matrix))
 
         # checking that nonzero_limit works as expected
-        similarity_matrix = self.similarity_matrix(corpus, dictionary, nonzero_limit=4).todense()
+        similarity_matrix = self.vectors.similarity_matrix(dictionary, nonzero_limit=4).todense()
         self.assertEquals(4, np.sum(similarity_matrix == 0))
 
-        similarity_matrix = self.similarity_matrix(corpus, dictionary, nonzero_limit=3).todense()
+        similarity_matrix = self.vectors.similarity_matrix(dictionary, nonzero_limit=3).todense()
         self.assertEquals(20, np.sum(similarity_matrix == 0))
 
     def test_most_similar(self):


### PR DESCRIPTION
If the tests pass, then this resolves #1961, and #1966.