### PR TITLE
Account for empty corpus in HDPModel. Fixes #2563

### DIFF
--- a/gensim/models/hdpmodel.py
+++ b/gensim/models/hdpmodel.py
@@ -339,6 +339,8 @@ class HdpModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             corresponding lda model from :meth:`~gensim.models.hdpmodel.HdpModel.suggested_lda_model`
 
         """
+        if len(corpus) == 0:
+            raise RuntimeError("cannot initialize model with empty corpus")
         self.corpus = corpus
         self.id2word = id2word
         self.chunksize = chunksize


### PR DESCRIPTION
There are a couple of ways to go about preventing the infinite loop mentioned in the Issue from occurring. I thought maybe to user logger.error, or to skip the while loop if the corpus is empty. ButI saw in the _inference_ method that a RunTimeError is thrown when lda_alpha and lda_beta are not initialized. So I thought this seemed consistent.