### PR TITLE
generator support in bm25

### DIFF
--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -74,7 +74,7 @@ class BM25(object):
             Given corpus.
 
         """
-        self.corpus_size = len(corpus)
+        self.corpus_size = 0
         self.avgdl = 0
         self.doc_freqs = []
         self.idf = {}
@@ -86,6 +86,7 @@ class BM25(object):
         nd = {}  # word -> number of documents with word
         num_doc = 0
         for document in corpus:
+            self.corpus_size += 1
             self.doc_len.append(len(document))
             num_doc += len(document)
 

--- a/gensim/test/test_BM25.py
+++ b/gensim/test/test_BM25.py
@@ -14,6 +14,7 @@ import unittest
 from gensim.summarization.bm25 import get_bm25_weights
 from gensim.test.utils import common_texts
 
+
 class TestBM25(unittest.TestCase):
     def test_max_match_with_itself(self):
         """ Document should show maximum matching with itself """

--- a/gensim/test/test_BM25.py
+++ b/gensim/test/test_BM25.py
@@ -14,11 +14,19 @@ import unittest
 from gensim.summarization.bm25 import get_bm25_weights
 from gensim.test.utils import common_texts
 
-
 class TestBM25(unittest.TestCase):
     def test_max_match_with_itself(self):
         """ Document should show maximum matching with itself """
         weights = get_bm25_weights(common_texts)
+        for index, doc_weights in enumerate(weights):
+            expected = max(doc_weights)
+            predicted = doc_weights[index]
+            self.assertAlmostEqual(expected, predicted)
+
+    def test_with_generator(self):
+        """ Check above function with input as generator """
+        text_gen = (i for i in common_texts)
+        weights = get_bm25_weights(text_gen)
         for index, doc_weights in enumerate(weights):
             expected = max(doc_weights)
             predicted = doc_weights[index]


### PR DESCRIPTION
Fixes #2434.

This PR does the following:
1. Make bm25 accept generators as inputs.