### PR TITLE
Improve "predict_output_word" to be possible to predict output word from context vectors not only context words.

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -124,7 +124,7 @@ except ImportError:
 
 from numpy import exp, dot, zeros, random, dtype, float32 as REAL,\
     uint32, seterr, array, uint8, vstack, fromstring, sqrt,\
-    empty, sum as np_sum, ones, logaddexp, log, outer
+    empty, sum as np_sum, ones, logaddexp, log, outer, ndarray
 
 from scipy.special import expit
 
@@ -861,16 +861,20 @@ class Word2Vec(BaseWordEmbeddingsModel):
         if not hasattr(self.wv, 'vectors') or not hasattr(self.trainables, 'syn1neg'):
             raise RuntimeError("Parameters required for predicting the output words not found.")
 
-        word_vocabs = [self.wv.vocab[w] for w in context_words_list if w in self.wv.vocab]
-        if not word_vocabs:
-            warnings.warn("All the input context words are out-of-vocabulary for the current model.")
+        word_vectors = []
+        for w in context_words_list:
+            if isinstance(w, ndarray):
+                word_vectors.append(w)
+            elif w in self.wv.vocab:
+                word_vectors.append(self.wv[w])
+
+        if not word_vectors:
+            warnings.warn("All the input context words are not vector or out-of-vocabulary for the current model.")
             return None
 
-        word2_indices = [word.index for word in word_vocabs]
-
-        l1 = np_sum(self.wv.vectors[word2_indices], axis=0)
-        if word2_indices and self.cbow_mean:
-            l1 /= len(word2_indices)
+        l1 = np_sum(word_vectors, axis=0)
+        if word_vectors and self.cbow_mean:
+            l1 /= len(word_vectors)
 
         # propagate hidden -> output and take softmax to get probabilities
         prob_values = exp(dot(l1, self.trainables.syn1neg.T))

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -867,9 +867,8 @@ class Word2Vec(BaseWordEmbeddingsModel):
                 word_vectors.append(w)
             elif w in self.wv.vocab:
                 word_vectors.append(self.wv[w])
-
         if not word_vectors:
-            warnings.warn("All the input context words are not vector or out-of-vocabulary for the current model.")
+            warnings.warn("All the input context words are not vectors or out-of-vocabulary for the current model.")
             return None
 
         l1 = np_sum(word_vectors, axis=0)

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -731,11 +731,22 @@ class TestWord2VecModel(unittest.TestCase):
     def testPredictOutputWord(self):
         '''Test word2vec predict_output_word method handling for negative sampling scheme'''
         # under normal circumstances
+        context_words = ['system', 'human']
         model_with_neg = word2vec.Word2Vec(sentences, min_count=1)
-        predictions_with_neg = model_with_neg.predict_output_word(['system', 'human'], topn=5)
+        predictions_with_neg = model_with_neg.predict_output_word(context_words, topn=5)
         self.assertTrue(len(predictions_with_neg) == 5)
 
-        # out-of-vobaculary scenario
+        # test using vectors from words in vocabulary as input
+        context_vectors = [model.wv[t] for t in context_words]
+        predictions_from_vectors = model_with_neg.predict_output_word(context_vectors, topn=5)
+        self.assertTrue(predictions_from_vectors == predictions_with_neg)
+
+        # test using modified vectors as input
+        context_vectors = [model.wv[t] * 0.9 for t in context_words]
+        predictions_from_mod_vectors = model_with_neg.predict_output_word(context_vectors, topn=5)
+        self.assertTrue(len(predictions_from_mod_vectors) == 5)
+
+        # out-of-vocabulary scenario
         predictions_out_of_vocab = model_with_neg.predict_output_word(['some', 'random', 'words'], topn=5)
         self.assertEqual(predictions_out_of_vocab, None)
 

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -737,12 +737,12 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertTrue(len(predictions_with_neg) == 5)
 
         # test using vectors from words in vocabulary as input
-        context_vectors = [model.wv[t] for t in context_words]
+        context_vectors = [model_with_neg.wv[t] for t in context_words]
         predictions_from_vectors = model_with_neg.predict_output_word(context_vectors, topn=5)
         self.assertTrue(predictions_from_vectors == predictions_with_neg)
 
         # test using modified vectors as input
-        context_vectors = [model.wv[t] * 0.9 for t in context_words]
+        context_vectors = [model_with_neg.wv[t] * 0.9 for t in context_words]
         predictions_from_mod_vectors = model_with_neg.predict_output_word(context_vectors, topn=5)
         self.assertTrue(len(predictions_from_mod_vectors) == 5)
 


### PR DESCRIPTION
hi.

i would like to predict output word probability from modified or retrofitted vectors of context words.

but Word2Vec.predict_output_word can predict output word just from original vectors of cotext words in vocab.

i fixed it also possible to recieve vectors not only words as input in this PR.

i'm a github newbie, so if any nit picking exists i will humbly fix it. thank you.