### PR TITLE
Improve Dynamic Topic Model (DTM) documentation

### DIFF
--- a/gensim/models/wrappers/dtmmodel.py
+++ b/gensim/models/wrappers/dtmmodel.py
@@ -98,7 +98,9 @@ class DtmModel(utils.SaveLoad):
         alpha : int, optional
             Hyperparameter that affects sparsity of the document-topics for the LDA models in each timeslice.
         top_chain_var : float, optional
-            Hyperparameter that determines how similar topics would be over multiple timeslice.
+            This hyperparameter controls one of the key aspect of topic evolution which is the speed at which
+            these topics evolve. A smaller top_chain_var leads to similar word distributions over multiple timeslice.
+
         rng_seed : int, optional
              Random seed.
         initialize_lda : bool, optional

--- a/gensim/models/wrappers/dtmmodel.py
+++ b/gensim/models/wrappers/dtmmodel.py
@@ -97,8 +97,8 @@ class DtmModel(utils.SaveLoad):
              Max em optimization iterations in LDA.
         alpha : int, optional
             Hyperparameter that affects sparsity of the document-topics for the LDA models in each timeslice.
-        top_chain_var : int, optional
-            Hyperparameter that affects.
+        top_chain_var : float, optional
+            Hyperparameter that determines how similar topics would be over multiple timeslice.
         rng_seed : int, optional
              Random seed.
         initialize_lda : bool, optional


### PR DESCRIPTION
make correction for the datatype for top_chain_var from int to float & updated the documentation on the description of the variable. 

Fixes #2637.