### PR TITLE
Limit visdom version (avoid py2 issue from the latest visdom release)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -233,7 +233,7 @@ win_testenv = [
     'scikit-learn',
     'Morfessor==2.0.2a4',
     'python-Levenshtein >= 0.10.2',
-    'visdom >= 0.1.8',
+    'visdom >= 0.1.8, <= 0.1.8.6',
 ]
 
 linux_testenv = win_testenv[:]


### PR DESCRIPTION
Visdom released `visdom==0.1.8.7` that doesn't compatible with `python2`, see https://github.com/facebookresearch/visdom/issues/548

For this reason, I limit visdom version in current PR (to avoid broken build)