### PR TITLE
Use complex dtype for distributed cases

### DIFF
--- a/gensim/models/atmodel.py
+++ b/gensim/models/atmodel.py
@@ -826,7 +826,7 @@ class AuthorTopicModel(LdaModel):
 
             reallen = 0
             for chunk_no, chunk_doc_idx in enumerate(
-                    utils.grouper(train_corpus_idx, chunksize, as_numpy=chunks_as_numpy)):
+                    utils.grouper(train_corpus_idx, chunksize, dtype=np.int32, as_numpy=chunks_as_numpy)):
                 chunk = [self.corpus[d] for d in chunk_doc_idx]
                 reallen += len(chunk)  # keep track of how many documents we've processed so far
 

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -948,6 +948,9 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             # initialize metrics list to store metric values after every epoch
             self.metrics = defaultdict(list)
 
+        # HACK np.int32 should be enough for word ids.
+        chunk_dtype = np.dtype([('1', np.int32), ('2', self.dtype)]) if chunks_as_numpy else self.dtype
+
         for pass_ in range(passes):
             if self.dispatcher:
                 logger.info('initializing %s workers', self.numworkers)
@@ -957,7 +960,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             dirty = False
 
             reallen = 0
-            chunks = utils.grouper(corpus, chunksize, as_numpy=chunks_as_numpy, dtype=self.dtype)
+            chunks = utils.grouper(corpus, chunksize, as_numpy=chunks_as_numpy, dtype=chunk_dtype)
             for chunk_no, chunk in enumerate(chunks):
                 reallen += len(chunk)  # keep track of how many documents we've processed so far
 

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -871,9 +871,8 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         gamma_threshold : float, optional
             Minimum change in the value of the gamma parameters to continue iterating.
         chunks_as_numpy : bool, optional
-            Whether each chunk passed to the inference step should be a numpy.ndarray or not. Numpy can in some settings
-            turn the term IDs into floats, these will be converted back into integers in inference, which incurs a
-            performance hit. For distributed computing it may be desirable to keep the chunks as `numpy.ndarray`.
+            Whether each chunk passed to the inference step should be a numpy.ndarray or not.
+            For distributed computing it may be desirable to keep the chunks as `numpy.ndarray`.
 
         """
         # use parameters given in constructor, unless user explicitly overrode them

--- a/gensim/models/ldamulticore.py
+++ b/gensim/models/ldamulticore.py
@@ -209,9 +209,8 @@ class LdaMulticore(LdaModel):
             Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`) used to update the
             model.
         chunks_as_numpy : bool
-            Whether each chunk passed to the inference step should be a np.ndarray or not. Numpy can in some settings
-            turn the term IDs into floats, these will be converted back into integers in inference, which incurs a
-            performance hit. For distributed computing it may be desirable to keep the chunks as `numpy.ndarray`.
+            Whether each chunk passed to the inference step should be a np.ndarray or not.
+            For distributed computing it may be desirable to keep the chunks as `numpy.ndarray`.
 
         """
         try:

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1217,7 +1217,7 @@ class InputQueue(multiprocessing.Process):
                 # HACK XXX convert documents to numpy arrays, to save memory.
                 # This also gives a scipy warning at runtime:
                 # "UserWarning: indices array has non-integer dtype (float32)"
-                wrapped_chunk = [[np.asarray(doc, dtype=dtype) for doc in chunk]]
+                wrapped_chunk = [[np.asarray(doc, dtype=self.dtype) for doc in chunk]]
             else:
                 wrapped_chunk = [list(chunk)]
 


### PR DESCRIPTION
+ fix doc for grouper
+ add argument in chunksize

Now word ids will not converse to float and it will be stored and pickled as an integer in memory and so there is no backward conversion issues + speed + size of pickled data.

benchmark:

``` python
import numpy as np
from pickle import dumps
bow = [(np.random.randint(1000000), np.random.rand()*10e6) for i in range(10000)]

def test(b):
    print('TRY:', len(b))

    print('pure python')

    %timeit dumps(b)

    print('np array without args')

    %timeit dumps(np.array(b))

    print('np array with simple dtype')
    %timeit dumps(np.array(b, dtype=np.float32))

    complex_dt = np.dtype([('1', np.int32), ('2', np.float32)])
    print('np array with complex dtype')
    %timeit dumps(np.array(b, dtype=complex_dt))

    print('-'*50)

test(bow[:50])
test(bow[:150])
test(bow[:500])
test(bow[:1000])
test(bow[:2000])
test(bow[:5000])
test(bow)
```

results (anyone else should recheck it):

```
TRY: 50
pure python
30.2 µs ± 407 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
np array without args
138 µs ± 4.54 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
np array with simple dtype
141 µs ± 4.92 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
np array with complex dtype
148 µs ± 3.8 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
--------------------------------------------------
TRY: 150
pure python
89.1 µs ± 520 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
np array without args
260 µs ± 6.07 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
np array with simple dtype
260 µs ± 5.11 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
np array with complex dtype
202 µs ± 4.8 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
--------------------------------------------------
TRY: 500
pure python
336 µs ± 5.43 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
np array without args
699 µs ± 11.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
np array with simple dtype
684 µs ± 7.86 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
np array with complex dtype
392 µs ± 5.77 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
--------------------------------------------------
TRY: 1000
pure python
660 µs ± 8.38 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
np array without args
1.33 ms ± 14.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
np array with simple dtype
1.32 ms ± 4.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
np array with complex dtype
689 µs ± 5.77 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
--------------------------------------------------
TRY: 2000
pure python
1.7 ms ± 76.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
np array without args
2.65 ms ± 61 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
np array with simple dtype
2.62 ms ± 20.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
np array with complex dtype
1.29 ms ± 11.6 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
--------------------------------------------------
TRY: 5000
pure python
4.11 ms ± 52.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
np array without args
6.58 ms ± 69.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
np array with simple dtype
6.56 ms ± 43.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
np array with complex dtype
2.92 ms ± 23.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
--------------------------------------------------
TRY: 10000
pure python
12 ms ± 95.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
np array without args
12.7 ms ± 35.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
np array with simple dtype
12.6 ms ± 34.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
np array with complex dtype
5.43 ms ± 43.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
--------------------------------------------------
```