### PR TITLE
Fix np.issubdtype warning

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -715,7 +715,7 @@ def unitvec(vec, norm='l2', return_norm=False):
         if norm == 'l2':
             veclen = np.sqrt(np.sum(vec.data ** 2))
         if veclen > 0.0:
-            if np.issubdtype(vec.dtype, np.signedinteger) or np.issubdtype(vec.dtype, np.unsignedinteger):
+            if np.issubdtype(vec.dtype, np.integer):
                 vec = vec.astype(np.float)
             vec /= veclen
             if return_norm:
@@ -734,7 +734,7 @@ def unitvec(vec, norm='l2', return_norm=False):
         if norm == 'l2':
             veclen = blas_nrm2(vec)
         if veclen > 0.0:
-            if np.issubdtype(vec.dtype, np.signedinteger) or np.issubdtype(vec.dtype, np.unsignedinteger):
+            if np.issubdtype(vec.dtype, np.integer):
                 vec = vec.astype(np.float)
             if return_norm:
                 return blas_scal(1.0 / veclen, vec).astype(vec.dtype), veclen

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -715,7 +715,7 @@ def unitvec(vec, norm='l2', return_norm=False):
         if norm == 'l2':
             veclen = np.sqrt(np.sum(vec.data ** 2))
         if veclen > 0.0:
-            if np.issubdtype(vec.dtype, np.int):
+            if np.issubdtype(vec.dtype, np.signedinteger) or np.issubdtype(vec.dtype, np.unsignedinteger):
                 vec = vec.astype(np.float)
             vec /= veclen
             if return_norm:
@@ -734,7 +734,7 @@ def unitvec(vec, norm='l2', return_norm=False):
         if norm == 'l2':
             veclen = blas_nrm2(vec)
         if veclen > 0.0:
-            if np.issubdtype(vec.dtype, np.int):
+            if np.issubdtype(vec.dtype, np.signedinteger) or np.issubdtype(vec.dtype, np.unsignedinteger):
                 vec = vec.astype(np.float)
             if return_norm:
                 return blas_scal(1.0 / veclen, vec).astype(vec.dtype), veclen

--- a/gensim/test/test_ldamodel.py
+++ b/gensim/test/test_ldamodel.py
@@ -201,14 +201,14 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
 
             for v, k in topic:
                 self.assertTrue(isinstance(k, six.string_types))
-                self.assertTrue(np.issubdtype(v, float))
+                self.assertTrue(np.issubdtype(v, np.floating))
 
     def testGetTopicTerms(self):
         topic_terms = self.model.get_topic_terms(1)
 
         for k, v in topic_terms:
             self.assertTrue(isinstance(k, numbers.Integral))
-            self.assertTrue(np.issubdtype(v, float))
+            self.assertTrue(np.issubdtype(v, np.floating))
 
     def testGetDocumentTopics(self):
 
@@ -222,7 +222,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
             self.assertTrue(isinstance(topic, list))
             for k, v in topic:
                 self.assertTrue(isinstance(k, numbers.Integral))
-                self.assertTrue(np.issubdtype(v, float))
+                self.assertTrue(np.issubdtype(v, np.floating))
 
         # Test case to use the get_document_topic function for the corpus
         all_topics = model.get_document_topics(self.corpus, per_word_topics=True)
@@ -233,7 +233,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
             self.assertTrue(isinstance(topic, tuple))
             for k, v in topic[0]:  # list of doc_topics
                 self.assertTrue(isinstance(k, numbers.Integral))
-                self.assertTrue(np.issubdtype(v, float))
+                self.assertTrue(np.issubdtype(v, np.floating))
 
             for w, topic_list in topic[1]:  # list of word_topics
                 self.assertTrue(isinstance(w, numbers.Integral))
@@ -257,7 +257,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
             self.assertTrue(isinstance(topic, tuple))
             for k, v in topic[0]:  # list of doc_topics
                 self.assertTrue(isinstance(k, numbers.Integral))
-                self.assertTrue(np.issubdtype(v, float))
+                self.assertTrue(np.issubdtype(v, np.floating))
                 if len(topic[0]) != 0:
                     doc_topic_count_na += 1
 
@@ -278,7 +278,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
 
         for k, v in doc_topics:
             self.assertTrue(isinstance(k, numbers.Integral))
