### PR TITLE
Undo the hash2index optimization

### DIFF
--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -696,7 +696,9 @@ class FastText(BaseWordEmbeddingsModel):
             raise RuntimeError(
                 "You cannot do an online vocabulary-update of a model which has no prior vocabulary. "
                 "First build the vocabulary of your model with a corpus "
-                "before doing an online update.")
+                "by calling the :meth:`gensim.models.fasttext.FastText.build_vocab` method "
+                "before doing an online update."
+            )
         else:
             self.vocabulary.old_vocab_len = len(self.wv.vocab)
 

--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -696,7 +696,7 @@ class FastText(BaseWordEmbeddingsModel):
             raise RuntimeError(
                 "You cannot do an online vocabulary-update of a model which has no prior vocabulary. "
                 "First build the vocabulary of your model with a corpus "
-                "by calling the :meth:`gensim.models.fasttext.FastText.build_vocab` method "
+                "by calling the gensim.models.fasttext.FastText.build_vocab method "
                 "before doing an online update."
             )
         else:

--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -707,6 +707,8 @@ class FastText(BaseWordEmbeddingsModel):
         if update:
             self.wv.update_ngrams_weights(self.trainables.seed, self.vocabulary.old_vocab_len)
 
+        return retval
+
     def _set_train_params(self, **kwargs):
         #
         # We need the wv.buckets_word member to be initialized in order to

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -2039,15 +2039,6 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
             False
 
         """
-        #
-        # FIXME: what's the right behavior here?
-        #
-        # If we maintain the previous behavior of this method (check for word
-        # _and_ ngram presence) then this method will never return False.
-        # This is because there will _always_ be a vector for any ngram.
-        # However, there is no guarantee that it will be "learned" - it may
-        # be still at its initial "unlearned" value.
-        #
         return True
 
     def save(self, *args, **kwargs):

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -1964,14 +1964,6 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
         replace=True.
     buckets_word : dict
         Maps vocabulary items (by their index) to the buckets they occur in.
-    hash2index : dict
-        Maps bucket numbers to an index within vectors_ngrams.  So, given an
-        ngram, you can get its vector by determining its bucket, mapping the
-        bucket to an index, and then indexing into vectors_ngrams (in other
-        words, vectors_ngrams[hash2index[hash_fn(ngram) % bucket]].
-    num_ngram_vectors : int
-        The number of vectors that correspond to ngrams, as opposed to terms
-        (full words).
 
     """
     def __init__(self, vector_size, min_n, max_n, bucket, compatible_hash):
@@ -1981,11 +1973,9 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
         self.vectors_ngrams = None
         self.vectors_ngrams_norm = None
         self.buckets_word = None
-        self.hash2index = {}
         self.min_n = min_n
         self.max_n = max_n
         self.bucket = bucket
-        self.num_ngram_vectors = 0
         self.compatible_hash = compatible_hash
 
     @classmethod
@@ -2030,12 +2020,32 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
         bool
             True if `word` or any character ngrams in `word` are present in the vocabulary, False otherwise.
 
+        Note
+        ----
+        This method **always** returns True, because of the way FastText works.
+
+        If you want to check if a word is an in-vocabulary term, use this instead:
+
+        .. pycon:
+
+            >>> from gensim.test.utils import datapath
+            >>> from gensim.models import FastText
+            >>> cap_path = datapath("crime-and-punishment.bin")
+            >>> model = FastText.load_fasttext_format(cap_path, full_model=False)
+            >>> 'steamtrain' in model.wv.vocab  # If False, is an OOV term
+            False
+
         """
-        if word in self.vocab:
-            return True
-        else:
-            hashes = ft_ngram_hashes(word, self.min_n, self.max_n, self.bucket, self.compatible_hash)
-            return any(h in self.hash2index for h in hashes)
+        #
+        # FIXME: what's the right behavior here?
+        #
+        # If we maintain the previous behavior of this method (check for word
+        # _and_ ngram presence) then this method will never return False.
+        # This is because there will _always_ be a vector for any ngram.
+        # However, there is no guarantee that it will be "learned" - it may
+        # be still at its initial "unlearned" value.
+        #
+        return True
 
     def save(self, *args, **kwargs):
         """Save object.
