### PR TITLE
Use heading instead of bold style in `translation_matrix.py`

### DIFF
--- a/gensim/models/translation_matrix.py
+++ b/gensim/models/translation_matrix.py
@@ -10,7 +10,8 @@ for any two sets of named-vectors where there are some paired-guideposts to lear
 
 Examples
 --------
-**How to make translation between two set of word-vectors**
+How to make translation between two set of word-vectors
+=======================================================
 
 Initialize a word-vector models
 
@@ -47,7 +48,8 @@ Save / load model
 ...     loaded_trans_model = TranslationMatrix.load(fname)  # load model
 
 
-**How to make translation between two :class:`~gensim.models.doc2vec.Doc2Vec` models**
+How to make translation between two :class:`~gensim.models.doc2vec.Doc2Vec` models
+==================================================================================
 
 Prepare data and models
 


### PR DESCRIPTION
This PR solves #2162 .

- Use heading instead of nested inline code
- Use also heading for the same level bolded sentence

----

# Preview

![2018-08-26 1 39 00](https://user-images.githubusercontent.com/7121753/44620573-c0bc5780-a8d1-11e8-9ac9-12236803a1bf.png)
