### PR TITLE
Doc-comment class Doc2Vec only via __init__ method

### DIFF
--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -552,10 +552,10 @@ class Doc2Vec(BaseWordEmbeddingsModel):
 
         trainables : :class:`~gensim.models.doc2vec.Doc2VecTrainables`
             This object represents the inner shallow neural network used to train the embeddings. The semantics of the
-            network differ slightly in the two available training modes (CBOW or SG) but you can think of it as a NN 
-            with a single projection and hidden layer which we train on the corpus. The weights are then used as our 
-            embeddings. The only addition to the underlying NN used in :class:`~gensim.models.word2vec.Word2Vec` is 
-            that the input includes not only the word vectors of each word in the context, but also the paragraph 
+            network differ slightly in the two available training modes (CBOW or SG) but you can think of it as a NN
+            with a single projection and hidden layer which we train on the corpus. The weights are then used as our
+            embeddings. The only addition to the underlying NN used in :class:`~gensim.models.word2vec.Word2Vec` is
+            that the input includes not only the word vectors of each word in the context, but also the paragraph
             vector.
         """
         if 'sentences' in kwargs:

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -434,43 +434,11 @@ class Doctag(namedtuple('Doctag', 'offset, word_count, doc_count')):
 
 
 class Doc2Vec(BaseWordEmbeddingsModel):
-    """Class for training, using and evaluating neural networks described in
-    `Distributed Representations of Sentences and Documents <http://arxiv.org/abs/1405.4053v2>`_.
-
-    Some important internal attributes are the following:
-
-    Attributes
-    ----------
-    wv : :class:`~gensim.models.keyedvectors.Word2VecKeyedVectors`
-        This object essentially contains the mapping between words and embeddings. After training, it can be used
-        directly to query those embeddings in various ways. See the module level docstring for examples.
-
-    docvecs : :class:`~gensim.models.keyedvectors.Doc2VecKeyedVectors`
-        This object contains the paragraph vectors learned from the training data. There will be one such vector
-        for each unique document tag supplied during training. They may be individually accessed using the tag
-        as an indexed-access key. For example, if one of the training documents used a tag of 'doc003':
-
-        .. sourcecode:: pycon
-
-            >>> model.docvecs['doc003']
-
-    vocabulary : :class:`~gensim.models.doc2vec.Doc2VecVocab`
-        This object represents the vocabulary (sometimes called Dictionary in gensim) of the model.
-        Besides keeping track of all unique words, this object provides extra functionality, such as
-        sorting words by frequency, or discarding extremely rare words.
-
-    trainables : :class:`~gensim.models.doc2vec.Doc2VecTrainables`
-        This object represents the inner shallow neural network used to train the embeddings. The semantics of the
-        network differ slightly in the two available training modes (CBOW or SG) but you can think of it as a NN with
-        a single projection and hidden layer which we train on the corpus. The weights are then used as our embeddings
-        The only addition to the underlying NN used in :class:`~gensim.models.word2vec.Word2Vec` is that the input
-        includes not only the word vectors of each word in the context, but also the paragraph vector.
-
-    """
     def __init__(self, documents=None, corpus_file=None, dm_mean=None, dm=1, dbow_words=0, dm_concat=0,
                  dm_tag_count=1, docvecs=None, docvecs_mapfile=None, comment=None, trim_rule=None, callbacks=(),
                  **kwargs):
-        """
+        """Class for training, using and evaluating neural networks described in
+        `Distributed Representations of Sentences and Documents <http://arxiv.org/abs/1405.4053v2>`_.
 
         Parameters
         ----------
@@ -559,6 +527,35 @@ class Doc2Vec(BaseWordEmbeddingsModel):
         callbacks : :obj: `list` of :obj: `~gensim.models.callbacks.CallbackAny2Vec`, optional
             List of callbacks that need to be executed/run at specific stages during training.
 
+
+        Some important internal attributes are the following:
+
+        Attributes
+        ----------
+        wv : :class:`~gensim.models.keyedvectors.Word2VecKeyedVectors`
+            This object essentially contains the mapping between words and embeddings. After training, it can be used
+            directly to query those embeddings in various ways. See the module level docstring for examples.
+
+        docvecs : :class:`~gensim.models.keyedvectors.Doc2VecKeyedVectors`
+            This object contains the paragraph vectors learned from the training data. There will be one such vector
+            for each unique document tag supplied during training. They may be individually accessed using the tag
+            as an indexed-access key. For example, if one of the training documents used a tag of 'doc003':
+
+            .. sourcecode:: pycon
+
+                >>> model.docvecs['doc003']
+
+        vocabulary : :class:`~gensim.models.doc2vec.Doc2VecVocab`
+            This object represents the vocabulary (sometimes called Dictionary in gensim) of the model.
+            Besides keeping track of all unique words, this object provides extra functionality, such as
+            sorting words by frequency, or discarding extremely rare words.
+
+        trainables : :class:`~gensim.models.doc2vec.Doc2VecTrainables`
+            This object represents the inner shallow neural network used to train the embeddings. The semantics of the
+            network differ slightly in the two available training modes (CBOW or SG) but you can think of it as a NN with
+            a single projection and hidden layer which we train on the corpus. The weights are then used as our embeddings
+            The only addition to the underlying NN used in :class:`~gensim.models.word2vec.Word2Vec` is that the input
+            includes not only the word vectors of each word in the context, but also the paragraph vector.
         """
         if 'sentences' in kwargs:
             raise DeprecationWarning(

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -552,10 +552,11 @@ class Doc2Vec(BaseWordEmbeddingsModel):
 
         trainables : :class:`~gensim.models.doc2vec.Doc2VecTrainables`
             This object represents the inner shallow neural network used to train the embeddings. The semantics of the
-            network differ slightly in the two available training modes (CBOW or SG) but you can think of it as a NN with
-            a single projection and hidden layer which we train on the corpus. The weights are then used as our embeddings
-            The only addition to the underlying NN used in :class:`~gensim.models.word2vec.Word2Vec` is that the input
-            includes not only the word vectors of each word in the context, but also the paragraph vector.
+            network differ slightly in the two available training modes (CBOW or SG) but you can think of it as a NN 
+            with a single projection and hidden layer which we train on the corpus. The weights are then used as our 
+            embeddings. The only addition to the underlying NN used in :class:`~gensim.models.word2vec.Word2Vec` is 
+            that the input includes not only the word vectors of each word in the context, but also the paragraph 
+            vector.
         """
         if 'sentences' in kwargs:
             raise DeprecationWarning(


### PR DESCRIPTION
For consideration/discussion: having both a class doc-comment, and an `__init__` method doc-comment, means both are stitched together in HTML docs (https://radimrehurek.com/gensim/models/doc2vec.html#gensim.models.doc2vec.Doc2Vec), **and** the parameter-details that every user needs to consult wind up **below** the confusing mess of internal-attributes that hardly anyone cares about. Google's Python doc-comment conventions suggest that a class and its parameters can be documented either under the class declaration, **or** under the `__init__` method, but not split between both. (See, eg: <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html>). Here I've moved the notes about the class under `__init__()`, as that seems to get the most important info – init parameters - to where both code- and doc- readers will most easily find it.