### PR TITLE
Fix the enumeration over 'alldata'

### DIFF
--- a/docs/notebooks/doc2vec-IMDB.ipynb
+++ b/docs/notebooks/doc2vec-IMDB.ipynb
@@ -198,7 +198,7 @@
     "alldocs = []  # Will hold all docs in original order\n",
     "with smart_open('aclImdb/alldata-id.txt', 'rb') as alldata:\n",
     "    alldata = alldata.read().decode('utf-8')\n",
-    "    for line_no, line in enumerate(alldata):\n",
+    "    for line_no, line in enumerate(alldata.splitlines()):\n",
     "        tokens = gensim.utils.to_unicode(line).split()\n",
     "        words = tokens[1:]\n",
     "        tags = [line_no] # 'tags = [tokens[0]]' would also work at extra memory cost\n",


### PR DESCRIPTION
Without the splitlines(), the enumerate goes over each word rather than each line/sentence. As a result, the split list goes out of range as it encounters values 0,1,2,3, and 4 at which point it throws the list out of bounds error as the number of elements in the list is 4 and the enumerate function gives it values more than 4.