@@ -2052,8 +2062,14 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
 
         """
         # don't bother storing the cached normalized vectors
-        kwargs['ignore'] = kwargs.get(
-            'ignore', ['vectors_norm', 'vectors_vocab_norm', 'vectors_ngrams_norm', 'buckets_word'])
+        ignore_attrs = [
+            'vectors_norm',
+            'vectors_vocab_norm',
+            'vectors_ngrams_norm',
+            'buckets_word',
+            'hash2index',
+        ]
+        kwargs['ignore'] = kwargs.get('ignore', ignore_attrs)
         super(FastTextKeyedVectors, self).save(*args, **kwargs)
 
     def word_vec(self, word, use_norm=False):
@@ -2087,15 +2103,18 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
                 ngram_weights = self.vectors_ngrams_norm
             else:
                 ngram_weights = self.vectors_ngrams
-            ngrams_found = 0
-            for ngram_hash in ft_ngram_hashes(word, self.min_n, self.max_n, self.bucket, self.compatible_hash):
-                if ngram_hash in self.hash2index:
-                    word_vec += ngram_weights[self.hash2index[ngram_hash]]
-                    ngrams_found += 1
-            if word_vec.any():
-                return word_vec / max(1, ngrams_found)
-            else:  # No ngrams of the word are present in self.ngrams
-                raise KeyError('all ngrams for word %s absent from model' % word)
+            ngram_hashes = ft_ngram_hashes(word, self.min_n, self.max_n, self.bucket, self.compatible_hash)
+            for nh in ngram_hashes:
+                word_vec += ngram_weights[nh]
+            return word_vec / len(ngram_hashes)
+
+    @classmethod
+    def load(cls, fname_or_handle, **kwargs):
+        kv = super(FastTextKeyedVectors, cls).load(fname_or_handle, **kwargs)
+        if kv.hasattr('hash2index'):
+            _rollback_optimization(kv)
+
+        return kv
 
     def init_sims(self, replace=False):
         """Precompute L2-normalized vectors.
@@ -2140,41 +2159,69 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
             fname, self.vocab, self.vectors, fvocab=fvocab, binary=binary, total_vec=total_vec)
 
     def init_ngrams_weights(self, seed):
