### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/src/changes_080.rst
+++ b/docs/src/changes_080.rst
@@ -69,7 +69,7 @@ Other changes (that you're unlikely to notice unless you look)
 ----------------------------------------------------------------------
 
 * Improved efficiency of ``lsi[corpus]`` transformations (documents are chunked internally for better performance).
-* Large matrices (numpy/scipy.sparse, in `LsiModel`, `Similarity` etc.) are now mmapped to/from disk when doing `save/load`. The `cPickle` approach used previously was too `buggy <http://groups.google.com/group/gensim/browse_thread/thread/3c4c6c0f76c5938c#>`_ and `slow <http://dieter.plaetinck.be/poor_mans_pickle_implementations_benchmark.html>`_.
+* Large matrices (numpy/scipy.sparse, in `LsiModel`, `Similarity` etc.) are now `mmapped <https://en.wikipedia.org/wiki/Mmap>`_ to/from disk when doing `save/load`. The `cPickle` approach used previously was too `buggy <http://groups.google.com/group/gensim/browse_thread/thread/3c4c6c0f76c5938c#>`_ and `slow <http://dieter.plaetinck.be/poor_mans_pickle_implementations_benchmark.html>`_.
 * Renamed `chunks` parameter to `chunksize` (i.e. `LsiModel(corpus, num_topics=100, chunksize=20000)`). This better reflects its purpose: size of a chunk=number of documents to be processed at once.
 * Also improved memory efficiency of LSI and LDA model generation (again).
 * Removed SciPy 0.6 from the list of supported SciPi versions (need >=0.7 now).

--- a/docs/src/intro.rst
+++ b/docs/src/intro.rst
@@ -30,7 +30,7 @@ Features
 
 * **Memory independence** -- there is no need for the whole training corpus to
   reside fully in RAM at any one time (can process large, web-scale corpora).
-* **Memory sharing** -- trained models can be persisted to disk and loaded back via mmap. Multiple processes can share the same data, cutting down RAM footprint.
+* **Memory sharing** -- trained models can be persisted to disk and loaded back via `mmap <https://en.wikipedia.org/wiki/Mmap>`_. Multiple processes can share the same data, cutting down RAM footprint.
 * Efficient implementations for several popular vector space algorithms,
   including :class:`~gensim.models.word2vec.Word2Vec`, :class:`~gensim.models.doc2vec.Doc2Vec`, :class:`~gensim.models.fasttext.FastText`,
   TF-IDF, Latent Semantic Analysis (LSI, LSA, see :class:`~gensim.models.lsimodel.LsiModel`),

--- a/docs/src/tut3.rst
+++ b/docs/src/tut3.rst
@@ -145,5 +145,5 @@ That doesn't mean it's perfect though:
   `user stories and general questions <http://groups.google.com/group/gensim/topics>`_.
 
 Gensim has no ambition to become an all-encompassing framework, across all NLP (or even Machine Learning) subfields.
-Its mission is to help NLP practicioners try out popular topic modelling algorithms
+Its mission is to help NLP practitioners try out popular topic modelling algorithms
 on large datasets easily, and to facilitate prototyping of new algorithms for researchers.


### PR DESCRIPTION
Fixed misspelling.

`/dics/src/changes_080.rst` contains the word "mmapped". Is it the misspelling of "mapped"? If so, I'll fix it too.  

> Large matrices (numpy/scipy.sparse, in `LsiModel`, `Similarity` etc.) are now **mmapped** to/from disk when doing `save/load`. The `cPickle` approach used previously was too `buggy <http://groups.google.com/group/gensim/browse_thread/thread/3c4c6c0f76c5938c#>`_ and `slow <http://dieter.plaetinck.be/poor_mans_pickle_implementations_benchmark.html>`_.
