### PR TITLE
Remove `__getitem__` code duplication in `gensim.models.phrases`

### DIFF
--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -232,6 +232,36 @@ class PhrasesTransformation(interfaces.TransformationABC):
         return model
 
 
+def sentence2token(phrases, sentence):
+    delimiter = phrases.delimiter  # delimiter used for lookup
+
+    is_single, sentence = _is_single(sentence)
+    if not is_single:
+        # if the input is an entire corpus (rather than a single sentence),
+        # return an iterable stream.
+        return phrases._apply(sentence)
+
+    delimiter = phrases.delimiter
+    bigrams = phrases.analyze_sentence(
+        sentence,
+        threshold=phrases.threshold,
+        common_terms=phrases.common_terms,
+        scorer=ft.partial(
+            phrases.scoring,
+            len_vocab=float(len(phrases.vocab)),
+            min_count=float(phrases.min_count),
+            corpus_word_count=float(phrases.corpus_word_count),
+        ),
+    )
+    new_s = []
+    for words, score in bigrams:
+        if score is not None:
+            words = delimiter.join(words)
+        new_s.append(words)
+
+    return [utils.to_unicode(w) for w in new_s]
+
+
 class Phrases(SentenceAnalyzer, PhrasesTransformation):
     """Detect phrases based on collocation counts."""
 
@@ -597,33 +627,8 @@ class Phrases(SentenceAnalyzer, PhrasesTransformation):
         """
         warnings.warn("For a faster implementation, use the gensim.models.phrases.Phraser class")
 
-        delimiter = self.delimiter  # delimiter used for lookup
+        return sentence2token(self, sentence)
 
-        is_single, sentence = _is_single(sentence)
-        if not is_single:
-            # if the input is an entire corpus (rather than a single sentence),
-            # return an iterable stream.
-            return self._apply(sentence)
-
-        delimiter = self.delimiter
-        bigrams = self.analyze_sentence(
-            sentence,
-            threshold=self.threshold,
-            common_terms=self.common_terms,
-            scorer=ft.partial(
-                self.scoring,
-                len_vocab=float(len(self.vocab)),
-                min_count=float(self.min_count),
-                corpus_word_count=float(self.corpus_word_count),
-            ),
-        )
-        new_s = []
-        for words, score in bigrams:
-            if score is not None:
-                words = delimiter.join(words)
-            new_s.append(words)
-
-        return [utils.to_unicode(w) for w in new_s]
 
 
 def original_scorer(worda_count, wordb_count, bigram_count, len_vocab, min_count, corpus_word_count):
@@ -855,24 +860,8 @@ class Phraser(SentenceAnalyzer, PhrasesTransformation):
         [u'graph_minors']
 
         """
-        is_single, sentence = _is_single(sentence)
-        if not is_single:
-            # if the input is an entire corpus (rather than a single sentence),
-            # return an iterable stream.
-            return self._apply(sentence)
-
-        delimiter = self.delimiter
-        bigrams = self.analyze_sentence(
-            sentence,
-            threshold=self.threshold,
-            common_terms=self.common_terms,
-            scorer=None)  # we will use our score_item function redefinition
-        new_s = []
-        for words, score in bigrams:
-            if score is not None:
-                words = delimiter.join(words)
-            new_s.append(words)
-        return [utils.to_unicode(w) for w in new_s]
+        
+        return sentence2token(self, sentence)
 
 
 if __name__ == '__main__':

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -232,15 +232,25 @@ class PhrasesTransformation(interfaces.TransformationABC):
         return model
 
 
-def sentence2token(phrase_class, sentence):
-    """ returns tokens after from a sentence by joining the phrases with delimeter.
-    Used by __getitem__ of Phraser and Phrases
+def _sentence2token(phrase_class, sentence):
+    """ returns tokens after from a sentence by joining the phrases with delimiter.
 
-    :param phrases: Class Phrases or Phraser
-    :param sentence: sentence to be processed
-    :returns: list of tokens from the sentence, where phrases ae joined with the delimeter."""
+    This function is used by: meth:`~gensim.models.phrases.Phrases.__getitem__` and
+    meth:`~gensim.models.phrases.Phraser.__getitem__`
 
+    Parameters
+    ----------
+    phrase_class :
+        class:`~gensim.models.phrases.Phrases` or :class:`~gensim.models.phrases.Phraser`
+    sentence : {list of str, iterable of list of str}
+            Sentence or text corpus.
 
+    Returns
+    -------
+    {list of str, :class:`gensim.interfaces.TransformedCorpus`}
+        `sentence` with detected phrase bigrams merged together, or a streamed corpus of such sentences
+        if the input was a corpus.
+    """
     is_single, sentence = _is_single(sentence)
     if not is_single:
         # if the input is an entire corpus (rather than a single sentence),
@@ -264,7 +274,7 @@ def sentence2token(phrase_class, sentence):
         if score is not None:
             words = delimiter.join(words)
         new_s.append(words)
-
+        
     return [utils.to_unicode(w) for w in new_s]
 
 
@@ -633,8 +643,7 @@ class Phrases(SentenceAnalyzer, PhrasesTransformation):
         """
         warnings.warn("For a faster implementation, use the gensim.models.phrases.Phraser class")
 
-        return sentence2token(self, sentence)
-
+        return _sentence2token(self, sentence)
 
 
 def original_scorer(worda_count, wordb_count, bigram_count, len_vocab, min_count, corpus_word_count):
@@ -866,8 +875,7 @@ class Phraser(SentenceAnalyzer, PhrasesTransformation):
         [u'graph_minors']
 
         """
-        
-        return sentence2token(self, sentence)
+        return _sentence2token(self, sentence)
 
 
 if __name__ == '__main__':

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -274,7 +274,6 @@ def _sentence2token(phrase_class, sentence):
         if score is not None:
             words = delimiter.join(words)
         new_s.append(words)
-        
     return [utils.to_unicode(w) for w in new_s]
 
 

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -233,7 +233,7 @@ class PhrasesTransformation(interfaces.TransformationABC):
 
 
 def _sentence2token(phrase_class, sentence):
-    """ returns tokens after from a sentence by joining the phrases with delimiter.
+    """ Convert the input tokens `sentence` into tokens where detected bigrams are joined by a selected delimiter.
 
     This function is used by: meth:`~gensim.models.phrases.Phrases.__getitem__` and
     meth:`~gensim.models.phrases.Phraser.__getitem__`
@@ -247,9 +247,10 @@ def _sentence2token(phrase_class, sentence):
 
     Returns
     -------
-    {list of str, :class:`gensim.interfaces.TransformedCorpus`}
+    {list of str, :class:`~gensim.interfaces.TransformedCorpus`}
         `sentence` with detected phrase bigrams merged together, or a streamed corpus of such sentences
         if the input was a corpus.
+
     """
     is_single, sentence = _is_single(sentence)
     if not is_single:


### PR DESCRIPTION
Fix #2149 
wrote a single function `sentence2token` that can be used by` _getitem_` of Phrase and Phrases class.