### PR TITLE
potential Doc2Vec feature: reverse inference in doc2vec 

### DIFF
--- a/gensim/models/base_any2vec.py
+++ b/gensim/models/base_any2vec.py
@@ -1514,6 +1514,9 @@ class BaseWordEmbeddingsModel(BaseAny2VecModel):
                 use_vector = l1
 
         if doc_vector is not None:
+            if len(doc_vector) != self.vector_size:
+                raise RuntimeError("The length of doc_vector should be"
+                                   "equal to the vector_size parameter of length %r" % self.vector_size)
             use_vector = doc_vector
 
         # propagate hidden -> output and take softmax to get probabilities

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -951,7 +951,7 @@ class Doc2Vec(BaseWordEmbeddingsModel):
 
         return doctag_vectors[0]
 
-    def predict_output_word(self, doc_vector, topn=10):
+    def predict_words(self, doc_vector, topn=10):
         """Get the probability distribution of the words given a document vector.
 
         Parameters
@@ -966,25 +966,8 @@ class Doc2Vec(BaseWordEmbeddingsModel):
             `topn` length list of tuples of (word, probability).
 
         """
-        if not self.negative:
-            raise RuntimeError(
-                "We have currently only implemented predict_output_word for the negative sampling scheme, "
-                "so you need to have run word2vec with negative > 0 for this to work."
-            )
 
-        if len(doc_vector) != self.vector_size:
-            raise RuntimeError("The length of doc_vector should be"
-                               "equal to the vector_size parameter of length %r" % self.vector_size)
-
-        if not hasattr(self.wv, 'vectors') or not hasattr(self.trainables, 'syn1neg'):
-            raise RuntimeError("Parameters required for predicting the output words not found.")
-
-        # propagate hidden -> output and take softmax to get probabilities
-        prob_values = exp(dot(doc_vector, self.trainables.syn1neg.T))
-        prob_values /= sum(prob_values)
-        top_indices = matutils.argsort(prob_values, topn=topn, reverse=True)
-        # returning the most probable output words with their probabilities
-        return [(self.wv.index2word[index1], prob_values[index1]) for index1 in top_indices]
+        return self._find_similar_words(doc_vector=doc_vector, topn=topn)
 
     def __getitem__(self, tag):
         """Get the vector representation of (possible multi-term) tag.

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -74,8 +74,7 @@ from collections import namedtuple, defaultdict, Iterable
 from timeit import default_timer
 
 from numpy import zeros, float32 as REAL, empty, ones, \
-    memmap as np_memmap, vstack, integer, dtype, sum as np_sum, add as np_add, repeat as np_repeat, concatenate, \
-    exp, dot
+    memmap as np_memmap, vstack, integer, dtype, sum as np_sum, add as np_add, repeat as np_repeat, concatenate
 
 
 from gensim.utils import call_on_class_only

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -140,7 +140,7 @@ try:
 except ImportError:
     from Queue import Queue, Empty
 
-from numpy import exp, dot, zeros, random, dtype, float32 as REAL,\
+from numpy import dot, zeros, random, dtype, float32 as REAL,\
     uint32, seterr, array, uint8, vstack, fromstring, sqrt,\
     empty, sum as np_sum, ones, logaddexp, log, outer
 

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -195,14 +195,13 @@ class TestDoc2VecModel(unittest.TestCase):
         self.assertTrue(len(predictions_with_neg) == 5)
 
         # out-of-document document vector
-        self.assertRaises(RuntimeError, model.predict_output_word, doc_vector=[0.1,0.2])
+        self.assertRaises(RuntimeError, model.predict_output_word, doc_vector=[0.1, 0.2])
 
         # negative sampling scheme not used
         model = doc2vec.Doc2Vec(vector_size=50, negative=0)
         model.build_vocab(documents=list_corpus)
         model.train(list_corpus, total_examples=model.corpus_count, epochs=model.epochs)
         self.assertRaises(RuntimeError, model.predict_output_word, doc_vector=model.docvecs[0])
-
 
     @unittest.skipIf(os.name == 'nt', "See another test for Windows below")
     def test_get_offsets_and_start_doctags(self):

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -191,17 +191,17 @@ class TestDoc2VecModel(unittest.TestCase):
         model.build_vocab(documents=list_corpus)
         model.train(list_corpus, total_examples=model.corpus_count, epochs=model.epochs)
 
-        predictions_with_neg = model.predict_output_word(doc_vector=model.docvecs[0], topn=5)
+        predictions_with_neg = model.predict_words(doc_vector=model.docvecs[0], topn=5)
         self.assertTrue(len(predictions_with_neg) == 5)
 
         # out-of-document document vector
-        self.assertRaises(RuntimeError, model.predict_output_word, doc_vector=[0.1, 0.2])
+        self.assertRaises(RuntimeError, model.predict_words, doc_vector=[0.1, 0.2])
 
         # negative sampling scheme not used
         model = doc2vec.Doc2Vec(vector_size=50, negative=0)
         model.build_vocab(documents=list_corpus)
         model.train(list_corpus, total_examples=model.corpus_count, epochs=model.epochs)
-        self.assertRaises(RuntimeError, model.predict_output_word, doc_vector=model.docvecs[0])
+        self.assertRaises(RuntimeError, model.predict_words, doc_vector=model.docvecs[0])
 
     @unittest.skipIf(os.name == 'nt', "See another test for Windows below")
     def test_get_offsets_and_start_doctags(self):

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -184,6 +184,26 @@ class TestDoc2VecModel(unittest.TestCase):
         self.assertRaises(TypeError, model.train, documents=None, corpus_file=None)
         self.assertRaises(TypeError, model.train, corpus_file=sentences)
 
+    def testPredictOutputWord(self):
+
+        # under normal circumstances
+        model = doc2vec.Doc2Vec(vector_size=50, negative=1)
+        model.build_vocab(documents=list_corpus)
+        model.train(list_corpus, total_examples=model.corpus_count, epochs=model.epochs)
+
+        predictions_with_neg = model.predict_output_word(doc_vector=model.docvecs[0], topn=5)
+        self.assertTrue(len(predictions_with_neg) == 5)
+
+        # out-of-document document vector
+        self.assertRaises(RuntimeError, model.predict_output_word, doc_vector=[0.1,0.2])
+
+        # negative sampling scheme not used
+        model = doc2vec.Doc2Vec(vector_size=50, negative=0)
+        model.build_vocab(documents=list_corpus)
+        model.train(list_corpus, total_examples=model.corpus_count, epochs=model.epochs)
+        self.assertRaises(RuntimeError, model.predict_output_word, doc_vector=model.docvecs[0])
+
+
     @unittest.skipIf(os.name == 'nt', "See another test for Windows below")
     def test_get_offsets_and_start_doctags(self):
         # Each line takes 6 bytes (including '\n' character)


### PR DESCRIPTION
This feature is in accordance to this issue: [2459](https://github.com/RaRe-Technologies/gensim/issues/2459)

It does the following:
1. `predict_output_word` function take a document vector and returns a list of tuples having word and probability score.
2. The reference for this implementation has been taken from `Word2Vec.predict_output_word()` function.