### PR TITLE
Add multiprocessing support for `BM25`

### DIFF
--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -196,7 +196,7 @@ def get_bm25_weights(corpus, n_jobs=1):
     ...     ["cat", "outer", "space"],
     ...     ["wag", "dog"]
     ... ]
-    >>> result = get_bm25_weights(corpus)
+    >>> result = get_bm25_weights(corpus, n_jobs=-1)
 
     """
     bm25 = BM25(corpus)

--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -38,8 +38,8 @@ import math
 from six import iteritems
 from six.moves import xrange
 from functools import partial
-from multiprocessing import Pool, cpu_count
-
+from multiprocessing import Pool
+from ..utils import effective_n_jobs
 
 PARAM_K1 = 1.5
 PARAM_B = 0.75
@@ -180,32 +180,6 @@ def _get_scores(bm25, document, average_idf):
     return scores
 
 
-def _effective_n_jobs(n_jobs):
-    """Determines the number of jobs can run in parallel.
-
-    Just like in sklearn, passing n_jobs=-1 means using all available
-    CPU cores.
-
-    Parameters
-    ----------
-    n_jobs : int
-        Number of workers requested by caller.
-
-    Returns
-    -------
-    int
-        number of effective jobs
-
-    """
-    if n_jobs == 0:
-        raise ValueError('n_jobs == 0 in Parallel has no meaning')
-    elif n_jobs is None:
-        return 1
-    elif n_jobs < 0:
-        n_jobs = max(cpu_count() + 1 + n_jobs, 1)
-    return n_jobs
-
-
 def get_bm25_weights(corpus, n_jobs=1):
     """Returns BM25 scores (weights) of documents in corpus.
     Each document has to be weighted with every document in given corpus.
@@ -236,7 +210,7 @@ def get_bm25_weights(corpus, n_jobs=1):
     bm25 = BM25(corpus)
     average_idf = sum(float(val) for val in bm25.idf.values()) / len(bm25.idf)
 
-    n_processes = _effective_n_jobs(n_jobs)
+    n_processes = effective_n_jobs(n_jobs)
     if n_processes == 1:
         weights = [bm25.get_scores(doc, average_idf) for doc in corpus]
         return weights

--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -157,7 +157,7 @@ class BM25(object):
 def _get_scores(bm25, document, average_idf):
     """Helper function for retrieving bm25 scores of given `document` in parallel
     in relation to every item in corpus.
-    
+
     Parameters
     ----------
     bm25 : BM25 object
@@ -171,7 +171,7 @@ def _get_scores(bm25, document, average_idf):
     -------
     list of float
         BM25 scores.
-    
+
     """
     scores = []
     for index in xrange(bm25.corpus_size):
@@ -185,7 +185,7 @@ def _effective_n_jobs(n_jobs):
 
     Just like in sklearn, passing n_jobs=-1 means using all available
     CPU cores.
-    
+
     Parameters
     ----------
     n_jobs : int
@@ -195,7 +195,7 @@ def _effective_n_jobs(n_jobs):
     -------
     int
         number of effective jobs
