### PR TITLE
Fix deprecation warning `np.sum(generator)`

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -1094,7 +1094,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             assert Elogthetad.dtype == self.dtype
 
             # E[log p(doc | theta, beta)]
-            score += np.sum(cnt * logsumexp(Elogthetad + Elogbeta[:, int(id)]) for id, cnt in doc)
+            score += sum(cnt * logsumexp(Elogthetad + Elogbeta[:, int(id)]) for id, cnt in doc)
 
             # E[log p(theta | alpha) - log q(theta | gamma)]; assumes alpha is a vector
             score += np.sum((self.alpha - gammad) * Elogthetad)


### PR DESCRIPTION
Fix #2270.
Since `np.sum(generator)` is **deprecated**, it is replaced by python inbuilt `sum`.
