### PR TITLE
Fix the off-by-one bug in the TFIDF model.

### DIFF
--- a/gensim/models/tfidfmodel.py
+++ b/gensim/models/tfidfmodel.py
@@ -392,7 +392,7 @@ class TfidfModel(interfaces.TransformationABC):
         # and finally compute the idf weights
         logger.info(
             "calculating IDF weights for %i documents and %i features (%i matrix non-zeros)",
-            self.num_docs, 1 + max([-1] + list(dfs.keys())), self.num_nnz
+            self.num_docs, max(dfs.keys()) + 1 if dfs else 0, self.num_nnz
         )
         self.idfs = precompute_idfs(self.wglobal, self.dfs, self.num_docs)
 

--- a/gensim/models/tfidfmodel.py
+++ b/gensim/models/tfidfmodel.py
@@ -390,10 +390,9 @@ class TfidfModel(interfaces.TransformationABC):
         self.num_nnz = numnnz
         self.dfs = dfs
         # and finally compute the idf weights
-        n_features = len(dfs) if dfs else 0
         logger.info(
             "calculating IDF weights for %i documents and %i features (%i matrix non-zeros)",
-            self.num_docs, n_features, self.num_nnz
+            self.num_docs, 1 + max([-1] + list(dfs.keys())), self.num_nnz
         )
         self.idfs = precompute_idfs(self.wglobal, self.dfs, self.num_docs)
 

--- a/gensim/models/tfidfmodel.py
+++ b/gensim/models/tfidfmodel.py
@@ -390,7 +390,7 @@ class TfidfModel(interfaces.TransformationABC):
         self.num_nnz = numnnz
         self.dfs = dfs
         # and finally compute the idf weights
-        n_features = max(dfs) if dfs else 0
+        n_features = len(dfs) if dfs else 0
         logger.info(
             "calculating IDF weights for %i documents and %i features (%i matrix non-zeros)",
             self.num_docs, n_features, self.num_nnz


### PR DESCRIPTION
Fixes #2375.
Use len to compute the number of features.
Since the ids are zero-indexed, Using max causes an off-by-one bug.