### PR TITLE
Add hacktoberfest-related documentation

### DIFF
--- a/HACKTOBERFEST.md
+++ b/HACKTOBERFEST.md
@@ -6,7 +6,7 @@ We've prepared a list of good issues to work on: [gensim hacktoberfest issues](h
 
 If the learning curve for `gensim` is a bit steep, give the [smart_open](https://github.com/RaRe-Technologies/smart_open) repository a try.
 `smart_open` is an important dependency of `gensim`: it performs file I/O over a variety of protocols and formats.
-There's also a list of Hacktoberfest-friendly issues to work on [smart_open hacktoberfest issues](https://github.com/RaRe-Technologies/smart_open/labels/hacktoberfest).
+There's also a list of Hacktoberfest-friendly issues to work on: [smart_open hacktoberfest issues](https://github.com/RaRe-Technologies/smart_open/labels/hacktoberfest).
 
 Of course, we welcome contributions on any of the existing issues, not just the ones labeled `hacktoberfest`.
 Just be sure that no-one else is already working on it first.

--- a/HACKTOBERFEST.md
+++ b/HACKTOBERFEST.md
@@ -11,7 +11,10 @@ There's also a list of Hacktoberfest-friendly issues to work on [here](https://g
 Of course, we welcome contributions on any of the existing issues, not just the ones labeled `hacktoberfest`.
 Just be sure that no-one else is already working on it first.
 
-Furthermore, we also welcome contributions not connected to an existing issues.
+Furthermore, we also welcome contributions not connected to an existing issue.
+This includes things like fixing typos in documentation, docstrings, etc.
+If you make such contributions, please make the motivation behind the contribution clear.
+Please avoid making innocuous changes without sufficient motivation (e.g. changing code formatting, etc).
 
 ## Before Contributing
 

--- a/HACKTOBERFEST.md
+++ b/HACKTOBERFEST.md
@@ -2,11 +2,11 @@
 
 It's that time of the year again!
 [Hacktoberfest](https://hacktoberfest.digitalocean.com) is here, and `gensim` needs **your** help.
-We've prepared a list of good issues to work on [here](https://github.com/RaRe-Technologies/gensim/labels/hacktoberfest).
+We've prepared a list of good issues to work on: [gensim hacktoberfest issues](https://github.com/RaRe-Technologies/gensim/labels/hacktoberfest).
 
 If the learning curve for `gensim` is a bit steep, give the [smart_open](https://github.com/RaRe-Technologies/smart_open) repository a try.
 `smart_open` is an important dependency of `gensim`: it performs file I/O over a variety of protocols and formats.
-There's also a list of Hacktoberfest-friendly issues to work on [here](https://github.com/RaRe-Technologies/smart_open/labels/hacktoberfest).
+There's also a list of Hacktoberfest-friendly issues to work on [smart_open hacktoberfest issues](https://github.com/RaRe-Technologies/smart_open/labels/hacktoberfest).
 
 Of course, we welcome contributions on any of the existing issues, not just the ones labeled `hacktoberfest`.
 Just be sure that no-one else is already working on it first.
@@ -23,5 +23,10 @@ Check out the following:
 - [First-time contributors guide](https://github.com/firstcontributions/first-contributions): if this is your first time contributing on GitHub.
 - [Hacktoberfest rules](https://hacktoberfest.digitalocean.com/faq#rules): read this in full
 - [Developer page](https://github.com/RaRe-Technologies/gensim/wiki/Developer-page) on our Wiki: for the git flow, code style, etc.
+
+## Questions
+
+If you have a questiona about a specific issue or PR, just ask there directly, and we'll get back to you as soon as we can.
+Otherwise, ping @mpenkov on [Twitter](https://twitter.com/mpenkov) or [Telegram](https://t.me/mpenkov).
 
 Happy Hacking!!

--- a/HACKTOBERFEST.md
+++ b/HACKTOBERFEST.md
@@ -1,0 +1,24 @@
+# :pizza: Hacktoberfest 2019 :beer:
+
+It's that time of the year again!
+[Hacktoberfest](https://hacktoberfest.digitalocean.com) is here, and `gensim` needs **your** help.
+We've prepared a list of good issues to work on [here](https://github.com/RaRe-Technologies/gensim/labels/hacktoberfest).
+
+If the learning curve for `gensim` is a bit steep, give the [smart_open](https://github.com/RaRe-Technologies/smart_open) repository a try.
+`smart_open` is an important dependency of `gensim`: it performs file I/O over a variety of protocols and formats.
+There's also a list of Hacktoberfest-friendly issues to work on [here](https://github.com/RaRe-Technologies/smart_open/labels/hacktoberfest).
+
+Of course, we welcome contributions on any of the existing issues, not just the ones labeled `hacktoberfest`.
+Just be sure that no-one else is already working on it first.
+
+Furthermore, we also welcome contributions not connected to an existing issues.
+
+## Before Contributing
+
+Check out the following:
+
+- [First-time contributors guide](https://github.com/firstcontributions/first-contributions): if this is your first time contributing on GitHub.
+- [Hacktoberfest rules](https://hacktoberfest.digitalocean.com/faq#rules): read this in full
+- [Developer page](https://github.com/RaRe-Technologies/gensim/wiki/Developer-page) on our Wiki: for the git flow, code style, etc.
+
+Happy Hacking!!

--- a/HACKTOBERFEST.md
+++ b/HACKTOBERFEST.md
@@ -9,11 +9,13 @@ If the learning curve for `gensim` is a bit steep, give the [smart_open](https:/
 There's also a list of Hacktoberfest-friendly issues to work on: [smart_open hacktoberfest issues](https://github.com/RaRe-Technologies/smart_open/labels/hacktoberfest).
 
 Of course, we welcome contributions on any of the existing issues, not just the ones labeled `hacktoberfest`.
-Just be sure that no-one else is already working on it first.
+If the issue is simple & quick, you can just submit your PR, with a proper reference to the issue it addresses.
+If the issue requires a little more work, but you have a good idea of how to proceed & know when you'll be submitting some initial work, please post a short note about your plans to the issue, or a "work-in-progress" ("[WIP]") pull-request indicating work is underway, to help avoid wasted duplicate work.
 
 Furthermore, we also welcome contributions not connected to an existing issue.
 This includes things like fixing typos in documentation, docstrings, etc.
 If you make such contributions, please make the motivation behind the contribution clear.
+You could start such a contribution with a new pull-request, or if you think it requires other discussion beforehand, as a separate new issue.
 Please avoid making innocuous changes without sufficient motivation (e.g. changing code formatting, etc).
 
 ## Before Contributing
@@ -26,7 +28,8 @@ Check out the following:
 
 ## Questions
 
-If you have a questiona about a specific issue or PR, just ask there directly, and we'll get back to you as soon as we can.
+If you have a general question about Gensim, please ask on the [mailing list](https://groups.google.com/forum/#!forum/gensim).
+If you have a question a about a specific issue or PR, just ask there directly, and we'll get back to you as soon as we can.
 Otherwise, ping @mpenkov on [Twitter](https://twitter.com/mpenkov) or [Telegram](https://t.me/mpenkov).
 
 Happy Hacking!!

--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@ gensim – Topic Modelling in Python
 [![Gitter](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-09a3d5.svg)](https://gitter.im/RaRe-Technologies/gensim)
 [![Follow](https://img.shields.io/twitter/follow/gensim_py.svg?style=social&label=Follow)](https://twitter.com/gensim_py)
 
-
-
 Gensim is a Python library for *topic modelling*, *document indexing*
 and *similarity retrieval* with large corpora. Target audience is the
 *natural language processing* (NLP) and *information retrieval* (IR)
 community.
+
+## :pizza: Hacktoberfest 2019 :beer:
+
+We are accepting PRs for Hacktoberfest!
+See [here](HACKTOBERFEST.md) for details.
 
 Features
 --------


### PR DESCRIPTION
I'm following up on hacktoberfest hints from the numfocus people. This document should help people get started contributing for Hacktoberfest. I've already gone through the tickets for gensim and smart_open and picked out several dozen for people to work on.

Once this is merged, it'd be good to attract people via Twitter, etc.