### PR TITLE
Disable google-style docstring support. Fix #1663

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -28,6 +28,8 @@ html_theme = 'gensim_theme'
 extensions = ['sphinx.ext.autodoc', 'sphinxcontrib.napoleon', 'sphinx.ext.imgmath', 'sphinxcontrib.programoutput']
 autoclass_content = "both"
 
+napoleon_google_docstring = False  # Disable support for google-style docstring
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
Disable google-style docstring support in `conf.py`, fix #1663 