-        self.hash2index = {}
-        ngram_indices, self.buckets_word = _process_fasttext_vocab(
+        """Initialize the vocabulary and ngrams weights prior to training.
+
+        Creates the weight matrices and initializes them with uniform random values.
+
+        Parameters
+        ----------
+        seed : float
+            The seed for the PRNG.
+
+        Note
+        ----
+        Call this **after** the vocabulary has been fully initialized.
+
+        """
+        self.buckets_word = _process_fasttext_vocab(
             self.vocab.items(),
             self.min_n,
             self.max_n,
             self.bucket,
             self.compatible_hash,
-            self.hash2index
         )
-        self.num_ngram_vectors = len(ngram_indices)
-        logger.info("Total number of ngrams is %d", self.num_ngram_vectors)
 
         rand_obj = np.random
         rand_obj.seed(seed)
 
         lo, hi = -1.0 / self.vector_size, 1.0 / self.vector_size
         vocab_shape = (len(self.vocab), self.vector_size)
-        ngrams_shape = (len(ngram_indices), self.vector_size)
+        ngrams_shape = (self.bucket, self.vector_size)
         self.vectors_vocab = rand_obj.uniform(lo, hi, vocab_shape).astype(REAL)
+
+        #
+        # We could have initialized vectors_ngrams at construction time, but we
+        # do it here for two reasons:
+        #
+        # 1. The constructor does not have access to the random seed
+        # 2. We want to use the same rand_obj to fill vectors_vocab _and_
+        #    vectors_ngrams, and vectors_vocab cannot happen at construction
+        #    time because the vocab is not initialized at that stage.
+        #
         self.vectors_ngrams = rand_obj.uniform(lo, hi, ngrams_shape).astype(REAL)
 
     def update_ngrams_weights(self, seed, old_vocab_len):
-        old_hash2index_len = len(self.hash2index)
+        """Update the vocabulary weights for training continuation.
 
-        new_ngram_hashes, self.buckets_word = _process_fasttext_vocab(
+        Parameters
+        ----------
+        seed : float
+            The seed for the PRNG.
+        old_vocab_length : int
+            The length of the vocabulary prior to its update.
+
+        Note
+        ----
+        Call this **after** the vocabulary has been updated.
+
+        """
+        self.buckets_word = _process_fasttext_vocab(
             self.vocab.items(),
             self.min_n,
             self.max_n,
             self.bucket,
             self.compatible_hash,
-            self.hash2index
         )
-        num_new_ngrams = len(new_ngram_hashes)
-        self.num_ngram_vectors += num_new_ngrams
-        logger.info("Number of new ngrams is %d", num_new_ngrams)
 
         rand_obj = np.random
         rand_obj.seed(seed)
@@ -2182,10 +2229,7 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
         new_vocab = len(self.vocab) - old_vocab_len
         self.vectors_vocab = _pad_random(self.vectors_vocab, new_vocab, rand_obj)
 
-        new_ngrams = len(self.hash2index) - old_hash2index_len
-        self.vectors_ngrams = _pad_random(self.vectors_ngrams, new_ngrams, rand_obj)
-
-    def init_post_load(self, vectors, match_gensim=False):
+    def init_post_load(self, vectors):
         """Perform initialization after loading a native Facebook model.
 
         Expects that the vocabulary (self.vocab) has already been initialized.
@@ -2198,9 +2242,7 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
             The order of the vectors must correspond to the indices in
             the vocabulary.
         match_gensim : boolean, optional
-            Match the behavior of gensim's FastText implementation and take a
-            subset of vectors_ngrams.  This behavior appears to be incompatible
-            with Facebook's implementation.
+            No longer supported.
 
         """
         vocab_words = len(self.vocab)
@@ -2215,31 +2257,7 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
         self.vectors = np.array(vectors[:vocab_words, :])
         self.vectors_vocab = np.array(vectors[:vocab_words, :])
         self.vectors_ngrams = np.array(vectors[vocab_words:, :])
-        self.hash2index = {i: i for i in range(self.bucket)}
         self.buckets_word = None  # This can get initialized later
-        self.num_ngram_vectors = self.bucket
-
-        if match_gensim:
-            #
-            # This gives us the same shape for vectors_ngrams, and we can
-            # satisfy our unit tests when running gensim vs native comparisons,
-            # but because we're discarding some ngrams, the accuracy of the
-            # model suffers.
-            #
-            ngram_hashes, _ = _process_fasttext_vocab(
-                self.vocab.items(),
-                self.min_n,
-                self.max_n,
-                self.bucket,
-                self.compatible_hash,
-                dict(),  # we don't care what goes here in this case
-            )
-            ngram_hashes = sorted(set(ngram_hashes))
-
-            keep_indices = [self.hash2index[h] for h in self.hash2index if h in ngram_hashes]
-            self.num_ngram_vectors = len(keep_indices)
-            self.vectors_ngrams = self.vectors_ngrams.take(keep_indices, axis=0)
-            self.hash2index = {hsh: idx for (idx, hsh) in enumerate(ngram_hashes)}
 
         self.adjust_vectors()
 
@@ -2257,12 +2275,17 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
             word_vec = np.copy(self.vectors_vocab[v.index])
             ngram_hashes = ft_ngram_hashes(w, self.min_n, self.max_n, self.bucket, self.compatible_hash)
             for nh in ngram_hashes:
-                word_vec += self.vectors_ngrams[self.hash2index[nh]]
+                word_vec += self.vectors_ngrams[nh]
             word_vec /= len(ngram_hashes) + 1
             self.vectors[v.index] = word_vec
 
+    @property
+    @deprecated("Attribute will be removed in 4.0.0, use self.bucket instead")
+    def num_ngram_vectors(self):
+        return self.bucket
 
-def _process_fasttext_vocab(iterable, min_n, max_n, num_buckets, compatible_hash, hash2index):
+
+def _process_fasttext_vocab(iterable, min_n, max_n, num_buckets, compatible_hash):
     """
     Performs a common operation for FastText weight initialization and
     updates: scan the vocabulary, calculate ngrams and their hashes, keep
@@ -2282,42 +2305,27 @@ def _process_fasttext_vocab(iterable, min_n, max_n, num_buckets, compatible_hash
     compatible_hash : boolean
         True for compatibility with the Facebook implementation.
         False for compatibility with the old Gensim implementation.
-    hash2index : dict
-        Updated in-place.
 
     Returns
     -------
-    A tuple of two elements.
-
-    word_indices : dict
+    dict
         Keys are indices of entities in the vocabulary (words).  Values are
         arrays containing indices into vectors_ngrams for each ngram of the
         word.
-    new_ngram_hashes : list
-        A list of hashes for newly encountered ngrams.  Each hash is modulo
-        num_buckets.
 
     """
-    old_hash2index_len = len(hash2index)
     word_indices = {}
-    new_ngram_hashes = []
 
     if num_buckets == 0:
-        return [], {v.index: np.array([], dtype=np.uint32) for w, v in iterable}
+        return {v.index: np.array([], dtype=np.uint32) for w, v in iterable}
 
     for word, vocab in iterable:
         wi = []
         for ngram_hash in ft_ngram_hashes(word, min_n, max_n, num_buckets, compatible_hash):
-            if ngram_hash not in hash2index:
-                #
-                # This is a new ngram.  Reserve a new index in hash2index.
-                #
-                hash2index[ngram_hash] = old_hash2index_len + len(new_ngram_hashes)
-                new_ngram_hashes.append(ngram_hash)
-            wi.append(hash2index[ngram_hash])
+            wi.append(ngram_hash)
         word_indices[vocab.index] = np.array(wi, dtype=np.uint32)
 
-    return new_ngram_hashes, word_indices
+    return word_indices
 
 
 def _pad_random(m, new_rows, rand):
@@ -2349,3 +2357,107 @@ def _l2_norm(m, replace=False):
         return m
     else:
         return (m / dist).astype(REAL)
+
+
+def _rollback_optimization(kv):
+    """Undo the optimization that pruned buckets.
+
+    This unfortunate optimization saves memory and CPU cycles, but breaks
+    compatibility with Facebook's model by introducing divergent behavior
+    for OOV words.
+
+    """
+    logger.warning(
+        "This older model was trained with a premature optimization. "
+        "The current Gensim version reverses this optimization during loading. "
+        "Save the model to a new file and reload to suppress this message."
+    )
+    assert hasattr(kv, 'hash2index')
+    assert hasattr(kv, 'num_ngram_vectors')
+
+    kv.vectors_ngrams = _unpack_copy(kv.vectors_ngrams, kv.bucket, kv.hash2index)
+
+    #
+    # We have replaced num_ngram_vectors with a property and deprecated it.
+    # We can't delete it because the new attribute masks the member.
+    #
+    del kv.hash2index
+
+
+def _unpack_copy(m, num_rows, hash2index, seed=1):
+    """Same as _unpack, but makes a copy of the matrix.
+
+    Simpler implementation, but uses more RAM.
+
+    """
+    rows, columns = m.shape
+    if rows == num_rows:
+        #
+        # Nothing to do.
+        #
+        return m
+    assert num_rows > rows
+
+    rand_obj = np.random
+    rand_obj.seed(seed)
+
+    n = np.empty((0, columns), dtype=m.dtype)
+    n = _pad_random(n, num_rows, rand_obj)
+
+    for src, dst in hash2index.items():
+        n[src] = m[dst]
+
+    return n
+
+
+def _unpack(m, num_rows, seed, hash2index):
+    """Restore the array to its natural shape, undoing the optimization.
+
+    Parameters
+    ----------
+
+    a : np.ndarray
+        The matrix to restore.
+    num_rows : int
+        The number of rows that this array should have.
+    seed : float
+        The seed for the PRNG.  Will be used to initialize new rows.
+    hash2index : dict
+        the product of the optimization we are undoing.
+
+    Returns
+    -------
+    np.array
+        The unpacked matrix.
+
+    Notes
+    -----
+
+    The unpacked matrix will reference some rows in the input matrix to save memory.
+    Throw away the old matrix after calling this function, or use np.copy.
+
+    This implementation is a work in progress.
+
+    """
+    rows, columns = a.shape
+    if rows == num_rows:
+        #
+        # Nothing to do.
+        #
+        return a
+    assert num_rows > rows
+
+    rand_obj = np.random
+    rand_obj.seed(seed)
+
+    #
+    # Rows at the bottom of the matrix will be "free": initialized to random values.
+    # Rows at the top of the matrix will contain learned vectors.
+    # Move the learned vectors down into their "proper" positions, starting from the bottom.
+    #
+    m = _pad_random(m, num_rows - rows, rand_obj)
+    for src, dst in reversed(hash2index.items()):
+        assert src < dst
+        m[src], m[dst] = m[dst], m[src]
+
+    return m

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -2366,8 +2366,6 @@ def _rollback_optimization(kv):
         "This saved FastText model was trained with an optimization we no longer support. "
         "The current Gensim version automatically reverses this optimization during loading. "
         "Save the loaded model to a new file and reload to suppress this message."
-        "The current Gensim version reverses this optimization during loading. "
-        "Save the model to a new file and reload to suppress this message."
     )
     assert hasattr(kv, 'hash2index')
     assert hasattr(kv, 'num_ngram_vectors')

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -1984,6 +1984,9 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
         if not hasattr(model, 'compatible_hash'):
             model.compatible_hash = False
 
