### PR TITLE
Fix non-deterministic test failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ setenv =
     DTM_PATH={env:DTM_PATH:}
     MALLET_HOME={env:MALLET_HOME:}
     SKIP_NETWORK_TESTS={env:SKIP_NETWORK_TESTS:}
+    PYTHONHASHSEED=1
 
 commands =
     python -c "from gensim.models.word2vec import FAST_VERSION; print(FAST_VERSION)"


### PR DESCRIPTION
Some of the non-deterministic tests failed frequently, I spend much time to rerun it again and again (especially in release time when we need to build gensim many times), most frequent fails are:
- `TestFastTextModel.test_cbow_hs_online`
- `TestWord2VecModel.test_cbow_hs_fromfile`
- `TestDoc2VecModel.testLoadOldModel`

This fails almost always happens on `python3`.

Here I pin `PYTHONHASHSEED` for testing purposes (will do the same thing for `gensim-wheels` repo too).

CC: @gojomo @piskvorky hope that you have no objection.

See also https://github.com/MacPython/gensim-wheels/pull/12