### PR TITLE
Make most_similar accept topn of any integer type

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -162,6 +162,7 @@ from __future__ import division  # py3 "true division"
 
 from itertools import chain
 import logging
+from numbers import Integral
 
 try:
     from queue import Queue, Empty
@@ -519,7 +520,7 @@ class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
             one-dimensional numpy array with the size of the vocabulary.
 
         """
-        if isinstance(topn, int) and topn < 1:
+        if isinstance(topn, Integral) and topn < 1:
             return []
 
         if positive is None:
@@ -807,7 +808,7 @@ class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
             one-dimensional numpy array with the size of the vocabulary.
 
         """
-        if isinstance(topn, int) and topn < 1:
+        if isinstance(topn, Integral) and topn < 1:
             return []
 
         if positive is None:
@@ -1678,7 +1679,7 @@ class Doc2VecKeyedVectors(BaseKeyedVectors):
             Sequence of (doctag/index, similarity).
 
         """
-        if isinstance(topn, int) and topn < 1:
+        if isinstance(topn, Integral) and topn < 1:
             return []
 
         if positive is None:

--- a/gensim/models/poincare.py
+++ b/gensim/models/poincare.py
@@ -1189,7 +1189,8 @@ class PoincareKeyedVectors(BaseKeyedVectors):
         node_or_vector : {str, int, numpy.array}
             node key or vector for which similar nodes are to be found.
         topn : int or None, optional
-            number of similar nodes to return, if `None`, returns all.
+            Number of top-N similar nodes to return, when `topn` is int. When `topn` is None,
+            then distance for all nodes are returned.
         restrict_vocab : int or None, optional
             Optional integer which limits the range of vectors which are searched for most-similar values.
             For example, restrict_vocab=10000 would only check the first 10000 node vectors in the vocabulary order.
@@ -1197,8 +1198,10 @@ class PoincareKeyedVectors(BaseKeyedVectors):
 
         Returns
         --------
-        list of (str, float)
-            List of tuples containing (node, distance) pairs in increasing order of distance.
+        list of (str, float) or numpy.array
+            When `topn` is int, a sequence of (node, distance) is returned in increasing order of distance.
+            When `topn` is None, then similarities for all words are returned as a one-dimensional numpy array with the
+            size of the vocabulary.
 
         Examples
         --------
@@ -1216,6 +1219,9 @@ class PoincareKeyedVectors(BaseKeyedVectors):
             [(u'kangaroo.n.01', 0.0), (u'marsupial.n.01', 0.26524229460827725)]
 
         """
+        if isinstance(topn, int) and topn < 1:
+            return []
+
         if not restrict_vocab:
             all_distances = self.distances(node_or_vector)
         else:

--- a/gensim/models/poincare.py
+++ b/gensim/models/poincare.py
@@ -44,6 +44,7 @@ Initialize and train a model from a file containing one relation per line
 
 import csv
 import logging
+from numbers import Integral
 import sys
 import time
 
@@ -1219,7 +1220,7 @@ class PoincareKeyedVectors(BaseKeyedVectors):
             [(u'kangaroo.n.01', 0.0), (u'marsupial.n.01', 0.26524229460827725)]
 
         """
-        if isinstance(topn, int) and topn < 1:
+        if isinstance(topn, Integral) and topn < 1:
             return []
 
         if not restrict_vocab:

--- a/gensim/similarities/termsim.py
+++ b/gensim/similarities/termsim.py
@@ -231,8 +231,9 @@ class SparseTermSimilarityMatrix(SaveLoad):
             num_rows = nonzero_limit - num_nonzero
             most_similar = [
                 (dictionary.token2id[term], similarity)
-                for term, similarity in index.most_similar(t1, num_rows)
-                if term in dictionary.token2id]
+                for term, similarity in index.most_similar(t1, topn=num_rows)
+                if term in dictionary.token2id
+            ] if num_rows > 0 else []
 
             if tfidf is None:
                 rows = sorted(most_similar)

--- a/gensim/similarities/termsim.py
+++ b/gensim/similarities/termsim.py
@@ -209,7 +209,7 @@ class SparseTermSimilarityMatrix(SaveLoad):
                     tfidf.idfs.items(),
                     key=lambda x: (lambda term_index, term_idf: (term_idf, -term_index))(*x), reverse=True)]
 
-        column_nonzero = np.array([1] * matrix_order, dtype=_shortest_uint_dtype(nonzero_limit))
+        column_nonzero = np.array([0] * matrix_order, dtype=_shortest_uint_dtype(nonzero_limit))
         column_sum = np.zeros(matrix_order, dtype=dtype)
         matrix = sparse.identity(matrix_order, dtype=dtype, format="dok")
 
@@ -227,7 +227,7 @@ class SparseTermSimilarityMatrix(SaveLoad):
                         0.0, 1.0))
 
             t1 = dictionary[t1_index]
-            num_nonzero = column_nonzero[t1_index] - 1
+            num_nonzero = column_nonzero[t1_index]
             num_rows = nonzero_limit - num_nonzero
             most_similar = [
                 (dictionary.token2id[term], similarity)
@@ -246,7 +246,7 @@ class SparseTermSimilarityMatrix(SaveLoad):
                 if positive_definite and column_sum[t1_index] + abs(similarity) >= 1.0:
                     break
                 if symmetric:
-                    if column_nonzero[t2_index] <= nonzero_limit \
+                    if column_nonzero[t2_index] < nonzero_limit \
                             and (not positive_definite or column_sum[t2_index] + abs(similarity) < 1.0) \
                             and not (t1_index, t2_index) in matrix:
                         matrix[t1_index, t2_index] = similarity

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -109,6 +109,9 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
         predicted = self.vectors.most_similar('war', topn=0)
         self.assertEqual(len(predicted), 0)
 
+        predicted = self.vectors.most_similar('war', topn=np.uint8(0))
+        self.assertEqual(len(predicted), 0)
+
     def test_relative_cosine_similarity(self):
         """Test relative_cosine_similarity returns expected results with an input of a word pair and topn"""
         wordnet_syn = [


### PR DESCRIPTION
This PR continues #2356 and #2461 and closes #2496. The PR makes the following changes:
- d910fa9: This change is unrelated to #2496, but it fixes one implementation of `most_similar` ([`PoincareKeyedVectors`](https://github.com/RaRe-Technologies/gensim/blob/develop/gensim/models/poincare.py#L822)) that I missed in #2461.
- b34b06e: This change closes #2496 by allowing any subtype of [`numbers.Integral`](https://docs.python.org/2.7/library/numbers.html#numbers.Integral) to be accepted as the parameter `topn` in `most_similar`. This change also adds a unit test.
- b588bd7: This change is an additional defensive fix of #2496 that patches the caller of `most_similar` not to use `topn=0`. This is because there are many implementations of `most_similar` and expecting all the current and future implementations to uphold the contract seems naive.
- 83455e2: This change makes the variable notation of the [`SparseTermSimilarityMatrix`](https://github.com/RaRe-Technologies/gensim/blob/develop/gensim/similarities/termsim.py#L184) consistent and prevents a possible integer overflow.