### PR TITLE
Make matutils.unitvec always return float norm when requested

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -733,7 +733,7 @@ def unitvec(vec, norm='l2', return_norm=False):
         if norm == 'l1':
             veclen = np.sum(np.abs(vec))
         if norm == 'l2':
-            veclen = blas_nrm2(vec)
+            veclen = blas_nrm2(vec) if len(vec) else 0.0
         if veclen > 0.0:
             if np.issubdtype(vec.dtype, np.integer):
                 vec = vec.astype(np.float)

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -725,7 +725,7 @@ def unitvec(vec, norm='l2', return_norm=False):
                 return vec
         else:
             if return_norm:
-                return vec, 1.
+                return vec, 1.0
             else:
                 return vec
 
@@ -743,14 +743,17 @@ def unitvec(vec, norm='l2', return_norm=False):
                 return blas_scal(1.0 / veclen, vec).astype(vec.dtype)
         else:
             if return_norm:
-                return vec, 1
+                return vec, 1.0
             else:
                 return vec
 
     try:
         first = next(iter(vec))  # is there at least one element?
     except StopIteration:
-        return vec
+        if return_norm:
+            return vec, 1.0
+        else:
+            return vec
 
     if isinstance(first, (tuple, list)) and len(first) == 2:  # gensim sparse format
         if norm == 'l1':

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -733,7 +733,10 @@ def unitvec(vec, norm='l2', return_norm=False):
         if norm == 'l1':
             veclen = np.sum(np.abs(vec))
         if norm == 'l2':
-            veclen = blas_nrm2(vec) if len(vec) else 0.0
+            if vec.size == 0:
+                veclen = 0.0
+            else:
+                veclen = blas_nrm2(vec)
         if veclen > 0.0:
             if np.issubdtype(vec.dtype, np.integer):
                 vec = vec.astype(np.float)

--- a/gensim/test/test_matutils.py
+++ b/gensim/test/test_matutils.py
@@ -241,6 +241,30 @@ class UnitvecTestCase(unittest.TestCase):
         self.assertTrue(np.allclose(unit_vector, man_unit_vector))
         self.assertTrue(np.issubdtype(unit_vector.dtype, np.floating))
 
+    def test_return_norm_zero_vector_scipy_sparse(self):
+        input_vector = sparse.csr_matrix([[]], dtype=np.int32)
+        return_value = matutils.unitvec(input_vector, return_norm=True)
+        self.assertTrue(isinstance(return_value, tuple))
+        norm = return_value[1]
+        self.assertTrue(isinstance(norm, float))
+        self.assertEqual(norm, 1.0)
+
+    def test_return_norm_zero_vector_numpy(self):
+        input_vector = np.array([], dtype=np.int32)
+        return_value = matutils.unitvec(input_vector, return_norm=True)
+        self.assertTrue(isinstance(return_value, tuple))
+        norm = return_value[1]
+        self.assertTrue(isinstance(norm, float))
+        self.assertEqual(norm, 1.0)
+
+    def test_return_norm_zero_vector_gensim_sparse(self):
+        input_vector = []
+        return_value = matutils.unitvec(input_vector, return_norm=True)
+        self.assertTrue(isinstance(return_value, tuple))
+        norm = return_value[1]
+        self.assertTrue(isinstance(norm, float))
+        self.assertEqual(norm, 1.0)
+
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)


### PR DESCRIPTION
Contrary to the documentation, `matutils.unitvec(…, return_norm=True)` function does not always return a float norm:

1. Zero vectors stored as numpy arrays will return an integer norm.
2. Zero vectors stored as lists of tuples (the Gensim BOW format) will return no norm.

This PR applies minimum changes to fix these two issues.