### PR TITLE
update legacy model loading, fix #2453

### DIFF
--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -1036,16 +1036,7 @@ class FastText(BaseWordEmbeddingsModel):
             from gensim.models.deprecated.fasttext import load_old_fasttext
             model = load_old_fasttext(*args, **kwargs)
 
-        if hasattr(model.wv, 'hash2index'):
-            gensim.models.keyedvectors._rollback_optimization(model.wv)
-
-        if not hasattr(model.wv, 'compatible_hash'):
-            logger.warning(
-                "This older model was trained with a buggy hash function. "
-                "The model will continue to work, but consider training it "
-                "from scratch."
-            )
-            model.wv.compatible_hash = False
+        gensim.models.keyedvectors._try_upgrade(model.wv)
 
         return model
 

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -1981,12 +1981,7 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
     @classmethod
     def load(cls, fname_or_handle, **kwargs):
         model = super(WordEmbeddingsKeyedVectors, cls).load(fname_or_handle, **kwargs)
-        if not hasattr(model, 'compatible_hash'):
-            model.compatible_hash = False
-
-        if hasattr(model, 'hash2index'):
-            _rollback_optimization(model)
-
+        _try_upgrade(model)
         return model
 
     @property
@@ -2478,3 +2473,16 @@ def _unpack(m, num_rows, hash2index, seed=1):
         m[[h, i]] = m[[i, h]]  # swap rows i and h
 
     return m
+
+
+def _try_upgrade(wv):
+    if hasattr(wv, 'hash2index'):
+        _rollback_optimization(wv)
+
+    if not hasattr(wv, 'compatible_hash'):
+        logger.warning(
+            "This older model was trained with a buggy hash function. "
+            "The model will continue to work, but consider training it "
+            "from scratch."
+        )
+        wv.compatible_hash = False

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -780,9 +780,8 @@ class TestFastTextModel(unittest.TestCase):
         self.assertTrue(model.trainables.vectors_lockf.shape == (12, ))
         self.assertTrue(model.vocabulary.cum_table.shape == (12, ))
 
-        self.assertEqual(len(model.wv.hash2index), 202)
-        self.assertTrue(model.wv.vectors_vocab.shape == (12, 100))
-        self.assertTrue(model.wv.vectors_ngrams.shape == (202, 100))
+        self.assertEqual(model.wv.vectors_vocab.shape, (12, 100))
+        self.assertEqual(model.wv.vectors_ngrams.shape, (2000000, 100))
 
         # Model stored in multiple files
         model_file = 'fasttext_old_sep'
@@ -795,9 +794,8 @@ class TestFastTextModel(unittest.TestCase):
         self.assertTrue(model.trainables.vectors_lockf.shape == (12, ))
         self.assertTrue(model.vocabulary.cum_table.shape == (12, ))
 
-        self.assertEqual(len(model.wv.hash2index), 202)
-        self.assertTrue(model.wv.vectors_vocab.shape == (12, 100))
-        self.assertTrue(model.wv.vectors_ngrams.shape == (202, 100))
+        self.assertEqual(model.wv.vectors_vocab.shape, (12, 100))
+        self.assertEqual(model.wv.vectors_ngrams.shape, (2000000, 100))
 
     def compare_with_wrapper(self, model_gensim, model_wrapper):
         # make sure we get >=2 overlapping words for top-10 similar words suggested for `night`


### PR DESCRIPTION
Previously, things like compatible_hash and _rollback_optimization were only applied to newer models.

This PR ensures they are applied to all models, including deprecated ones.

Fix #2453 