### PR TITLE
Remove duplicate count from `Phraser` log message

### DIFF
--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -776,7 +776,7 @@ class Phraser(SentenceAnalyzer, PhrasesTransformation):
             count += 1
             if not count % 50000:
                 logger.info('Phraser added %i phrasegrams', count)
-        logger.info('Phraser built with %i %i phrasegrams', count, len(self.phrasegrams))
+        logger.info('Phraser built with %i phrasegrams', len(self.phrasegrams))
 
     def pseudocorpus(self, phrases_model):
         """Alias for :func:`gensim.models.phrases.pseudocorpus`.


### PR DESCRIPTION
I suspect this duplicate count was there for debugging purposes, but perhaps it should be removed now.