### PR TITLE
back gensim.downloader.load_info function by a cache

### DIFF
--- a/gensim/downloader.py
+++ b/gensim/downloader.py
@@ -55,6 +55,8 @@ import shutil
 import tempfile
 from functools import partial
 
+from smart_open import open
+
 if sys.version_info[0] == 2:
     import urllib
     from urllib2 import urlopen
@@ -171,6 +173,7 @@ def _load_info(url=DATA_LIST_URL, encoding='utf-8'):
     updated each time a network request _succeeds_.
     """
     cache_path = os.path.join(base_dir, 'information.json')
+    _create_base_dir()
 
     try:
         info_bytes = urlopen(url).read()

--- a/gensim/downloader.py
+++ b/gensim/downloader.py
@@ -177,7 +177,7 @@ def _load_info(url=DATA_LIST_URL, encoding='utf-8'):
 
     try:
         info_bytes = urlopen(url).read()
-    except (OSError, IOError) as err:
+    except (OSError, IOError):
         #
         # The exception raised by urlopen differs between Py2 and Py3.
         #

--- a/gensim/downloader.py
+++ b/gensim/downloader.py
@@ -183,7 +183,7 @@ def _load_info(url=DATA_LIST_URL, encoding='utf-8'):
         #
         logger.error('caught non-fatal exception, see trace below')
         logger.exception(err)
-        logger.error('attempting to recover from local cache (%r)', cache_path)
+        logger.error('attempting to recover from local cache %r', cache_path)
     else:
         with open(cache_path, 'wb') as fout:
             fout.write(info_bytes)

--- a/gensim/downloader.py
+++ b/gensim/downloader.py
@@ -45,6 +45,7 @@ Also, this API available via CLI::
 from __future__ import absolute_import
 import argparse
 import os
+import io
 import json
 import logging
 import sys
@@ -54,8 +55,6 @@ import math
 import shutil
 import tempfile
 from functools import partial
-
-from smart_open import open
 
 if sys.version_info[0] == 2:
     import urllib
@@ -193,7 +192,10 @@ def _load_info(url=DATA_LIST_URL, encoding='utf-8'):
             fout.write(info_bytes)
 
     try:
-        with open(cache_path, 'r', encoding=encoding) as fin:
+        #
+        # We need io.open here because Py2 open doesn't support encoding keyword
+        #
+        with io.open(cache_path, 'r', encoding=encoding) as fin:
             return json.load(fin)
     except IOError:
         raise ValueError(

--- a/gensim/downloader.py
+++ b/gensim/downloader.py
@@ -193,8 +193,10 @@ def _load_info(url=DATA_LIST_URL, encoding='utf-8'):
         with open(cache_path, 'r', encoding=encoding) as fin:
             return json.load(fin)
     except IOError:
-        raise ValueError('unable to read local cache %r during fallback' % cache_path)
-
+        raise ValueError(
+            'unable to read local cache %r during fallback, '
+            'connect to the Internet and retry' % cache_path
+        )
 
 
 def info(name=None, show_only_latest=True, name_only=False):


### PR DESCRIPTION
Currently, it's not possible to use the gensim.downloader submodule without a network connection, even for datasets that have already been downloaded.

This PR removes the above restriction by keeping the dataset information in a local cache. This cache gets updated transparently.

You can confirm it works via:

```
$ python -m gensim.downloader --info | head
{
    "corpora": {
        "semeval-2016-2017-task3-subtaskBC": {
            "num_records": -1,
            "record_format": "dict",
            "file_size": 6344358,
            "reader_code": "https://github.com/RaRe-Technologies/gensim-data/releases/download/semeval-2016-2017-task3-subtaskB-eng/__init__.py",
            "license": "All files released for the task are free for general research use",
            "fields": {
                "2016-train": [
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
BrokenPipeError: [Errno 32] Broken pipe
```

and then repeating the above command after disconnecting from the network.