### PR TITLE
Fix 1589

### DIFF
--- a/gensim/models/atmodel.py
+++ b/gensim/models/atmodel.py
@@ -391,15 +391,17 @@ class AuthorTopicModel(LdaModel):
                 doc_no = d
             # Get the IDs and counts of all the words in the current document.
             # TODO: this is duplication of code in LdaModel. Refactor.
+
             if doc and not isinstance(doc[0][0], six.integer_types):
                 # make sure the term IDs are ints, otherwise np will get upset
                 ids = [int(id) for id, _ in doc]
             else:
                 ids = [id for id, _ in doc]
-            cts = np.array([cnt for _, cnt in doc])
+            ids = np.array(ids, dtype=np.integer)
+            cts = np.array([cnt for _, cnt in doc], dtype=np.integer)
 
             # Get all authors in current document, and convert the author names to integer IDs.
-            authors_d = [self.author2id[a] for a in self.doc2author[doc_no]]
+            authors_d = np.array([self.author2id[a] for a in self.doc2author[doc_no]], dtype=np.integer)
 
             gammad = self.state.gamma[authors_d, :]  # gamma of document d before update.
             tilde_gamma = gammad.copy()  # gamma that will be updated.
@@ -828,9 +830,9 @@ class AuthorTopicModel(LdaModel):
             else:
                 doc_no = d
             # Get all authors in current document, and convert the author names to integer IDs.
-            authors_d = [self.author2id[a] for a in self.doc2author[doc_no]]
-            ids = np.array([id for id, _ in doc])  # Word IDs in doc.
-            cts = np.array([cnt for _, cnt in doc])  # Word counts.
+            authors_d = np.array([self.author2id[a] for a in self.doc2author[doc_no]], dtype=np.integer)
+            ids = np.array([id for id, _ in doc], dtype=np.integer)  # Word IDs in doc.
+            cts = np.array([cnt for _, cnt in doc], dtype=np.integer)  # Word counts.
 
             if d % self.chunksize == 0:
                 logger.debug("bound: at document #%i in chunk", d)

--- a/gensim/test/test_atmodel.py
+++ b/gensim/test/test_atmodel.py
@@ -49,15 +49,19 @@ texts = [['human', 'interface', 'computer'],
  ['trees'],
  ['graph', 'trees'],
  ['graph', 'minors', 'trees'],
- ['graph', 'minors', 'survey']]
+ ['graph', 'minors', 'survey'],
+ ['only_occurs_once_in_corpus_and_alone_in_doc'],
+]
 dictionary = Dictionary(texts)
 corpus = [dictionary.doc2bow(text) for text in texts]
 
 # Assign some authors randomly to the documents above.
-author2doc = {'john': [0, 1, 2, 3, 4, 5, 6], 'jane': [2, 3, 4, 5, 6, 7, 8], 'jack': [0, 2, 4, 6, 8], 'jill': [1, 3, 5, 7]}
+author2doc = {'john': [0, 1, 2, 3, 4, 5, 6], 'jane': [2, 3, 4, 5, 6, 7, 8], 'jack': [0, 2, 4, 6, 8], 'jill': [1, 3, 5, 7], 'joaquin': [9]}
 doc2author = {0: ['john', 'jack'], 1: ['john', 'jill'], 2: ['john', 'jane', 'jack'], 3: ['john', 'jane', 'jill'],
         4: ['john', 'jane', 'jack'], 5: ['john', 'jane', 'jill'], 6: ['john', 'jane', 'jack'], 7: ['jane', 'jill'],
-        8: ['jane', 'jack']}
+        8: ['jane', 'jack'],
+        9: ['juaqin'],
+}
 
 # More data with new and old authors (to test update method).
 # Although the text is just a subset of the previous, the model
@@ -115,6 +119,15 @@ class TestAuthorTopicModel(unittest.TestCase, basetests.TestBaseTopicModel):
         jill_topics = model.get_author_topics('jill')
         jill_topics = matutils.sparse2full(jill_topics, model.num_topics)
         self.assertTrue(all(jill_topics > 0))
+
+    def testEmptyDocument(self):
+        _dictionary = Dictionary(texts)
+        _dictionary.filter_extremes(no_below=2)
+        _corpus = [_dictionary.doc2bow(text) for text in texts]
+        try:
+            model = self.class_(_corpus, author2doc=author2doc, id2word=_dictionary, num_topics=2)
+        except IndexError:
+            raise IndexError("error occurs in 1.0.0 release tag")
 
     def testAuthor2docMissing(self):
         # Check that the results are the same if author2doc is constructed automatically from doc2author.


### PR DESCRIPTION
Empty numpy arrays default to `dtype=np.float`, rather than infering `dtype=np.integer` or `dtype=np.bool`. This means that empty arrays with out `dtype` casting cannot be used as index arrays. 

