### PR TITLE
Fix quote of vocabulary in word2vec class

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -614,7 +614,7 @@ class Word2Vec(BaseWordEmbeddingsModel):
         This object essentially contains the mapping between words and embeddings. After training, it can be used
         directly to query those embeddings in various ways. See the module level docstring for examples.
 
-    vocabulary : :class:'~gensim.models.word2vec.Word2VecVocab'
+    vocabulary : :class:`~gensim.models.word2vec.Word2VecVocab`
         This object represents the vocabulary (sometimes called Dictionary in gensim) of the model.
         Besides keeping track of all unique words, this object provides extra functionality, such as
         constructing a huffman tree (frequent words are closer to the root), or discarding extremely rare words.


### PR DESCRIPTION
`Word2VecVocab` did not be parsed correctly.

Before
![2018-08-25 0 56 41](https://user-images.githubusercontent.com/7121753/44595865-576f1280-a805-11e8-94ec-c5987bf2dbf7.png)

After
![2018-08-25 1 08 44](https://user-images.githubusercontent.com/7121753/44595869-5938d600-a805-11e8-8cc9-69323b22c517.png)
