### PR TITLE
Adding type check for corpus_file argument

### DIFF
--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -795,19 +795,15 @@ class Doc2Vec(BaseWordEmbeddingsModel):
         """
         kwargs = {}
 
-        # Check if both documents and corpus_file are None
         if corpus_file is None and documents is None:
             raise TypeError("Either one of corpus_file or documents value must be provided")
 
-        # Check if both documents and corpus_file are not None
         if corpus_file is not None and documents is not None:
             raise TypeError("Both corpus_file and documents must not be provided at the same time")
 
-        # Check if corpus_file is string type
         if documents is None and not os.path.isfile(corpus_file):
             raise TypeError("Parameter corpus_file must be a valid path to a file, got %r instead" % corpus_file)
 
-        # Check if documents is iterable
         if documents is not None and not isinstance(documents, Iterable):
             raise TypeError("documents must be an iterable of list, got %r instead" % documents)
 

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -807,9 +807,9 @@ class Doc2Vec(BaseWordEmbeddingsModel):
         if not isinstance(corpus_file, string_types) and documents is None:
             raise TypeError("Parameter corpus_file must be a valid path to a file, got %s instead." % corpus_file)
 
-        # Check if documents is iterable and not string type
-        if isinstance(documents, Iterable) and isinstance(documents, string_types):
-            raise TypeError("documents must be an iterable of list and not a string type.")
+        # Check if documents is iterable
+        if not isinstance(documents, Iterable):
+            raise TypeError("documents must be an iterable of list, got %s instead." % documents)
 
         if corpus_file is not None:
             # Calculate offsets for each worker along with initial doctags (doctag ~ document/line number in a file)

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -797,19 +797,19 @@ class Doc2Vec(BaseWordEmbeddingsModel):
 
         # Check if both documents and corpus_file are None
         if corpus_file is None and documents is None:
-            raise TypeError("Either one of corpus_file or documents value must be provided.")
+            raise TypeError("Either one of corpus_file or documents value must be provided")
 
         # Check if both documents and corpus_file are not None
         if corpus_file is not None and documents is not None:
-            raise TypeError("Instead provide value to either of corpus_file or documents parameter but not both.")
+            raise TypeError("Both corpus_file and documents must not be provided at the same time")
 
         # Check if corpus_file is string type
         if documents is None and not os.path.isfile(corpus_file):
-            raise TypeError("Parameter corpus_file must be a valid path to a file, got %s instead." % corpus_file)
+            raise TypeError("Parameter corpus_file must be a valid path to a file, got %r instead" % corpus_file)
 
         # Check if documents is iterable
         if documents is not None and not isinstance(documents, Iterable):
-            raise TypeError("documents must be an iterable of list, got %s instead." % documents)
+            raise TypeError("documents must be an iterable of list, got %r instead" % documents)
 
         if corpus_file is not None:
             # Calculate offsets for each worker along with initial doctags (doctag ~ document/line number in a file)

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -800,12 +800,12 @@ class Doc2Vec(BaseWordEmbeddingsModel):
             raise TypeError("Either one of corpus_file or documents value must be provided.")
 
         # Check if both documents and corpus_file are not None
-        if corpus_file is not None and documents is not None:
+        if not ((corpus_file is None) ^ (documents is None)):
             raise TypeError("Instead provide value to either of corpus_file or documents parameter but not both.")
 
         # Check if documents is not None and not string type either
         if documents is not None and isinstance(documents, string_types):
-            raise TypeError("Documents must be an iterable of list and not a string type.")
+            raise TypeError("documents must be an iterable of list and not a string type.")
 
         # Check the type of corpus_file
         if not isinstance(corpus_file, string_types) and documents is None:

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -800,11 +800,11 @@ class Doc2Vec(BaseWordEmbeddingsModel):
             raise TypeError("Either one of corpus_file or documents value must be provided.")
 
         # Check if both documents and corpus_file are not None
-        if not ((corpus_file is None) ^ (documents is None)):
+        if corpus_file is not None and documents is not None:
             raise TypeError("Instead provide value to either of corpus_file or documents parameter but not both.")
 
         # Check if corpus_file is string type
-        if documents is None and not isinstance(corpus_file, string_types):
+        if documents is None and not os.path.isfile(corpus_file):
             raise TypeError("Parameter corpus_file must be a valid path to a file, got %s instead." % corpus_file)
 
         # Check if documents is iterable

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -70,7 +70,7 @@ try:
 except ImportError:
     from Queue import Queue  # noqa:F401
 
-from collections import namedtuple, defaultdict, Iterable
+from collections import namedtuple, defaultdict
 from timeit import default_timer
 
 from numpy import zeros, float32 as REAL, empty, ones, \

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -809,8 +809,8 @@ class Doc2Vec(BaseWordEmbeddingsModel):
 
         # Check the type of corpus_file
         if corpus_file is not None and not isinstance(corpus_file, string_types):
-            raise TypeError(f"""Parameter corpus_file of train() must be a
-                             string (path to a file) got {corpus_file} instead.""")
+            raise TypeError("""Parameter corpus_file of train() must be a
+                             string (path to an existing file) got %s instead.""" % corpus_file)
 
         if corpus_file is not None:
             # Calculate offsets for each worker along with initial doctags (doctag ~ document/line number in a file)

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -800,16 +800,17 @@ class Doc2Vec(BaseWordEmbeddingsModel):
             raise TypeError("Either one of corpus_file or documents value must be provided.")
 
         # Check if both documents and corpus_file are not None
-        if not corpus_file is None and not documents is None:
+        if corpus_file is not None and documents is not None:
             raise TypeError("Instead provide value to either of corpus_file or documents parameter but not both.")
 
         # Check if documents is not None and iterable but not string type
-        if not documents is None and isinstance(documents, Iterable) and isinstance(documents, string_types):
+        if documents is not None and isinstance(documents, Iterable) and isinstance(documents, string_types):
             raise TypeError("Documents must be an iterable of list and not a string type.")
 
         # Check the type of corpus_file
         if corpus_file is not None and not isinstance(corpus_file, string_types):
-            raise TypeError(f"Parameter corpus_file of train() must be a string (path to a file) got {corpus_file} instead.")
+            raise TypeError(f"""Parameter corpus_file of train() must be a
+                             string (path to a file) got {corpus_file} instead.""")
 
         if corpus_file is not None:
             # Calculate offsets for each worker along with initial doctags (doctag ~ document/line number in a file)

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -803,14 +803,13 @@ class Doc2Vec(BaseWordEmbeddingsModel):
         if corpus_file is not None and documents is not None:
             raise TypeError("Instead provide value to either of corpus_file or documents parameter but not both.")
 
-        # Check if documents is not None and iterable but not string type
-        if documents is not None and isinstance(documents, Iterable) and isinstance(documents, string_types):
+        # Check if documents is not None and not string type either
+        if documents is not None and isinstance(documents, string_types):
             raise TypeError("Documents must be an iterable of list and not a string type.")
 
         # Check the type of corpus_file
-        if corpus_file is not None and not isinstance(corpus_file, string_types):
-            raise TypeError("""Parameter corpus_file of train() must be a
-                             string (path to an existing file) got %s instead.""" % corpus_file)
+        if not isinstance(corpus_file, string_types) and documents is None:
+            raise TypeError("Parameter corpus_file must be a valid path to a file, got %s instead." % corpus_file)
 
         if corpus_file is not None:
             # Calculate offsets for each worker along with initial doctags (doctag ~ document/line number in a file)

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -70,7 +70,7 @@ try:
 except ImportError:
     from Queue import Queue  # noqa:F401
 
-from collections import namedtuple, defaultdict
+from collections import namedtuple, defaultdict, Iterable
 from timeit import default_timer
 
 from numpy import zeros, float32 as REAL, empty, ones, \
@@ -795,9 +795,21 @@ class Doc2Vec(BaseWordEmbeddingsModel):
         """
         kwargs = {}
 
