### PR TITLE
Fix integer overflow during `FastText` training with `corpus_file`

### DIFF
--- a/gensim/models/fasttext_corpusfile.pyx
+++ b/gensim/models/fasttext_corpusfile.pyx
@@ -133,7 +133,7 @@ def train_epoch_sg(
 
     cdef int i, j, k
     cdef int effective_words = 0, effective_sentences = 0
-    cdef int total_effective_words = 0, total_sentences = 0, total_words = 0
+    cdef long long total_effective_words = 0, total_sentences = 0, total_words = 0
     cdef int sent_idx, idx_start, idx_end
 
     init_ft_config(&c, model, _alpha, _work, _l1)


### PR DESCRIPTION
(#2258)

* replace `int` by `long long`