### PR TITLE
Replace slow `mean(abs(x-y))` with fast `matutils.mean_absolute_difference`

### DIFF
--- a/gensim/models/atmodel.py
+++ b/gensim/models/atmodel.py
@@ -67,7 +67,7 @@ from os import remove
 from gensim import utils
 from gensim.models import LdaModel
 from gensim.models.ldamodel import LdaState
-from gensim.matutils import dirichlet_expectation
+from gensim.matutils import dirichlet_expectation, mean_absolute_difference
 from gensim.corpora import MmCorpus
 from itertools import chain
 from scipy.special import gammaln  # gamma function utils
@@ -505,7 +505,7 @@ class AuthorTopicModel(LdaModel):
 
                 # Check for convergence.
                 # Criterion is mean change in "local" gamma.
-                meanchange_gamma = np.mean(abs(tilde_gamma - lastgamma))
+                meanchange_gamma = mean_absolute_difference(tilde_gamma.ravel(), lastgamma.ravel())
                 gamma_condition = meanchange_gamma < self.gamma_threshold
                 if gamma_condition:
                     converged += 1

--- a/gensim/models/hdpmodel.py
+++ b/gensim/models/hdpmodel.py
@@ -60,7 +60,7 @@ from scipy.special import gammaln, psi  # gamma function utils
 from six.moves import xrange
 
 from gensim import interfaces, utils, matutils
-from gensim.matutils import dirichlet_expectation
+from gensim.matutils import dirichlet_expectation, mean_absolute_difference
 from gensim.models import basemodel, ldamodel
 
 from gensim.utils import deprecated
@@ -130,7 +130,7 @@ def lda_e_step(doc_word_ids, doc_word_counts, alpha, beta, max_iter=100):
         Elogtheta = dirichlet_expectation(gamma)
         expElogtheta = np.exp(Elogtheta)
         phinorm = np.dot(expElogtheta, betad) + 1e-100
-        meanchange = np.mean(abs(gamma - lastgamma))
+        meanchange = mean_absolute_difference(gamma, lastgamma)
         if meanchange < meanchangethresh:
             break
 

--- a/gensim/test/simspeed.py
+++ b/gensim/test/simspeed.py
@@ -119,7 +119,7 @@ if __name__ == '__main__':
             unchunksizeed = sims
         else:
             queries = math.ceil(1.0 * len(corpus_dense) / chunksize)
-            diff = np.mean(np.abs(unchunksizeed - sims))
+            diff = gensim.matutils.mean_absolute_difference(unchunksizeed, sims)
             logging.info(
                 "chunksize=%i, time=%.4fs (%.2f docs/s, %.2f queries/s), meandiff=%.3e",
                 chunksize, taken, len(corpus_dense) / taken, queries / taken, diff
@@ -161,7 +161,7 @@ if __name__ == '__main__':
             unchunksizeed = sims
         else:
             queries = math.ceil(1.0 * len(corpus_sparse) / chunksize)
-            diff = np.mean(np.abs(unchunksizeed - sims))
+            diff = gensim.matutils.mean_absolute_difference(unchunksizeed, sims)
             logging.info(
                 "chunksize=%i, time=%.4fs (%.2f docs/s, %.2f queries/s), meandiff=%.3e",
                 chunksize, taken, len(corpus_sparse) / taken, queries / taken, diff


### PR DESCRIPTION
I've noticed that in many places are used a slow version of mean_absolute_difference. So I've find all this places and just replace them with the right function.