### PR TITLE
Generate documentation for the gensim.similarities.termsim module

### DIFF
--- a/docs/src/apiref.rst
+++ b/docs/src/apiref.rst
@@ -71,6 +71,7 @@ Modules:
     models/deprecated/fasttext_wrapper
     models/base_any2vec
     similarities/docsim
+    similarities/termsim
     similarities/index
     sklearn_api/atmodel
     sklearn_api/d2vmodel

--- a/docs/src/similarities/termsim.rst
+++ b/docs/src/similarities/termsim.rst
@@ -1,0 +1,8 @@
+:mod:`similarities.termsim` -- Term similarity queries
+========================================================================
+
+.. automodule:: gensim.similarities.termsim
+    :synopsis: Term similarity queries
+    :members:
+    :inherited-members:
+


### PR DESCRIPTION
This pull request makes Sphinx produce the [`gensim.similarities.termsim`](https://github.com/RaRe-Technologies/gensim/blob/develop/gensim/similarities/termsim.py) module documentation.