### PR TITLE
Add missing content to tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,14 +4,29 @@ include CHANGELOG.md
 include COPYING
 include COPYING.LESSER
 include ez_setup.py
+
 include gensim/models/voidptr.h
+include gensim/models/fast_line_sentence.h
+
 include gensim/models/word2vec_inner.c
 include gensim/models/word2vec_inner.pyx
 include gensim/models/word2vec_inner.pxd
+include gensim/models/word2vec_corpusfile.cpp
+include gensim/models/word2vec_corpusfile.pyx
+include gensim/models/word2vec_corpusfile.pxd
+
 include gensim/models/doc2vec_inner.c
 include gensim/models/doc2vec_inner.pyx
+include gensim/models/doc2vec_inner.pxd
+include gensim/models/doc2vec_corpusfile.cpp
+include gensim/models/doc2vec_corpusfile.pyx
+
 include gensim/models/fasttext_inner.c
 include gensim/models/fasttext_inner.pyx
+include gensim/models/fasttext_inner.pxd
+include gensim/models/fasttext_corpusfile.cpp
+include gensim/models/fasttext_corpusfile.pyx
+
 include gensim/models/_utils_any2vec.c
 include gensim/models/_utils_any2vec.pyx
 include gensim/corpora/_mmreader.c

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -139,7 +139,7 @@ class TestFastTextModel(unittest.TestCase):
         self.assertTrue(np.allclose(wv.syn0_ngrams, loaded_wv.syn0_ngrams))
         self.assertEqual(len(wv.vocab), len(loaded_wv.vocab))
 
-    @unittest.skipIf(os.name == 'nt' and six.PY2,
+    @unittest.skipIf(os.name == 'nt',
         "corpus_file is not supported for Windows + Py2 and avoid memory error with Appveyor x32")
     def test_persistence_fromfile(self):
         with temporary_file(get_tmpfile('gensim_fasttext1.tst')) as corpus_file:

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -139,8 +139,8 @@ class TestFastTextModel(unittest.TestCase):
         self.assertTrue(np.allclose(wv.syn0_ngrams, loaded_wv.syn0_ngrams))
         self.assertEqual(len(wv.vocab), len(loaded_wv.vocab))
 
-    @unittest.skipIf(os.name == 'nt', "corpus_file is not supported for Windows + Py2"
-                                      "and avoid memory error with Appveyor x32")
+    @unittest.skipIf(os.name == 'nt' and six.PY2,
+        "corpus_file is not supported for Windows + Py2 and avoid memory error with Appveyor x32")
     def test_persistence_fromfile(self):
         with temporary_file(get_tmpfile('gensim_fasttext1.tst')) as corpus_file:
             utils.save_as_line_sentence(sentences, corpus_file)


### PR DESCRIPTION
The main reason why conda packages not builded - missing files in tarball, because conda use `tar.gz` from PyPI, unlike gensim-wheels, where we use repository itself. Anyway, missing files in tarball is a bug (because user can't build all from sources).

With adding new files, conda build & test package succesfully (see https://github.com/conda-forge/gensim-feedstock/pull/14 for more info)