### PR TITLE
Add Binder badges to tutorial pages

### DIFF
--- a/docs/src/tut1.rst
+++ b/docs/src/tut1.rst
@@ -5,7 +5,12 @@ Corpora and Vector Spaces
 
 This tutorial is available as a Jupyter Notebook `here <https://github.com/piskvorky/gensim/blob/develop/docs/notebooks/Corpora_and_Vector_Spaces.ipynb>`_.
 
-Don't forget to set
+Or run these notebooks online (no installation required) via the Binder project:
+
+.. image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/RaRe-Technologies/gensim/master
+
+| Don't forget to set
 
 >>> import logging
 >>> logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)

--- a/docs/src/tut1.rst
+++ b/docs/src/tut1.rst
@@ -5,10 +5,10 @@ Corpora and Vector Spaces
 
 This tutorial is available as a Jupyter Notebook `here <https://github.com/piskvorky/gensim/blob/develop/docs/notebooks/Corpora_and_Vector_Spaces.ipynb>`_.
 
-Or run these notebooks online (no installation required) via the Binder project:
+Or run this notebook online (no installation required) via the Binder project:
 
 .. image:: https://mybinder.org/badge_logo.svg
- :target: https://mybinder.org/v2/gh/RaRe-Technologies/gensim/master
+ :target: https://mybinder.org/v2/gh/RaRe-Technologies/gensim/master?filepath=%2Fdocs%2Fnotebooks%2FCorpora_and_Vector_Spaces.ipynb
 
 | Don't forget to set
 

--- a/docs/src/tutorial.rst
+++ b/docs/src/tutorial.rst
@@ -30,6 +30,11 @@ priority levels; to activate logging (this is optional), run
 >>> import logging
 >>> logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)
 
+Many of the topics in these tutorials are also presented in Jupyter notebooks, which can be run in your browser via the Binder project (no installation required) by clicking here:
+
+.. image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/RaRe-Technologies/gensim/master
+
 
 .. _first-example:
 

--- a/docs/src/tutorial.rst
+++ b/docs/src/tutorial.rst
@@ -33,7 +33,7 @@ priority levels; to activate logging (this is optional), run
 Many of the topics in these tutorials are also presented in Jupyter notebooks, which can be run in your browser via the Binder project (no installation required) by clicking here:
 
 .. image:: https://mybinder.org/badge_logo.svg
- :target: https://mybinder.org/v2/gh/RaRe-Technologies/gensim/master
+ :target: https://mybinder.org/v2/gh/RaRe-Technologies/gensim/master?filepath=%2Fdocs%2Fnotebooks
 
 
 .. _first-example:


### PR DESCRIPTION
The [Binder Project](https://mybinder.org/) is a free (at least for the time being) service that'll automatically provision and run containers that allow notebooks in GitHub repos to be run in a browser with no user installation required. 

It's a neat project, and I figure this adding this link will lower the barrier to entry for new users.

This PR just adds a badge to the tutorial documentation so that readers can actually run the tutorial notebooks inside their browser with out needing to clone the Gensim repo and set up and environment. 

The link in the main tutorial page will open into a folder containing all the notebooks. I annotated one tutorial page with a link to the specific notebook. I can potentially annotate the other tutorial pages to point to specific notebooks if y'all think these links are desirable (and I have time)