### PR TITLE
use itertools.chain to concatenate lists

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -149,6 +149,7 @@ and so on.
 from __future__ import division  # py3 "true division"
 
 from collections import deque
+from itertools import chain
 import logging
 
 try:
@@ -1134,8 +1135,8 @@ class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
 
         total = {
             'section': 'Total accuracy',
-            'correct': sum((s['correct'] for s in sections), []),
-            'incorrect': sum((s['incorrect'] for s in sections), []),
+            'correct': list(chain.from_iterable(s['correct'] for s in sections)),
+            'incorrect': list(chain.from_iterable(s['incorrect'] for s in sections)),
         }
 
         oov_ratio = float(oov) / quadruplets_no * 100

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -593,12 +593,18 @@ class TestWord2VecModel(unittest.TestCase):
             self.assertFalse((unlocked1 == model.wv.vectors[1]).all())  # unlocked vector should vary
             self.assertTrue((locked0 == model.wv.vectors[0]).all())  # locked vector should not vary
 
-    def testAccuracy(self):
-        """Test Word2Vec accuracy and KeyedVectors accuracy give the same result"""
+    def testEvaluateWordAnalogies(self):
+        """Test that evaluating analogies on KeyedVectors give sane results"""
         model = word2vec.Word2Vec(LeeCorpus())
-        w2v_accuracy = model.wv.evaluate_word_analogies(datapath('questions-words.txt'))
-        kv_accuracy = model.wv.evaluate_word_analogies(datapath('questions-words.txt'))
-        self.assertEqual(w2v_accuracy, kv_accuracy)
+        score, sections = model.wv.evaluate_word_analogies(datapath('questions-words.txt'))
+        self.assertGreaterEqual(score, 0.0)
+        self.assertLessEqual(score, 1.0)
+        self.assertGreater(len(sections), 0)
+        # Check that dict contains the right keys
+        first_section = sections[0]
+        self.assertIn('section', first_section)
+        self.assertIn('correct', first_section)
+        self.assertIn('incorrect', first_section)
 
     def testEvaluateWordPairs(self):
         """Test Spearman and Pearson correlation coefficients give sane results on similarity datasets"""


### PR DESCRIPTION
The Python docs discourage `sum` for concatenating lists, and suggests `itertools.chain` instead<sup>[[1]](https://docs.python.org/3.5/library/functions.html#sum)</sup>. I think this makes it clearer that the value is a list and not a number.

Also, the unit test for the `evaluate_word_analogies` function seemed to have been written for the deprecated `accuracy` function, where Word2Vec accuracy and KeyedVector accuracy may have been separate methods (?). It seemed pointless to compute analogies twice on the same model, so I changed the test to instead check important aspects of the return value from `evaluate_word_analogies`.