+        # Check if both documents and corpus_file are None
+        if corpus_file is None and documents is None:
+            raise TypeError("Either one of corpus_file or documents value must be provided.")
+
+        # Check if both documents and corpus_file are not None
+        if not corpus_file is None and not documents is None:
+            raise TypeError("Instead provide value to either of corpus_file or documents parameter but not both.")
+
+        # Check if documents is not None and iterable but not string type
+        if not documents is None and isinstance(documents, Iterable) and isinstance(documents, string_types):
+            raise TypeError("Documents must be an iterable of list and not a string type.")
+
         # Check the type of corpus_file
-        if not isinstance(corpus_file, string_types):
-            raise TypeError("Parameter corpus_file of train() must be a string (path to a file).")
+        if corpus_file is not None and not isinstance(corpus_file, string_types):
+            raise TypeError(f"Parameter corpus_file of train() must be a string (path to a file) got {corpus_file} instead.")
 
         if corpus_file is not None:
             # Calculate offsets for each worker along with initial doctags (doctag ~ document/line number in a file)

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -804,11 +804,11 @@ class Doc2Vec(BaseWordEmbeddingsModel):
             raise TypeError("Instead provide value to either of corpus_file or documents parameter but not both.")
 
         # Check if corpus_file is string type
-        if not isinstance(corpus_file, string_types) and documents is None:
+        if documents is None and not isinstance(corpus_file, string_types):
             raise TypeError("Parameter corpus_file must be a valid path to a file, got %s instead." % corpus_file)
 
         # Check if documents is iterable