-            self.assertTrue(np.issubdtype(v, float))
+            self.assertTrue(np.issubdtype(v, np.floating))
 
         for w, topic_list in word_topics:
             self.assertTrue(isinstance(w, numbers.Integral))
@@ -306,7 +306,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         result = model.get_term_topics(2)
         for topic_no, probability in result:
             self.assertTrue(isinstance(topic_no, int))
-            self.assertTrue(np.issubdtype(probability, float))
+            self.assertTrue(np.issubdtype(probability, np.floating))
 
         # checks if topic '1' is in the result list
         # FIXME: Fails on osx and win
@@ -316,7 +316,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         result = model.get_term_topics(str(model.id2word[2]))
         for topic_no, probability in result:
             self.assertTrue(isinstance(topic_no, int))
-            self.assertTrue(np.issubdtype(probability, float))
+            self.assertTrue(np.issubdtype(probability, np.floating))
 
         # checks if topic '1' is in the result list
         # FIXME: Fails on osx and win

--- a/gensim/test/test_matutils.py
+++ b/gensim/test/test_matutils.py
@@ -176,14 +176,14 @@ class UnitvecTestCase(unittest.TestCase):
         unit_vector = matutils.unitvec(input_vector)
         man_unit_vector = manual_unitvec(input_vector)
         self.assertTrue(np.allclose(unit_vector.data, man_unit_vector.data, atol=1e-3))
-        self.assertTrue(np.issubdtype(unit_vector.dtype, float))
+        self.assertTrue(np.issubdtype(unit_vector.dtype, np.floating))
 
     def test_sparse_npint64(self):
         input_vector = sparse.csr_matrix(np.asarray([[1, 0, 0, 0, 3], [0, 0, 4, 3, 0]])).astype(np.int64)
         unit_vector = matutils.unitvec(input_vector)
         man_unit_vector = manual_unitvec(input_vector)
         self.assertTrue(np.allclose(unit_vector.data, man_unit_vector.data, atol=1e-3))
-        self.assertTrue(np.issubdtype(unit_vector.dtype, float))
+        self.assertTrue(np.issubdtype(unit_vector.dtype, np.floating))
 
     def test_dense_npfloat32(self):
         input_vector = np.random.uniform(size=(5,)).astype(np.float32)
@@ -204,14 +204,14 @@ class UnitvecTestCase(unittest.TestCase):
         unit_vector = matutils.unitvec(input_vector)
         man_unit_vector = manual_unitvec(input_vector)
         self.assertTrue(np.allclose(unit_vector, man_unit_vector))
-        self.assertTrue(np.issubdtype(unit_vector.dtype, float))
+        self.assertTrue(np.issubdtype(unit_vector.dtype, np.floating))
 
     def test_dense_npint64(self):
         input_vector = np.random.randint(10, size=5).astype(np.int32)
         unit_vector = matutils.unitvec(input_vector)
         man_unit_vector = manual_unitvec(input_vector)
         self.assertTrue(np.allclose(unit_vector, man_unit_vector))
-        self.assertTrue(np.issubdtype(unit_vector.dtype, float))
+        self.assertTrue(np.issubdtype(unit_vector.dtype, np.floating))
 
     def test_sparse_python_float(self):
         input_vector = sparse.csr_matrix(np.asarray([[1, 0, 0, 0, 3], [0, 0, 4, 3, 0]])).astype(float)
@@ -225,7 +225,7 @@ class UnitvecTestCase(unittest.TestCase):
         unit_vector = matutils.unitvec(input_vector)
         man_unit_vector = manual_unitvec(input_vector)
         self.assertTrue(np.allclose(unit_vector.data, man_unit_vector.data, atol=1e-3))
-        self.assertTrue(np.issubdtype(unit_vector.dtype, float))
+        self.assertTrue(np.issubdtype(unit_vector.dtype, np.floating))
 
     def test_dense_python_float(self):
         input_vector = np.random.uniform(size=(5,)).astype(float)
@@ -239,7 +239,7 @@ class UnitvecTestCase(unittest.TestCase):
         unit_vector = matutils.unitvec(input_vector)
         man_unit_vector = manual_unitvec(input_vector)
         self.assertTrue(np.allclose(unit_vector, man_unit_vector))
-        self.assertTrue(np.issubdtype(unit_vector.dtype, float))
+        self.assertTrue(np.issubdtype(unit_vector.dtype, np.floating))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Modify check of subtypes of np.int for subtypes of np.signedinteger or np.unsignedinteger

Fixes #2188