### PR TITLE
Fix memory consumption in AuthorTopicModel

### DIFF
--- a/gensim/models/atmodel.py
+++ b/gensim/models/atmodel.py
@@ -767,9 +767,9 @@ class AuthorTopicModel(LdaModel):
 
             # Train on all documents of authors in input_corpus.
             train_corpus_idx = []
-            for _ in author2doc.keys():  # For all authors in input corpus.
-                for doc_ids in self.author2doc.values():  # For all documents in total corpus.
-                    train_corpus_idx.extend(doc_ids)
+
+            for doc_ids in self.author2doc.values():  # For all documents in total corpus.
+                train_corpus_idx.extend(doc_ids)
 
             # Make the list of training documents unique.
             train_corpus_idx = list(set(train_corpus_idx))

--- a/gensim/models/atmodel.py
+++ b/gensim/models/atmodel.py
@@ -767,8 +767,8 @@ class AuthorTopicModel(LdaModel):
 
             # Train on all documents of authors in input_corpus.
             train_corpus_idx = []
-
-            for doc_ids in self.author2doc.values():  # For all documents in total corpus.
+            # Collect all documents of authors.
+            for doc_ids in self.author2doc.values():
                 train_corpus_idx.extend(doc_ids)
 
             # Make the list of training documents unique.

--- a/gensim/models/atmodel.py
+++ b/gensim/models/atmodel.py
@@ -766,13 +766,13 @@ class AuthorTopicModel(LdaModel):
                 self.doc2author[d] = a_list
 
             # Train on all documents of authors in input_corpus.
-            train_corpus_idx = []
+            train_corpus_idx = set()
             # Collect all documents of authors.
             for doc_ids in self.author2doc.values():
-                train_corpus_idx.extend(doc_ids)
+                train_corpus_idx.update(doc_ids)
 
             # Make the list of training documents unique.
-            train_corpus_idx = list(set(train_corpus_idx))
+            train_corpus_idx = sorted(train_corpus_idx)
 
         # train_corpus_idx is only a list of indexes, so "len" is valid.
         lencorpus = len(train_corpus_idx)


### PR DESCRIPTION
@menshikh-iv 
I submitted this PR to address the memory consumption issue faced when using the `AuthorTopicModel` as also recognized in #1947. We had to fix this issue for a research project and maybe you are interested to use this simple fix in the main project. The concatenation of the entire corpus for all authors and then removing unique values (resulting in all unique values in the corpus), can be reduced to this, and the results did not change.

This fix reduced the memory consumption on our project with ≈400.000 docs from 32GB to 2GB for the entire duration of the training. 