-        if not isinstance(documents, Iterable):
+        if documents is not None and not isinstance(documents, Iterable):
             raise TypeError("documents must be an iterable of list, got %s instead." % documents)
 
         if corpus_file is not None:

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -70,7 +70,7 @@ try:
 except ImportError:
     from Queue import Queue  # noqa:F401
 
-from collections import namedtuple, defaultdict
+from collections import namedtuple, defaultdict, Iterable
 from timeit import default_timer
 
 from numpy import zeros, float32 as REAL, empty, ones, \
@@ -803,13 +803,13 @@ class Doc2Vec(BaseWordEmbeddingsModel):
         if not ((corpus_file is None) ^ (documents is None)):
             raise TypeError("Instead provide value to either of corpus_file or documents parameter but not both.")
 
-        # Check if documents is not None and not string type either
-        if documents is not None and isinstance(documents, string_types):
-            raise TypeError("documents must be an iterable of list and not a string type.")
-
-        # Check the type of corpus_file
+        # Check if corpus_file is string type
         if not isinstance(corpus_file, string_types) and documents is None:
             raise TypeError("Parameter corpus_file must be a valid path to a file, got %s instead." % corpus_file)
+
+        # Check if documents is iterable and not string type
+        if isinstance(documents, Iterable) and isinstance(documents, string_types):
+            raise TypeError("documents must be an iterable of list and not a string type.")
 
         if corpus_file is not None:
             # Calculate offsets for each worker along with initial doctags (doctag ~ document/line number in a file)

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -794,6 +794,11 @@ class Doc2Vec(BaseWordEmbeddingsModel):
 
         """
         kwargs = {}
+
+        # Check the type of corpus_file
+        if not isinstance(corpus_file, string_types):
+            raise TypeError("Parameter corpus_file of train() must be a string (path to a file).")
+
         if corpus_file is not None:
             # Calculate offsets for each worker along with initial doctags (doctag ~ document/line number in a file)
             offsets, start_doctags = self._get_offsets_and_start_doctags_for_corpusfile(corpus_file, self.workers)

--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -904,19 +904,15 @@ class FastText(BaseWordEmbeddingsModel):
 
         """
 
-        # Check if both sentences and corpus_file are None
         if corpus_file is None and sentences is None:
             raise TypeError("Either one of corpus_file or sentences value must be provided")
 
-        # Check if both sentences and corpus_file are not None
         if corpus_file is not None and sentences is not None:
             raise TypeError("Both corpus_file and sentences must not be provided at the same time")
 