+        if model.hasattr('hash2index'):
+            _rollback_optimization(model)
+
         return model
 
     @property
@@ -2107,14 +2110,6 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
             for nh in ngram_hashes:
                 word_vec += ngram_weights[nh]
             return word_vec / len(ngram_hashes)
-
-    @classmethod
-    def load(cls, fname_or_handle, **kwargs):
-        kv = super(FastTextKeyedVectors, cls).load(fname_or_handle, **kwargs)
-        if kv.hasattr('hash2index'):
-            _rollback_optimization(kv)
-
-        return kv
 
     def init_sims(self, replace=False):
         """Precompute L2-normalized vectors.
@@ -2416,7 +2411,7 @@ def _unpack(m, num_rows, seed, hash2index):
     Parameters
     ----------
 
-    a : np.ndarray
+    m : np.ndarray
         The matrix to restore.
     num_rows : int
         The number of rows that this array should have.
@@ -2439,12 +2434,12 @@ def _unpack(m, num_rows, seed, hash2index):
     This implementation is a work in progress.
 
     """
-    rows, columns = a.shape
+    rows, columns = m.shape
     if rows == num_rows:
         #
         # Nothing to do.
         #
-        return a
+        return m
     assert num_rows > rows
 
     rand_obj = np.random

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -1984,7 +1984,7 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
         if not hasattr(model, 'compatible_hash'):
             model.compatible_hash = False
 
