### PR TITLE
Fix "aliasing chunkize to chunkize_serial" warning on Windows

### DIFF
--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1215,8 +1215,6 @@ class InputQueue(multiprocessing.Process):
 
 
 if os.name == 'nt':
-    warnings.warn("detected Windows; aliasing chunkize to chunkize_serial")
-
     def chunkize(corpus, chunksize, maxsize=0, as_numpy=False):
         """Split `corpus` into fixed-sized chunks, using :func:`~gensim.utils.chunkize_serial`.
 
@@ -1237,6 +1235,8 @@ if os.name == 'nt':
             "chunksize"-ed chunks of elements from `corpus`.
 
         """
+        if maxsize > 0:
+            warnings.warn("detected Windows; aliasing chunkize to chunkize_serial")
         for chunk in chunkize_serial(corpus, chunksize, as_numpy=as_numpy):
             yield chunk
 else:


### PR DESCRIPTION
After the fix there seems to be no User warning on while importing gensim on Windows.
Fix #2088 