### PR TITLE
Fix regression bug in tutorial

### DIFF
--- a/docs/src/tut1.rst
+++ b/docs/src/tut1.rst
@@ -50,8 +50,10 @@ as well as words that only appear once in the corpus:
     >>>
     >>> # remove common words and tokenize
     >>> stoplist = set('for a of the and to in'.split())
-    >>> texts = [[word for word in document.lower().split() if word not in stoplist]
-    >>>          for document in documents]
+    >>> texts = [
+    >>>     [word for word in document.lower().split() if word not in stoplist]
+    >>>     for document in documents
+    >>> ]
     >>>
     >>> # remove words that appear only once
     >>> frequency = defaultdict(int)
@@ -59,8 +61,10 @@ as well as words that only appear once in the corpus:
     >>>     for token in text:
     >>>         frequency[token] += 1
     >>>
-    >>> texts = [[token for token in text if frequency[token] > 1]
-    >>>          for text in texts]
+    >>> texts = [
+    >>>     [token for token in text if frequency[token] > 1]
+    >>>     for text in texts
+    >>> ]
     >>>
     >>> pprint(texts)
     [['human', 'interface', 'computer'],
@@ -95,10 +99,13 @@ a question-answer pair, in the style of:
 It is advantageous to represent the questions only by their (integer) ids. The mapping
 between the questions and ids is called a dictionary:
 
->>> dictionary = corpora.Dictionary(texts)
->>> dictionary.save('/tmp/deerwester.dict')  # store the dictionary, for future reference
->>> print(dictionary)
-Dictionary(12 unique tokens)
+.. sourcecode:: pycon
+
+    >>> from gensim import corpora
+    >>> dictionary = corpora.Dictionary(texts)
+    >>> dictionary.save('/tmp/deerwester.dict')  # store the dictionary, for future reference
+    >>> print(dictionary)
+    Dictionary(12 unique tokens)
 
 Here we assigned a unique integer id to all words appearing in the corpus with the
 :class:`gensim.corpora.dictionary.Dictionary` class. This sweeps across the texts, collecting word counts
@@ -207,8 +214,11 @@ Similarly, to construct the dictionary without loading all texts into memory:
     >>> # collect statistics about all tokens
     >>> dictionary = corpora.Dictionary(line.lower().split() for line in open('mycorpus.txt'))
     >>> # remove stop words and words that appear only once
-    >>> stop_ids = [dictionary.token2id[stopword] for stopword in stoplist
-    >>>             if stopword in dictionary.token2id]
+    >>> stop_ids = [
+    >>>     dictionary.token2id[stopword]
+    >>>     for stopword in stoplist
+    >>>     if stopword in dictionary.token2id
+    >>> ]
     >>> once_ids = [tokenid for tokenid, docfreq in iteritems(dictionary.dfs) if docfreq == 1]
     >>> dictionary.filter_tokens(stop_ids + once_ids)  # remove stop words and words that appear only once
     >>> dictionary.compactify()  # remove gaps in id sequence after words that were removed


### PR DESCRIPTION
There is a minor bug in the [Corpora and vector spaces](https://radimrehurek.com/gensim/tut1.html): The import of `corpora` got removed by in #2192 [here](https://github.com/RaRe-Technologies/gensim/commit/4543646d3fe3496e11bc935e72cbf9b18504442e#diff-4c6ad40ae122a450e380ca08bda00468L23) (I assume by accident).

Identified by a confused user on our [mailing list](https://groups.google.com/forum/#!topic/gensim/1krhNlwGwDY).

This PR reconstitutes the import, plus fixes the code style since I was at it.