### PR TITLE
Typo fix

### DIFF
--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -190,7 +190,7 @@ You may continue training them on new data:
     True
 
 If you do not intend to continue training the model, consider using the
-:func:`gensim.models.FastText.load_facebook_vectors` function instead.
+:func:`gensim.models.fastText.load_facebook_vectors` function instead.
 That function only loads the word embeddings (keyed vectors), consuming much less CPU and RAM:
 
 .. sourcecode:: pycon

--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -190,7 +190,7 @@ You may continue training them on new data:
     True
 
 If you do not intend to continue training the model, consider using the
-:func:`gensim.models.fastText.load_facebook_vectors` function instead.
+:func:`gensim.models.fasttext.load_facebook_vectors` function instead.
 That function only loads the word embeddings (keyed vectors), consuming much less CPU and RAM:
 
 .. sourcecode:: pycon


### PR DESCRIPTION
Minor typo in the docs

`load_facebook_vectors` is not a method of FastText class