### PR TITLE
Fix infinite diff in `LdaModel.do_mstep`

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -1045,7 +1045,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         # print out some debug info at the end of each EM iteration
         self.print_topics(5)
-        diff = mean_absolute_difference(previous_Elogbeta, current_Elogbeta)
+        diff = mean_absolute_difference(previous_Elogbeta.ravel(), current_Elogbeta.ravel())
         logger.info("topic diff=%f, rho=%f", diff, rho)
 
         if self.optimize_eta:


### PR DESCRIPTION
Fix partially #416 
Fix partially #2051

This PR solves infinite diff in output. It works for me. This caused by a big negative values in `self.state.sstate` and narrow dtype of values. I try to solve only this bug. `self.expElogbeta` can contain zeros anyway. That can be solved by pointing a more wide dtype, for example `np.float64`. I don't increase dtype of self.expElogbeta as I know there is a drawback between memory consumption/file sizes/sent bytes and precision. User should be smart enough and choose wisely himself.