### PR TITLE
Make clear prune_at documentation

### DIFF
--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -57,7 +57,8 @@ class Dictionary(utils.SaveLoad, Mapping):
             Documents to be used to initialize the mapping and collect corpus statistics.
         prune_at : int, optional
             Dictionary will try to keep no more than `prune_at` words in its mapping, to limit its RAM
-            footprint. The correctness is not guaranteed. Use `filter_extremes` to perform proper filtering.
+            footprint, the correctness is not guaranteed.
+            Use :meth:`~gensim.corpora.dictionary.Dictionary.filter_extremes` to perform proper filtering.
 
         Examples
         --------
@@ -174,7 +175,8 @@ class Dictionary(utils.SaveLoad, Mapping):
             Input corpus. All tokens should be already **tokenized and normalized**.
         prune_at : int, optional
             Dictionary will try to keep no more than `prune_at` words in its mapping, to limit its RAM
-            footprint. The correctness is not guaranteed. Use `filter_extremes` to perform proper filtering.
+            footprint, the correctness is not guaranteed.
+            Use :meth:`~gensim.corpora.dictionary.Dictionary.filter_extremes` to perform proper filtering.
 
         Examples
         --------

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -56,7 +56,8 @@ class Dictionary(utils.SaveLoad, Mapping):
         documents : iterable of iterable of str, optional
             Documents to be used to initialize the mapping and collect corpus statistics.
         prune_at : int, optional
-            Dictionary will keep no more than `prune_at` words in its mapping, to limit its RAM footprint.
+            Dictionary will try to keep no more than `prune_at` words in its mapping, to limit its RAM
+            footprint. The correctness is not guaranteed. Use `filter_extremes` to perform proper filtering.
 
         Examples
         --------
@@ -172,7 +173,8 @@ class Dictionary(utils.SaveLoad, Mapping):
         documents : iterable of iterable of str
             Input corpus. All tokens should be already **tokenized and normalized**.
         prune_at : int, optional
-            Dictionary will keep no more than `prune_at` words in its mapping, to limit its RAM footprint.
+            Dictionary will try to keep no more than `prune_at` words in its mapping, to limit its RAM
+            footprint. The correctness is not guaranteed. Use `filter_extremes` to perform proper filtering.
 
         Examples
         --------


### PR DESCRIPTION
According to the code, the `prune_at` parameter in `Dictionary.__init__` and `add_documents` is only for reducing memory usage, and has no guarantee on correctness, but the documentation of this parameter was confusing to users.