### PR TITLE
Fix WordEmbeddingsKeyedVectors.most_similar

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -511,7 +511,7 @@ class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
             Sequence of (word, similarity).
 
         """
-        if topn < 1:
+        if topn is not None and topn < 1:
             return []
 
         if positive is None:
@@ -553,6 +553,8 @@ class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
 
         limited = self.vectors_norm if restrict_vocab is None else self.vectors_norm[:restrict_vocab]
         dists = dot(limited, mean)
+        if topn is None:
+            return dists
         best = matutils.argsort(dists, topn=topn + len(all_words), reverse=True)
         # ignore (don't return) words from the input
         result = [(self.index2word[sim], float(dists[sim])) for sim in best if sim not in all_words]

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -511,6 +511,9 @@ class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
             Sequence of (word, similarity).
 
         """
+        if topn < 1:
+            return []
+
         if positive is None:
             positive = []
         if negative is None:
@@ -550,8 +553,6 @@ class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
 
         limited = self.vectors_norm if restrict_vocab is None else self.vectors_norm[:restrict_vocab]
         dists = dot(limited, mean)
-        if not topn:
-            return dists
         best = matutils.argsort(dists, topn=topn + len(all_words), reverse=True)
         # ignore (don't return) words from the input
         result = [(self.index2word[sim], float(dists[sim])) for sim in best if sim not in all_words]

--- a/gensim/similarities/docsim.py
+++ b/gensim/similarities/docsim.py
@@ -866,13 +866,13 @@ class SoftCosineSimilarity(interfaces.SimilarityABC):
         >>> from gensim.test.utils import common_texts
         >>> from gensim.corpora import Dictionary
         >>> from gensim.models import Word2Vec, WordEmbeddingSimilarityIndex
-        >>> from gensim.similarities import SoftCosineSimilarity, TermSimilarityMatrix
+        >>> from gensim.similarities import SoftCosineSimilarity, SparseTermSimilarityMatrix
         >>>
         >>> model = Word2Vec(common_texts, size=20, min_count=1)  # train word-vectors
-        >>> termsim_index = WordEmbeddingSimilarityIndex(model)
+        >>> termsim_index = WordEmbeddingSimilarityIndex(model.wv)
         >>> dictionary = Dictionary(common_texts)
         >>> bow_corpus = [dictionary.doc2bow(document) for document in common_texts]
-        >>> similarity_matrix = TermSimilarityMatrix(termsim_index, dictionary)  # construct similarity matrix
+        >>> similarity_matrix = SparseTermSimilarityMatrix(termsim_index, dictionary)  # construct similarity matrix
         >>> docsim_index = SoftCosineSimilarity(bow_corpus, similarity_matrix, num_best=10)
         >>>
         >>> query = 'graph trees computer'.split()  # make a query

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -103,6 +103,9 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
         self.assertEqual(len(self.vectors.most_similar('war', topn=5)), 5)
         self.assertEqual(len(self.vectors.most_similar('war', topn=10)), 10)
 
+        predicted = self.vectors.most_similar('war', topn=None)
+        self.assertEqual(len(predicted), len(self.vectors.vocab))
+
     def test_relative_cosine_similarity(self):
         """Test relative_cosine_similarity returns expected results with an input of a word pair and topn"""
         wordnet_syn = [

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -103,9 +103,6 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
         self.assertEqual(len(self.vectors.most_similar('war', topn=5)), 5)
         self.assertEqual(len(self.vectors.most_similar('war', topn=10)), 10)
 
-        predicted = self.vectors.most_similar('war', topn=None)
-        self.assertEqual(len(predicted), len(self.vectors.vocab))
-
     def test_relative_cosine_similarity(self):
         """Test relative_cosine_similarity returns expected results with an input of a word pair and topn"""
         wordnet_syn = [


### PR DESCRIPTION
This PR fixes two issues discovered in #2105:

- The `gensim.models.keyedvectors.WordEmbeddingsKeyedVectors.most_similar` method returns an unexpected result (a numeric array rather than an empty list) when `topn=0`.
- The example code for `gensim.similarities.SoftCosineSimilarity` needs fixing.