### PR TITLE
Bug inconsistent shape of matrix returned by scipy2scipy_clipped Fixes #2065

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -310,7 +310,7 @@ def scipy2scipy_clipped(matrix, topn, eps=1e-9):
         # Instantiate and return a sparse csr_matrix which preserves the order of indices/data.
         return scipy.sparse.csr.csr_matrix(
             (matrix_data, matrix_indices, matrix_indptr),
-            shape=(matrix.shape[0], np.max(matrix_indices) + 1)
+            shape=(matrix.shape[0], matrix.shape[1])
         )
 
 


### PR DESCRIPTION
Fixed inconsistent shape of matrix returned by scipy2scipy_clipped, as described in issue #2065 
Solved by explicitly setting the second dimension of the new matrix to that of the input matrix.