### PR TITLE
override _log_progress() in word2vec to track training loss

### DIFF
--- a/gensim/models/base_any2vec.py
+++ b/gensim/models/base_any2vec.py
@@ -645,16 +645,16 @@ class BaseWordEmbeddingsModel(BaseAny2VecModel):
         if total_examples:
             # examples-based progress %
             logger.info(
-                "EPOCH %i - PROGRESS: at %.2f%% examples, %.0f words/s, in_qsize %i, out_qsize %i, current_loss %.3f",
+                "EPOCH %i - PROGRESS: at %.2f%% examples, %.0f words/s, in_qsize %i, out_qsize %i",
                 cur_epoch + 1, 100.0 * example_count / total_examples, trained_word_count / elapsed,
-                utils.qsize(job_queue), utils.qsize(progress_queue), self.get_latest_training_loss() / example_count
+                utils.qsize(job_queue), utils.qsize(progress_queue)
             )
         else:
             # words-based progress %
             logger.info(
-                "EPOCH %i - PROGRESS: at %.2f%% words, %.0f words/s, in_qsize %i, out_qsize %i, current_loss %.3f",
+                "EPOCH %i - PROGRESS: at %.2f%% words, %.0f words/s, in_qsize %i, out_qsize %i",
                 cur_epoch + 1, 100.0 * raw_word_count / total_words, trained_word_count / elapsed,
-                utils.qsize(job_queue), utils.qsize(progress_queue), self.get_latest_training_loss() / example_count
+                utils.qsize(job_queue), utils.qsize(progress_queue)
             )
 
     def _log_epoch_end(self, cur_epoch, example_count, total_examples, raw_word_count, total_words,

--- a/gensim/models/base_any2vec.py
+++ b/gensim/models/base_any2vec.py
@@ -155,20 +155,7 @@ class BaseAny2VecModel(utils.SaveLoad):
 
     def _log_progress(self, job_queue, progress_queue, cur_epoch, example_count, total_examples,
                       raw_word_count, total_words, trained_word_count, elapsed):
-        if total_examples:
-            # examples-based progress %
-            logger.info(
-                "EPOCH %i - PROGRESS: at %.2f%% examples, %.0f words/s, in_qsize %i, out_qsize %i",
-                cur_epoch + 1, 100.0 * example_count / total_examples, trained_word_count / elapsed,
-                utils.qsize(job_queue), utils.qsize(progress_queue)
-            )
-        else:
-            # words-based progress %
-            logger.info(
-                "EPOCH %i - PROGRESS: at %.2f%% words, %.0f words/s, in_qsize %i, out_qsize %i",
-                cur_epoch + 1, 100.0 * raw_word_count / total_words, trained_word_count / elapsed,
-                utils.qsize(job_queue), utils.qsize(progress_queue)
-            )
+        raise NotImplementedError()
 
     def _log_epoch_end(self, cur_epoch, example_count, total_examples, raw_word_count, total_words,
                        trained_word_count, elapsed):
@@ -658,16 +645,16 @@ class BaseWordEmbeddingsModel(BaseAny2VecModel):
         if total_examples:
             # examples-based progress %
             logger.info(
-                "EPOCH %i - PROGRESS: at %.2f%% examples, %.0f words/s, in_qsize %i, out_qsize %i",
+                "EPOCH %i - PROGRESS: at %.2f%% examples, %.0f words/s, in_qsize %i, out_qsize %i, current_loss %.3f",
                 cur_epoch + 1, 100.0 * example_count / total_examples, trained_word_count / elapsed,
-                utils.qsize(job_queue), utils.qsize(progress_queue)
+                utils.qsize(job_queue), utils.qsize(progress_queue), self.get_latest_training_loss() / example_count
             )
         else:
             # words-based progress %
             logger.info(
-                "EPOCH %i - PROGRESS: at %.2f%% words, %.0f words/s, in_qsize %i, out_qsize %i",
+                "EPOCH %i - PROGRESS: at %.2f%% words, %.0f words/s, in_qsize %i, out_qsize %i, current_loss %.3f",
                 cur_epoch + 1, 100.0 * raw_word_count / total_words, trained_word_count / elapsed,
-                utils.qsize(job_queue), utils.qsize(progress_queue)
+                utils.qsize(job_queue), utils.qsize(progress_queue), self.get_latest_training_loss() / example_count
             )
 
     def _log_epoch_end(self, cur_epoch, example_count, total_examples, raw_word_count, total_words,

--- a/gensim/models/base_any2vec.py
+++ b/gensim/models/base_any2vec.py
@@ -155,7 +155,20 @@ class BaseAny2VecModel(utils.SaveLoad):
 
     def _log_progress(self, job_queue, progress_queue, cur_epoch, example_count, total_examples,
                       raw_word_count, total_words, trained_word_count, elapsed):
-        raise NotImplementedError()
+        if total_examples:
+            # examples-based progress %
+            logger.info(
+                "EPOCH %i - PROGRESS: at %.2f%% examples, %.0f words/s, in_qsize %i, out_qsize %i",
+                cur_epoch + 1, 100.0 * example_count / total_examples, trained_word_count / elapsed,
+                utils.qsize(job_queue), utils.qsize(progress_queue)
+            )
+        else:
+            # words-based progress %
+            logger.info(
+                "EPOCH %i - PROGRESS: at %.2f%% words, %.0f words/s, in_qsize %i, out_qsize %i",
+                cur_epoch + 1, 100.0 * raw_word_count / total_words, trained_word_count / elapsed,
+                utils.qsize(job_queue), utils.qsize(progress_queue)
+            )
 
     def _log_epoch_end(self, cur_epoch, example_count, total_examples, raw_word_count, total_words,
                        trained_word_count, elapsed):

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -939,6 +939,23 @@ class Word2Vec(BaseWordEmbeddingsModel):
     def get_latest_training_loss(self):
         return self.running_training_loss
 
+    def _log_progress(self, job_queue, progress_queue, cur_epoch, example_count, total_examples,
+                      raw_word_count, total_words, trained_word_count, elapsed):
+        if total_examples:
+            # examples-based progress %
+            logger.info(
+                "EPOCH %i - PROGRESS: at %.2f%% examples, %.0f words/s, in_qsize %i, out_qsize %i, current_loss %.3f",
+                cur_epoch + 1, 100.0 * example_count / total_examples, trained_word_count / elapsed,
+                utils.qsize(job_queue), utils.qsize(progress_queue), self.get_latest_training_loss() / example_count
+            )
+        else:
+            # words-based progress %
+            logger.info(
+                "EPOCH %i - PROGRESS: at %.2f%% words, %.0f words/s, in_qsize %i, out_qsize %i, current_loss %.3f",
+                cur_epoch + 1, 100.0 * raw_word_count / total_words, trained_word_count / elapsed,
+                utils.qsize(job_queue), utils.qsize(progress_queue), self.get_latest_training_loss() / example_count
+            )
+
     @deprecated(
         "Method will be removed in 4.0.0, keep just_word_vectors = model.wv to retain just the KeyedVectors instance"
     )


### PR DESCRIPTION
I came across this suggestion from @villmow in this thread https://github.com/RaRe-Technologies/gensim/issues/1172 and thought I'd implement since @menshikh-iv thought it was a good idea and doesn't seem to have been done by anyone else.

First time I've contributed so appologies if not followed correct process etc.