### PR TITLE
Group and sort API reference

### DIFF
--- a/docs/src/apiref.rst
+++ b/docs/src/apiref.rst
@@ -3,16 +3,26 @@
 API Reference
 =============
 
-Modules:
+.. comment: !!! keep TOC tree sorted
+
+Common modules:
 
 .. toctree::
     :maxdepth: 0
 
-    interfaces
-    utils
+    downloader
     matutils
     _matutils
-    downloader
+    interfaces
+    test/utils
+    utils
+    viz/poincare
+
+Сorpora modules:
+
+.. toctree::
+    :maxdepth: 0
+
     corpora/bleicorpus
     corpora/csvcorpus
     corpora/dictionary
@@ -27,51 +37,93 @@ Modules:
     corpora/textcorpus
     corpora/ucicorpus
     corpora/wikicorpus
+
+Model modules:
+
+.. toctree::
+    :maxdepth: 0
+
+    models/atmodel
+    models/basemodel
+    models/base_any2vec
+    models/coherencemodel
+    models/callbacks
+    models/deprecated/doc2vec
+    models/deprecated/fasttext
+    models/deprecated/word2vec
+    models/deprecated/keyedvectors
+    models/deprecated/fasttext_wrapper
+    models/doc2vec
+    models/doc2vec_inner
+    models/fasttext
+    models/fasttext_inner
+    models/hdpmodel
+    models/keyedvectors
     models/ldamodel
     models/ldamulticore
-    models/lsimodel
     models/ldaseqmodel
-    models/tfidfmodel
-    models/rpmodel
-    models/hdpmodel
-    models/logentropy_model
-    models/normmodel
-    models/translation_matrix
-    models/lsi_dispatcher
-    models/lsi_worker
     models/lda_dispatcher
     models/lda_worker
-    models/atmodel
-    models/word2vec
-    models/keyedvectors
-    models/doc2vec
-    models/fasttext
+    models/logentropy_model
+    models/lsimodel
+    models/lsi_dispatcher
+    models/lsi_worker
+    models/normmodel
     models/phrases
     models/poincare
-    models/coherencemodel
-    models/basemodel
-    models/callbacks
+    models/rpmodel
+    models/tfidfmodel
+    models/translation_matrix
     models/utils_any2vec
     models/_utils_any2vec
+    models/word2vec
     models/word2vec_inner
-    models/doc2vec_inner
-    models/fasttext_inner
     models/wrappers/ldamallet
     models/wrappers/dtmmodel
     models/wrappers/ldavowpalwabbit.rst
     models/wrappers/wordrank
     models/wrappers/varembed
     models/wrappers/fasttext
-    models/deprecated/doc2vec
-    models/deprecated/fasttext
-    models/deprecated/word2vec
-    models/deprecated/keyedvectors
-    models/deprecated/fasttext_wrapper
-    models/base_any2vec
+
+Parsing modules:
+
+.. toctree::
+    :maxdepth: 0
+
+    parsing/porter
+    parsing/preprocessing
+
+Scripts:
+
+.. toctree::
+    :maxdepth: 0
+
+    scripts/glove2word2vec
+    scripts/make_wikicorpus
+    scripts/make_wiki_online
+    scripts/make_wiki_online_lemma
+    scripts/make_wiki_online_nodebug
+    scripts/package_info
+    scripts/segment_wiki
+    scripts/word2vec2tensor
+    scripts/word2vec_standalone
+
+Similarities modules:
+
+.. toctree::
+    :maxdepth: 0
+
     similarities/docsim
     similarities/index
+
+sklearn-related modules:
+
+.. toctree::
+    :maxdepth: 0
+
     sklearn_api/atmodel
     sklearn_api/d2vmodel
+    sklearn_api/ftmodel
     sklearn_api/hdp
     sklearn_api/ldamodel
     sklearn_api/ldaseqmodel
@@ -81,24 +133,12 @@ Modules:
     sklearn_api/text2bow
     sklearn_api/tfidf
     sklearn_api/w2vmodel
-    test/utils
-    topic_coherence/aggregation
-    topic_coherence/direct_confirmation_measure
-    topic_coherence/indirect_confirmation_measure
-    topic_coherence/probability_estimation
-    topic_coherence/segmentation
-    topic_coherence/text_analysis
-    scripts/package_info
-    scripts/glove2word2vec
-    scripts/make_wikicorpus
-    scripts/word2vec_standalone
-    scripts/make_wiki_online
-    scripts/make_wiki_online_lemma
-    scripts/make_wiki_online_nodebug
-    scripts/word2vec2tensor
-    scripts/segment_wiki
-    parsing/porter
-    parsing/preprocessing
+
+Summarization modules:
+
+.. toctree::
+    :maxdepth: 0
+
     summarization/bm25
     summarization/commons
     summarization/graph
@@ -108,4 +148,16 @@ Modules:
     summarization/summariser
     summarization/syntactic_unit
     summarization/textcleaner
-    viz/poincare
+
+Topic coherence modules:
+
+.. toctree::
+    :maxdepth: 0
+
+    topic_coherence/aggregation
+    topic_coherence/direct_confirmation_measure
+    topic_coherence/indirect_confirmation_measure
+    topic_coherence/probability_estimation
+    topic_coherence/segmentation
+    topic_coherence/text_analysis
+

--- a/docs/src/sklearn_api/ftmodel.rst
+++ b/docs/src/sklearn_api/ftmodel.rst
@@ -1,0 +1,9 @@
+:mod:`sklearn_api.ftmodel` -- Scikit learn wrapper for FastText model
+===========================================================================
+
+.. automodule:: gensim.sklearn_api.ftmodel
+    :synopsis: Scikit learn wrapper for FastText model
+    :members:
+    :inherited-members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Current API ref is awful. All is in one big heap and not sorted by anyhow. 
+ I've found that ftmodel is not specified in the API list.