### PR TITLE
Increase max supported numpy version to < 1.17.0 for py2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -233,7 +233,7 @@ Copyright (c) 2009-now Radim Rehurek
 # https://docs.pytest.org/en/latest/py27-py34-deprecation.html
 #
 if PY2:
-    NUMPY_STR = 'numpy >= 1.11.3, <= 1.16.1'
+    NUMPY_STR = 'numpy >= 1.11.3, < 1.17.0'
     PYTEST_STR = 'pytest == 4.6.4'
 else:
     NUMPY_STR = 'numpy >= 1.11.3'


### PR DESCRIPTION
Fix #2634

As reported in the issue, the last version of numpy that supported python2 was 1.16.5, so this requirement can be increased slightly from 1.16.1