### PR TITLE
Don't override `Doc2Vec.infer_vector` defaults in `Doc2VecKeyedVectors.similarity_unseen_documents`

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -1814,7 +1814,7 @@ class Doc2VecKeyedVectors(BaseKeyedVectors):
             other_vectors = self[other_docs]
         return 1 - WordEmbeddingsKeyedVectors.cosine_similarities(input_vector, other_vectors)
 
-    def similarity_unseen_docs(self, model, doc_words1, doc_words2, alpha=0.1, min_alpha=0.0001, steps=5):
+    def similarity_unseen_docs(self, model, doc_words1, doc_words2, alpha=None, min_alpha=None, steps=None):
         """Compute cosine similarity between two post-bulk out of training documents.
 
         Parameters


### PR DESCRIPTION
`similarity_unseen_documents()` is explicitly specifying the (old, crude) `infer_vector()` defaults, rather than letting `infer_vector()` apply its own default behavior - which nowadays is to re-use the alpha/epochs parameters that the model was configured to use. 