### PR TITLE
Update self.vector_norms after adding new vectors to gensim.models.keyedvectors.WordEmbeddingKeyedVectors

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -1348,7 +1348,7 @@ class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
         if getattr(self, 'vectors_norm', None) is None or replace:
             logger.info("precomputing L2-norms of word weight vectors")
             self.vectors_norm = _l2_norm(self.vectors, replace=replace)
-        elif (len(self.vectors_norm) == len(self.vectors)):  # if all of the vectors are precomputed
+        elif len(self.vectors_norm) == len(self.vectors):  # all vectors are precomputed
             pass
         else:  # when some newly added vectors in self.vectors are not precomputed
             logger.info("adding L2-norm vectors for new documents")


### PR DESCRIPTION
The original function of `init_sim` is checking if there are no objects in `self.vectors_norm`, then it is calculated and saved by L2-normalizing `self.vectors`. 

However, if there are any newly added vectors in `self.vectors` that have not been pre-computed into L2-normalized vectors, we should pre-compute them then add to the `self.vectors_norm`.

This is extremely useful, because although KeyedVectors have ability to add new vectors (such as inferred vectors) and their tags, they cannot execute `self.most_similar()` method for newly added vectors because the method requires lookup of `self.vectors_norm`. 