### PR TITLE
pin sklearn version for Py2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -230,11 +230,18 @@ win_testenv = [
     'cython',
     'pyemd',
     'testfixtures',
-    'scikit-learn',
     'Morfessor==2.0.2a4',
     'python-Levenshtein >= 0.10.2',
     'visdom >= 0.1.8, != 0.1.8.7',
 ]
+
+if sys.version_info[:2] == (2, 7):
+    #
+    # The last supported version for Py2.
+    #
+    win_testenv.append('scikit-learn==0.20.3')
+else:
+    win_testenv.append('scikit-learn')
 
 linux_testenv = win_testenv[:]
 

--- a/setup.py
+++ b/setup.py
@@ -237,9 +237,12 @@ win_testenv = [
 
 if sys.version_info[:2] == (2, 7):
     #
-    # The last supported version for Py2.
+    # 0.20.3 is the last version of scikit-learn that supports Py2.
+    # Similarly, for version 5.1.1 of tornado.  We require tornado indirectly
+    # via visdom.
     #
     win_testenv.append('scikit-learn==0.20.3')
+    win_testenv.append('tornado==5.1.1')
 else:
     win_testenv.append('scikit-learn')
 


### PR DESCRIPTION
This is required to continue testing under Py2 in AppVeyor.