### PR TITLE
Dask

### DIFF
--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1148,7 +1148,11 @@ def chunkize_serial(iterable, chunksize, as_numpy=False):
         if as_numpy:
             # convert each document to a 2d numpy array (~6x faster when transmitting
             # chunk data over the wire, in Pyro)
-            wrapped_chunk = [[np.array(doc) for doc in itertools.islice(it, int(chunksize))]]
+            #wrapped_chunk = [[np.array(doc) for doc in itertools.islice(it, int(chunksize))]]
+            wrapped_chunk = [[np.asarray(doc,dtype=int) for doc in itertools.islice(it, int(chunksize))]]
+            #docs  = [doc for doc in itertools.islice(it, int(chunksize))]
+            #wrapped_chunk = [[np.array(doc) for doc in docs] ]
+            #wrapped_chunk2 = [[np.asarray(doc,dtype=int) for doc in docs] ]
         else:
             wrapped_chunk = [list(itertools.islice(it, int(chunksize)))]
         if not wrapped_chunk[0]:

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1148,11 +1148,7 @@ def chunkize_serial(iterable, chunksize, as_numpy=False):
         if as_numpy:
             # convert each document to a 2d numpy array (~6x faster when transmitting
             # chunk data over the wire, in Pyro)
-            #wrapped_chunk = [[np.array(doc) for doc in itertools.islice(it, int(chunksize))]]
-            wrapped_chunk = [[np.asarray(doc,dtype=int) for doc in itertools.islice(it, int(chunksize))]]
-            #docs  = [doc for doc in itertools.islice(it, int(chunksize))]
-            #wrapped_chunk = [[np.array(doc) for doc in docs] ]
-            #wrapped_chunk2 = [[np.asarray(doc,dtype=int) for doc in docs] ]
+            wrapped_chunk = [[np.array(doc) for doc in itertools.islice(it, int(chunksize))]]
         else:
             wrapped_chunk = [list(itertools.islice(it, int(chunksize)))]
         if not wrapped_chunk[0]:


### PR DESCRIPTION
Replace pyro distributed clusters with dask based clusters.

I have 2 implementations of distributing workload using a dask cluster.

The first approach currently has an outstanding bug/issue with dask distributed, in that the non-blocking queue (the queue get times out) will cause the dask scheduler to crash. We're currently trying to get this resolved. The advantage of this approach is that it mirrors the pyro implementation in that the dask workers keep running a lda model, and respond to queue events to either perform work on a cluster or to perform a lda state synchronization.

The second approach, is less efficient in that a lda model is created each and every time a chunk is operated on, but is more dask like, in that dask submit operations are performed, i.e. futures are created and waited until they complete.  Currently the number of dask workers is limited to prevent over-provisioning of a worker. This may be related to mkl threads. This approach has been tested against against 1.3 million documents, and found that the 3 dask workers (1 worker on 3 machines) outperformed a similar 3 pyro configuration. 

If there is interest in this, this can be cleaned up, and reviewed to ensure correctness.