-    
+
     """
     if n_jobs == 0:
         raise ValueError('n_jobs == 0 in Parallel has no meaning')

--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -182,6 +182,8 @@ def get_bm25_weights(corpus, n_jobs=1):
     ----------
     corpus : list of list of str
         Corpus of documents.
+    n_jobs : int
+        The number of processes to use for computing bm25.
 
     Returns
     -------

--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -206,11 +206,6 @@ def get_bm25_weights(corpus, n_jobs=1):
         weights = [bm25.get_scores(doc, average_idf) for doc in corpus]
         return weights
 
-    # weights = []
-    # for doc in corpus:
-    #     scores = bm25.get_scores(doc, average_idf)
-    #     weights.append(scores)
-
     get_score = partial(_get_scores, bm25, average_idf=average_idf)
     pool = Pool(n_jobs)
     weights = pool.map(get_score, corpus)

--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -155,6 +155,7 @@ class BM25(object):
 
 
 def _get_scores(bm25, document, average_idf):
+    """helper function for retrieve bm25 scores in parallel"""
     scores = []
     for index in xrange(bm25.corpus_size):
         score = bm25.get_score(document, index, average_idf)

--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -203,7 +203,7 @@ def get_bm25_weights(corpus, n_jobs=1):
     average_idf = sum(float(val) for val in bm25.idf.values()) / len(bm25.idf)
 
     if _effective_n_jobs(n_jobs) == 1:
-        weights = [bm25.get_scores(doc, average_idf)]
+        weights = [bm25.get_scores(doc, average_idf) for doc in corpus]
         return weights
 
     # weights = []

--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -202,12 +202,13 @@ def get_bm25_weights(corpus, n_jobs=1):
     bm25 = BM25(corpus)
     average_idf = sum(float(val) for val in bm25.idf.values()) / len(bm25.idf)
 
-    if _effective_n_jobs(n_jobs) == 1:
+    n_processes = _effective_n_jobs(n_jobs)
+    if n_processes == 1:
         weights = [bm25.get_scores(doc, average_idf) for doc in corpus]
         return weights
 
     get_score = partial(_get_scores, bm25, average_idf=average_idf)
-    pool = Pool(n_jobs)
+    pool = Pool(n_processes)
     weights = pool.map(get_score, corpus)
     pool.close()
     pool.join()

--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -22,7 +22,7 @@ Examples
 ...     ["cat", "outer", "space"],
 ...     ["wag", "dog"]
 ... ]
->>> result = get_bm25_weights(corpus)
+>>> result = get_bm25_weights(corpus, n_jobs=-1)
 
 
 Data:

--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -155,7 +155,7 @@ class BM25(object):
 
 
 def _get_scores(bm25, document, average_idf):
-    """helper function for retrieve bm25 scores in parallel"""
+    """helper function for retrieving bm25 scores in parallel"""
     scores = []
     for index in xrange(bm25.corpus_size):
         score = bm25.get_score(document, index, average_idf)

--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -155,7 +155,24 @@ class BM25(object):
 
 
 def _get_scores(bm25, document, average_idf):
-    """helper function for retrieving bm25 scores in parallel"""
+    """Helper function for retrieving bm25 scores of given `document` in parallel
+    in relation to every item in corpus.
+    
+    Parameters
+    ----------
+    bm25 : BM25 object
+        BM25 object fitted on the corpus where documents are retrieved.
+    document : list of str
+        Document to be scored.
+    average_idf : float
+        Average idf in corpus.
+
+    Returns
+    -------
+    list of float
+        BM25 scores.
+    
+    """
     scores = []
     for index in xrange(bm25.corpus_size):
         score = bm25.get_score(document, index, average_idf)
@@ -164,7 +181,22 @@ def _get_scores(bm25, document, average_idf):
 
 
 def _effective_n_jobs(n_jobs):
-    """Determine the number of jobs which are going to run in parallel"""
+    """Determines the number of jobs can run in parallel.
+
+    Just like in sklearn, passing n_jobs=-1 means using all available
+    CPU cores.
+    
+    Parameters
+    ----------
+    n_jobs : int
+        Number of workers requested by caller.
+
+    Returns
+    -------
+    int
+        number of effective jobs
+    
+    """
     if n_jobs == 0:
         raise ValueError('n_jobs == 0 in Parallel has no meaning')
     elif n_jobs is None:

--- a/gensim/test/test_BM25.py
+++ b/gensim/test/test_BM25.py
@@ -49,9 +49,9 @@ class TestBM25(unittest.TestCase):
         weights1 = get_bm25_weights(common_texts)
         weights2 = get_bm25_weights(common_texts, n_jobs=2)
         weights3 = get_bm25_weights(common_texts, n_jobs=-1)
-        self.assertEqual(weights1, weights2)
-        self.assertEqual(weights1, weights3)
-        self.assertEqual(weights2, weights3)
+        self.assertAlmostEqual(weights1, weights2)
+        self.assertAlmostEqual(weights1, weights3)
+        self.assertAlmostEqual(weights2, weights3)
 
 
 if __name__ == '__main__':

--- a/gensim/test/test_BM25.py
+++ b/gensim/test/test_BM25.py
@@ -44,6 +44,15 @@ class TestBM25(unittest.TestCase):
         self.assertAlmostEqual(weights[0][1], 0)
         self.assertAlmostEqual(weights[1][0], 0)
 
+    def test_multiprocessing(self):
+        """ Result should be the same using different processes """
+        weights1 = get_bm25_weights(common_texts)
+        weights2 = get_bm25_weights(common_texts, n_jobs=2)
+        weights3 = get_bm25_weights(common_texts, n_jobs=-1)
+        self.assertEqual(weights1, weights2)
+        self.assertEqual(weights1, weights3)
+        self.assertEqual(weights2, weights3)
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -44,6 +44,8 @@ from six.moves import xrange
 
 from smart_open import smart_open
 
+from multiprocessing import cpu_count
+
 if sys.version_info[0] >= 3:
     unicode = str
 
@@ -2025,3 +2027,29 @@ def lazy_flatten(nested_list):
                 yield sub
         else:
             yield el
+
+
+def effective_n_jobs(n_jobs):
+    """Determines the number of jobs can run in parallel.
+
+    Just like in sklearn, passing n_jobs=-1 means using all available
+    CPU cores.
+
+    Parameters
+    ----------
+    n_jobs : int
+        Number of workers requested by caller.
+
+    Returns
+    -------
+    int
+        Number of effective jobs.
+
+    """
+    if n_jobs == 0:
+        raise ValueError('n_jobs == 0 in Parallel has no meaning')
+    elif n_jobs is None:
+        return 1
+    elif n_jobs < 0:
+        n_jobs = max(cpu_count() + 1 + n_jobs, 1)
+    return n_jobs


### PR DESCRIPTION
I realized that computing BM25 for large corpus can be quite time consuming, so I added multiprocessing support for the original BM25. I did not open an issue as this is a very quick fix and thought that I would probably make a PR directly. I also added a test to verify the result of using multiprocessing is identical to the original approach. Probably not many people use this function, but hopefully it helps :)