-        # Check if corpus_file is string type
         if sentences is None and not os.path.isfile(corpus_file):
             raise TypeError("Parameter corpus_file must be a valid path to a file, got %r instead" % corpus_file)
 
-        # Check if sentences is iterable
         if sentences is not None and not isinstance(sentences, Iterable):
             raise TypeError("sentences must be an iterable of list, got %r instead" % sentences)
 

--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -280,10 +280,12 @@ It consists of several important classes:
 """
 
 import logging
+import os
 
 import numpy as np
 from numpy import ones, vstack, float32 as REAL, sum as np_sum
 import six
+from collections import Iterable
 
 import gensim.models._fasttext_bin
 
@@ -901,6 +903,23 @@ class FastText(BaseWordEmbeddingsModel):
             >>> model.train(sentences, total_examples=model.corpus_count, epochs=model.epochs)
 
         """
+
+        # Check if both sentences and corpus_file are None
+        if corpus_file is None and sentences is None:
+            raise TypeError("Either one of corpus_file or sentences value must be provided")
+
+        # Check if both sentences and corpus_file are not None
+        if corpus_file is not None and sentences is not None:
+            raise TypeError("Both corpus_file and sentences must not be provided at the same time")
+
+        # Check if corpus_file is string type
+        if sentences is None and not os.path.isfile(corpus_file):
+            raise TypeError("Parameter corpus_file must be a valid path to a file, got %r instead" % corpus_file)
+
+        # Check if sentences is iterable
+        if sentences is not None and not isinstance(sentences, Iterable):
+            raise TypeError("sentences must be an iterable of list, got %r instead" % sentences)
+
         super(FastText, self).train(
             sentences=sentences, corpus_file=corpus_file, total_examples=total_examples, total_words=total_words,
             epochs=epochs, start_alpha=start_alpha, end_alpha=end_alpha, word_count=word_count,

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -173,6 +173,23 @@ class TestDoc2VecModel(unittest.TestCase):
             sims_to_infer = loaded_model.docvecs.most_similar([doc0_inferred], topn=len(loaded_model.docvecs))
             self.assertTrue(sims_to_infer)
 
+    def testDoc2vecTrainParameters(self):
+
+        model = doc2vec.Doc2Vec(vector_size=50)
+        model.build_vocab(documents=list_corpus)
+
+        # check if corpus_file is not a string
+        self.assertRaises(TypeError, model.train, corpus_file=11111)
+        # check if documents is an iterable (but not string)
+        self.assertRaises(TypeError, model.train, documents="blabla")
+        # check is both the parameters are provided
+        self.assertRaises(TypeError, model.train, documents=sentences, corpus_file='test')
+        # check if both the parameters are left empty
+        self.assertRaises(TypeError, model.train, documents=None, corpus_file=None)
+        # check if corpus_file is an iterable
+        self.assertRaises(TypeError, model.train, corpus_file=sentences)
+
+
     @unittest.skipIf(os.name == 'nt', "See another test for Windows below")
     def test_get_offsets_and_start_doctags(self):
         # Each line takes 6 bytes (including '\n' character)
@@ -387,7 +404,7 @@ class TestDoc2VecModel(unittest.TestCase):
             tmpf = get_tmpfile('gensim_doc2vec.tst')
             model.save(tmpf)
             loaded = doc2vec.Doc2Vec.load(tmpf)
-            loaded.train(sentences, total_examples=loaded.corpus_count, epochs=loaded.epochs)
+            loaded.train(documents=sentences, total_examples=loaded.corpus_count, epochs=loaded.epochs)
 
     def test_training(self):
         """Test doc2vec training."""

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -178,15 +178,10 @@ class TestDoc2VecModel(unittest.TestCase):
         model = doc2vec.Doc2Vec(vector_size=50)
         model.build_vocab(documents=list_corpus)
 
-        # check if corpus_file is not a string
         self.assertRaises(TypeError, model.train, corpus_file=11111)
-        # check if documents is an iterable
         self.assertRaises(TypeError, model.train, documents=11111)
-        # check is both the parameters are provided
         self.assertRaises(TypeError, model.train, documents=sentences, corpus_file='test')
-        # check if both the parameters are left empty
         self.assertRaises(TypeError, model.train, documents=None, corpus_file=None)
-        # check if corpus_file is an iterable
         self.assertRaises(TypeError, model.train, corpus_file=sentences)
 
     @unittest.skipIf(os.name == 'nt', "See another test for Windows below")

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -180,8 +180,8 @@ class TestDoc2VecModel(unittest.TestCase):
 
         # check if corpus_file is not a string
         self.assertRaises(TypeError, model.train, corpus_file=11111)
-        # check if documents is an iterable (but not string)
-        self.assertRaises(TypeError, model.train, documents="blabla")
+        # check if documents is an iterable
+        self.assertRaises(TypeError, model.train, documents=11111)
         # check is both the parameters are provided
         self.assertRaises(TypeError, model.train, documents=sentences, corpus_file='test')
         # check if both the parameters are left empty

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -189,7 +189,6 @@ class TestDoc2VecModel(unittest.TestCase):
         # check if corpus_file is an iterable
         self.assertRaises(TypeError, model.train, corpus_file=sentences)
 
-
     @unittest.skipIf(os.name == 'nt', "See another test for Windows below")
     def test_get_offsets_and_start_doctags(self):
         # Each line takes 6 bytes (including '\n' character)

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -95,6 +95,22 @@ class TestFastTextModel(unittest.TestCase):
         oov_vec = model.wv['minor']  # oov word
         self.assertEqual(len(oov_vec), 10)
 
+    def testFastTextTrainParameters(self):
+
+        model =  FT_gensim(size=10, min_count=1, hs=1, negative=0, seed=42, workers=1)
+        model.build_vocab(sentences=sentences)
+
+        # check if corpus_file is not a string
+        self.assertRaises(TypeError, model.train, corpus_file=11111)
+        # check if sentences is an iterable
+        self.assertRaises(TypeError, model.train, sentences=11111)
+        # check is both the parameters are provided
+        self.assertRaises(TypeError, model.train, sentences=sentences, corpus_file='test')
+        # check if both the parameters are left empty
+        self.assertRaises(TypeError, model.train, sentences=None, corpus_file=None)
+        # check if corpus_file is an iterable
+        self.assertRaises(TypeError, model.train, corpus_file=sentences)
+
     @unittest.skipIf(os.name == 'nt' and six.PY2, "corpus_file training is not supported on Windows + Py27")
     def test_training_fromfile(self):
         with temporary_file(get_tmpfile('gensim_fasttext.tst')) as corpus_file:

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -100,15 +100,10 @@ class TestFastTextModel(unittest.TestCase):
         model = FT_gensim(size=10, min_count=1, hs=1, negative=0, seed=42, workers=1)
         model.build_vocab(sentences=sentences)
 
-        # check if corpus_file is not a string
         self.assertRaises(TypeError, model.train, corpus_file=11111)
-        # check if sentences is an iterable
         self.assertRaises(TypeError, model.train, sentences=11111)
-        # check is both the parameters are provided
         self.assertRaises(TypeError, model.train, sentences=sentences, corpus_file='test')
-        # check if both the parameters are left empty
         self.assertRaises(TypeError, model.train, sentences=None, corpus_file=None)
-        # check if corpus_file is an iterable
         self.assertRaises(TypeError, model.train, corpus_file=sentences)
 
     @unittest.skipIf(os.name == 'nt' and six.PY2, "corpus_file training is not supported on Windows + Py27")

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -97,7 +97,7 @@ class TestFastTextModel(unittest.TestCase):
 
     def testFastTextTrainParameters(self):
 
-        model =  FT_gensim(size=10, min_count=1, hs=1, negative=0, seed=42, workers=1)
+        model = FT_gensim(size=10, min_count=1, hs=1, negative=0, seed=42, workers=1)
         model.build_vocab(sentences=sentences)
 
         # check if corpus_file is not a string


### PR DESCRIPTION
Add a type check for `corpus_file` argument and raise type error if the type of `corpus_file` is not a string. Fixes #2460.