### PR TITLE
Replace `open()` by `smart_open()` in `gensim.models.fasttext._load_fasttext_format`

### DIFF
--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -93,13 +93,13 @@ import numpy as np
 from numpy import ones, vstack, float32 as REAL, sum as np_sum
 import six
 
-# TODO use smart_open again when https://github.com/RaRe-Technologies/smart_open/issues/207 will be fixed
 import gensim.models._fasttext_bin
 
 from gensim.models.word2vec import Word2VecVocab, Word2VecTrainables, train_sg_pair, train_cbow_pair
 from gensim.models.keyedvectors import FastTextKeyedVectors
 from gensim.models.base_any2vec import BaseWordEmbeddingsModel
 from gensim.models.utils_any2vec import _compute_ngrams, _ft_hash, _ft_hash_broken
+from smart_open import smart_open
 
 from gensim.utils import deprecated, call_on_class_only
 
@@ -979,7 +979,7 @@ def _load_fasttext_format(model_file, encoding='utf-8'):
     """
     if not model_file.endswith('.bin'):
         model_file += '.bin'
-    with open(model_file, 'rb') as fin:
+    with smart_open(model_file, 'rb') as fin:
         m = gensim.models._fasttext_bin.load(fin, encoding=encoding)
 
     model = FastText(

--- a/setup.py
+++ b/setup.py
@@ -347,7 +347,7 @@ setup(
         'numpy >= 1.11.3',
         'scipy >= 0.18.1',
         'six >= 1.5.0',
-        'smart_open >= 1.7.1',
+        'smart_open >= 1.7.0',
     ],
     tests_require=linux_testenv,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -347,7 +347,7 @@ setup(
         'numpy >= 1.11.3',
         'scipy >= 0.18.1',
         'six >= 1.5.0',
-        'smart_open >= 1.2.1',
+        'smart_open >= 1.7.1',
     ],
     tests_require=linux_testenv,
     extras_require={


### PR DESCRIPTION
Fixed a [TODO](https://github.com/RaRe-Technologies/gensim/blob/6e66849f429190b7599622973b81897031d199b5/gensim/models/fasttext.py#L96) in fasttext.py.
Since [https://github.com/RaRe-Technologies/smart_open/issues/207 ](https://github.com/RaRe-Technologies/smart_open/issues/207 ) is fixed now, we can replace open by smart_open.