-        if model.hasattr('hash2index'):
+        if hasattr(model, 'hash2index'):
             _rollback_optimization(model)
 
         return model

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -2363,7 +2363,9 @@ def _rollback_optimization(kv):
 
     """
     logger.warning(
-        "This older model was trained with a premature optimization. "
+        "This saved FastText model was trained with an optimization we no longer support. "
+        "The current Gensim version automatically reverses this optimization during loading. "
+        "Save the loaded model to a new file and reload to suppress this message."
         "The current Gensim version reverses this optimization during loading. "
         "Save the model to a new file and reload to suppress this message."
     )

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -1199,6 +1199,30 @@ class UnpackTest(unittest.TestCase):
         self.assertTrue(np.all(m[1] == n[11]))
         self.assertTrue(np.all(m[2] == n[12]))
 
+    def test_sanity(self):
+        import gensim.models.keyedvectors
+
+        m = np.array(range(9))
+        m.shape = (3, 3)
+        hash2index = {10: 0, 11: 1, 12: 2}
+
+        n = gensim.models.keyedvectors._unpack(m, 25, hash2index)
+        self.assertTrue(np.all(np.array([0, 1, 2]) == n[10]))
+        self.assertTrue(np.all(np.array([3, 4, 5]) == n[11]))
+        self.assertTrue(np.all(np.array([6, 7, 8]) == n[12]))
+
+    def test_tricky(self):
+        import gensim.models.keyedvectors
+
+        m = np.array(range(9))
+        m.shape = (3, 3)
+        hash2index = {1: 0, 0: 1, 12: 2}
+
+        n = gensim.models.keyedvectors._unpack(m, 25, hash2index)
+        self.assertTrue(np.all(np.array([3, 4, 5]) == n[0]))
+        self.assertTrue(np.all(np.array([0, 1, 2]) == n[1]))
+        self.assertTrue(np.all(np.array([6, 7, 8]) == n[12]))
+
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -1186,44 +1186,6 @@ class ZeroBucketTest(unittest.TestCase):
         self.assertRaises(KeyError, model.wv.word_vec, 'streamtrain')
 
 
-class UnpackTest(unittest.TestCase):
-    def test_copy_sanity(self):
-        import gensim.models.keyedvectors
-
-        m = np.array(range(9))
-        m.shape = (3, 3)
-        hash2index = {10: 0, 11: 1, 12: 2}
-
-        n = gensim.models.keyedvectors._unpack_copy(m, 25, hash2index)
-        self.assertTrue(np.all(m[0] == n[10]))
-        self.assertTrue(np.all(m[1] == n[11]))
-        self.assertTrue(np.all(m[2] == n[12]))
-
-    def test_sanity(self):
-        import gensim.models.keyedvectors
-
-        m = np.array(range(9))
-        m.shape = (3, 3)
-        hash2index = {10: 0, 11: 1, 12: 2}
-
-        n = gensim.models.keyedvectors._unpack(m, 25, hash2index)
-        self.assertTrue(np.all(np.array([0, 1, 2]) == n[10]))
-        self.assertTrue(np.all(np.array([3, 4, 5]) == n[11]))
-        self.assertTrue(np.all(np.array([6, 7, 8]) == n[12]))
-
-    def test_tricky(self):
-        import gensim.models.keyedvectors
-
-        m = np.array(range(9))
-        m.shape = (3, 3)
-        hash2index = {1: 0, 0: 1, 12: 2}
-
-        n = gensim.models.keyedvectors._unpack(m, 25, hash2index)
-        self.assertTrue(np.all(np.array([3, 4, 5]) == n[0]))
-        self.assertTrue(np.all(np.array([0, 1, 2]) == n[1]))
-        self.assertTrue(np.all(np.array([6, 7, 8]) == n[12]))
-
-
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)
     unittest.main()

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -1186,6 +1186,20 @@ class ZeroBucketTest(unittest.TestCase):
         self.assertRaises(KeyError, model.wv.word_vec, 'streamtrain')
 
 
+class UnpackTest(unittest.TestCase):
+    def test_copy_sanity(self):
+        import gensim.models.keyedvectors
+
+        m = np.array(range(9))
+        m.shape = (3, 3)
+        hash2index = {10: 0, 11: 1, 12: 2}
+
+        n = gensim.models.keyedvectors._unpack_copy(m, 25, hash2index)
+        self.assertTrue(np.all(m[0] == n[10]))
+        self.assertTrue(np.all(m[1] == n[11]))
+        self.assertTrue(np.all(m[2] == n[12]))
+
+
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)
     unittest.main()

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -306,6 +306,48 @@ class L2NormTest(unittest.TestCase):
         self.assertTrue(np.allclose(m, norm))
 
 
+class UnpackTest(unittest.TestCase):
+    def test_copy_sanity(self):
+        m = np.array(range(9))
+        m.shape = (3, 3)
+        hash2index = {10: 0, 11: 1, 12: 2}
+
+        n = gensim.models.keyedvectors._unpack_copy(m, 25, hash2index)
+        self.assertTrue(np.all(m[0] == n[10]))
+        self.assertTrue(np.all(m[1] == n[11]))
+        self.assertTrue(np.all(m[2] == n[12]))
+
+    def test_sanity(self):
+        m = np.array(range(9))
+        m.shape = (3, 3)
+        hash2index = {10: 0, 11: 1, 12: 2}
+
+        n = gensim.models.keyedvectors._unpack(m, 25, hash2index)
+        self.assertTrue(np.all(np.array([0, 1, 2]) == n[10]))
+        self.assertTrue(np.all(np.array([3, 4, 5]) == n[11]))
+        self.assertTrue(np.all(np.array([6, 7, 8]) == n[12]))
+
+    def test_tricky(self):
+        m = np.array(range(9))
+        m.shape = (3, 3)
+        hash2index = {1: 0, 0: 1, 12: 2}
+
+        n = gensim.models.keyedvectors._unpack(m, 25, hash2index)
+        self.assertTrue(np.all(np.array([3, 4, 5]) == n[0]))
+        self.assertTrue(np.all(np.array([0, 1, 2]) == n[1]))
+        self.assertTrue(np.all(np.array([6, 7, 8]) == n[12]))
+
+    def test_identity(self):
+        m = np.array(range(9))
+        m.shape = (3, 3)
+        hash2index = {0: 0, 1: 1, 2: 2}
+
+        n = gensim.models.keyedvectors._unpack(m, 25, hash2index)
+        self.assertTrue(np.all(np.array([0, 1, 2]) == n[0]))
+        self.assertTrue(np.all(np.array([3, 4, 5]) == n[1]))
+        self.assertTrue(np.all(np.array([6, 7, 8]) == n[2]))
+
+
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)
     unittest.main()


### PR DESCRIPTION
This optimization reduced the number of ngram buckets to include only ngrams that we have seen during training.

This seemed like a good idea at the time, because it saved CPU cycles and RAM, but turned out to be a bad idea, because it introduced divergent behavior when compared to the reference implementation. For example:

We were unable to calculate vectors for terms that were _completely_ out of the vocab (so the term and all its ngrams were unseen). This is bad because the original FB implementation **always** returns a vector. It may _seem_ useless because it's initialized to a random vector, but that's not entirely true, because that vector is random at _initialization_ time. When we're querying the ngram's vector, the vector is _deterministic_, so it is useful.

Another problem is that it complicated the implementation. We now needed an additional layer of indirection that mapped hashes to bucket indices. Without this optimization, this mapping is essentially the identifiy function: the hash N always maps to the Nth bucket.

This pull request removes the optimization, resolving the problems that it introduced.

Fixes #2329 