### PR TITLE
Fix citation of Mikolov paper

### DIFF
--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -621,8 +621,8 @@ class Phrases(SentenceAnalyzer, PhrasesTransformation):
 
 
 def original_scorer(worda_count, wordb_count, bigram_count, len_vocab, min_count, corpus_word_count):
-    """Calculation score, based on original `"Efficient Estimaton of Word Representations in Vector Space" by
-    Mikolov <https://arxiv.org/pdf/1301.3781.pdf>`_.
+    """Calculation score, based on original `"Distributed Representations of Words and Phrases
+    and their Compositionality" by Mikolov <https://arxiv.org/pdf/1310.4546.pdf>`_.
 
     Parameters
     ----------
@@ -641,7 +641,7 @@ def original_scorer(worda_count, wordb_count, bigram_count, len_vocab, min_count
 
     Notes
     -----
-    Formula: :math:`\\frac{(worda\_count - min\_count) * len\_vocab }{ (worda\_count * wordb\_count)}`.
+    Formula: :math:`\\frac{(bigram\_count - min\_count) * len\_vocab }{ (worda\_count * wordb\_count)}`.
 
     """
     return (bigram_count - min_count) / worda_count / wordb_count * len_vocab

--- a/gensim/sklearn_api/phrases.py
+++ b/gensim/sklearn_api/phrases.py
@@ -35,9 +35,9 @@ from gensim import models
 class PhrasesTransformer(TransformerMixin, BaseEstimator):
     """Base Phrases module, wraps :class:`~gensim.models.phrases.Phrases`.
 
-    For more information, please have a look to `Mikolov, et. al: "Efficient Estimation of Word Representations in
-    Vector Space" <https://arxiv.org/pdf/1301.3781.pdf>`_ and `Gerlof Bouma: "Normalized (Pointwise) Mutual Information
-    in Collocation Extraction" <https://svn.spraakdata.gu.se/repos/gerlof/pub/www/Docs/npmi-pfd.pdf>`_.
+    For more information, please have a look to `Mikolov, et. al: "Distributed Representations of Words and Phrases and
+    their Compositionality" <https://arxiv.org/pdf/1310.4546.pdf>`_ and `Gerlof Bouma: "Normalized (Pointwise) Mutual
+    Information in Collocation Extraction" <https://svn.spraakdata.gu.se/repos/gerlof/pub/www/Docs/npmi-pfd.pdf>`_.
 
     """
     def __init__(self, min_count=5, threshold=10.0, max_vocab_size=40000000,
@@ -63,8 +63,8 @@ class PhrasesTransformer(TransformerMixin, BaseEstimator):
             or with a function with the expected parameter names. Two built-in scoring functions are available
             by setting `scoring` to a string:
 
-                * 'default': Explained in `Mikolov, et. al: "Efficient Estimation of Word Representations
-                  in Vector Space" <https://arxiv.org/pdf/1301.3781.pdf>`_.
+                * 'default': Explained in `Mikolov, et. al: "Distributed Representations of Words and Phrases
+                  and their Compositionality" <https://arxiv.org/pdf/1310.4546.pdf>`_.
                 * 'npmi': Explained in `Gerlof Bouma: "Normalized (Pointwise) Mutual Information in Collocation
                   Extraction" <https://svn.spraakdata.gu.se/repos/gerlof/pub/www/Docs/npmi-pfd.pdf>`_.
 


### PR DESCRIPTION
The default scorer used by the phraser is Equation 6 from https://arxiv.org/pdf/1310.4546.pdf

I've updated citations in the gensim documentation to reflect this. I also fixed a typo in the docstring, which led to an incorrect formula.