### PR TITLE
Optimizing load_word2vec_format for binary equal to true

### DIFF
--- a/gensim/models/utils_any2vec.py
+++ b/gensim/models/utils_any2vec.py
@@ -382,7 +382,8 @@ def _load_word2vec_format(cls, fname, fvocab=None, binary=False, encoding='utf8'
                 word = utils.to_unicode(b''.join(word), encoding=encoding, errors=unicode_errors)
                 with utils.ignore_deprecation_warning():
                     # TODO use frombuffer or something similar
-                    weights = fromstring(fin.read(binary_len), dtype=REAL).astype(datatype)
+                    raw_data=fin.read(binary_len).split()
+                    weights = np.array(raw_data, dtype=REAL).astype(datatype)
                 add_word(word, weights)
         else:
             for line_no in range(vocab_size):


### PR DESCRIPTION
#2642  Changed numpy.fromstring() to split() because it is slow in comparision to split().