### PR TITLE
fix python version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import warnings
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 
-if sys.version_info[:2] < (2, 7) or (sys.version_info[:1] == 3 and sys.version_info[:2] < (3, 5)):
+if sys.version_info[:2] < (2, 7) or (sys.version_info[:1][0] == 3 and sys.version_info[:2] < (3, 5)):
     raise Exception('This version of gensim needs Python 2.7, 3.5 or later.')
 
 # the following code is adapted from tornado's setup.py:

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ import warnings
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 
+PY2 = sys.version_info[0] == 2
+
 if sys.version_info[:2] < (2, 7) or ((3, 0) <= sys.version_info[:2] < (3, 5)):
     raise Exception('This version of gensim needs Python 2.7, 3.5 or later.')
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import warnings
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 
-if sys.version_info[:2] < (2, 7) or (sys.version_info[:1][0] == 3 and sys.version_info[:2] < (3, 5)):
+if sys.version_info[:2] < (2, 7) or ((3, 0) <= sys.version_info[:2] < (3, 5)):
     raise Exception('This version of gensim needs Python 2.7, 3.5 or later.')
 
 # the following code is adapted from tornado's setup.py:


### PR DESCRIPTION
python version check is wrong now.
it uses sys.version_info[:1] but it returns tuples not Integer.
so it always fails.

I just fixed it

Thanks.