### PR TITLE
[Issue-2670] Bug fix: Initialize doc_no2 because it is not set when corpus' is empty

### DIFF
--- a/gensim/models/logentropy_model.py
+++ b/gensim/models/logentropy_model.py
@@ -108,6 +108,8 @@ class LogEntropyModel(interfaces.TransformationABC):
             self.n_docs, len(glob_freq), self.n_words
         )
         logger.debug('iterating over corpus')
+        # initial doc2 in case corpus is empty
+        doc_no2 = 0
         for doc_no2, bow in enumerate(corpus):
             for key, freq in bow:
                 p = (float(freq) / glob_freq[key]) * math.log(float(freq) / glob_freq[key])

--- a/gensim/models/logentropy_model.py
+++ b/gensim/models/logentropy_model.py
@@ -108,7 +108,8 @@ class LogEntropyModel(interfaces.TransformationABC):
             self.n_docs, len(glob_freq), self.n_words
         )
         logger.debug('iterating over corpus')
-        # initial doc2 in case corpus is empty
+
+        # initialize doc_no2 index in case corpus is empty
         doc_no2 = 0
         for doc_no2, bow in enumerate(corpus):
             for key, freq in bow:

--- a/gensim/test/test_logentropy_model.py
+++ b/gensim/test/test_logentropy_model.py
@@ -26,32 +26,19 @@ class TestLogEntropyModel(unittest.TestCase):
         self.corpus_ok = MmCorpus(datapath('test_corpus_ok.mm'))
         self.corpus_empty = []
 
-    def testGeneratorFail(self):
-        # attempt to create model generator
+    def test_generator_fail(self):
+        """Test creating a model using a generator as input; should fail.
+        """
         def get_generator(test_corpus=TestLogEntropyModel.TEST_CORPUS):
             for test_doc in test_corpus:
                 yield test_doc
-        try:
-            model = logentropy_model.LogEntropyModel(get_generator())
-        except ValueError:
-            model = 'None'
-        except Exception:
-            model = 'Other'
-        # logentropy_model.LogEntropyModel should throw a value error
-        self.assertNotEqual(model, 'Other', "Invalid error state.")
-        self.assertEqual(model, 'None')
+        
+        self.assertRaises(ValueError, logentropy_model.LogEntropyModel, get_generator())
 
-    def testEmptyFail(self):
-        # attempt to create model with empty corpus
-        try:
-            model = logentropy_model.LogEntropyModel(self.corpus_empty)
-        except ValueError:
-            model = 'None'
-        except Exception:
-            model = 'Other'
-        # logentropy_model.LogEntropyModel should throw a value error
-        self.assertNotEqual(model, 'Other', "Invalid error state.")
-        self.assertEqual(model, 'None')
+    def test_empty_fail(self):
+        """Test creating a model using an empty input; should fail.
+        """
+        self.assertRaises(ValueError, logentropy_model.LogEntropyModel, self.corpus_empty)
 
     def testTransform(self):
         # create the transformation model

--- a/gensim/test/test_logentropy_model.py
+++ b/gensim/test/test_logentropy_model.py
@@ -24,7 +24,7 @@ class TestLogEntropyModel(unittest.TestCase):
     def setUp(self):
         self.corpus_small = MmCorpus(datapath('test_corpus_small.mm'))
         self.corpus_ok = MmCorpus(datapath('test_corpus_ok.mm'))
-        self.corpus_empty = [[()]]
+        self.corpus_empty = []
 
     def testGeneratorFail(self):
         # attempt to create model generator

--- a/gensim/test/test_logentropy_model.py
+++ b/gensim/test/test_logentropy_model.py
@@ -19,9 +19,42 @@ from gensim.test.utils import datapath, get_tmpfile
 
 
 class TestLogEntropyModel(unittest.TestCase):
+    TEST_CORPUS = [[(1, 1.0)], [], [(0, 0.5), (2, 1.0)], []]
+
     def setUp(self):
         self.corpus_small = MmCorpus(datapath('test_corpus_small.mm'))
         self.corpus_ok = MmCorpus(datapath('test_corpus_ok.mm'))
+        self.corpus_empty = [[()]]
+
+    def testGeneratorFail(self):
+        # attempt to create model generator
+        def get_generator(test_corpus=TestLogEntropyModel.TEST_CORPUS):
+            for iter in test_corpus:
+                yield iter
+        
+        try:
+            model = logentropy_model.LogEntropyModel(get_generator())
+        except ValueError as val_err:
+            model = 'None'
+        except Exception as val_err:
+            model = 'Other'
+            
+        # logentropy_model.LogEntropyModel should throw a value error
+        self.assertNotEqual(model, 'Other', "Invalid error state.")
+        self.assertEqual(model, 'None')
+
+    def testEmptyFail(self):
+        # attempt to create model with empty corpus
+        try:
+            model = logentropy_model.LogEntropyModel(self.corpus_empty)
+        except ValueError as val_err:
+            model = 'None'
+        except Exception as val_err:
+            model = 'Other'
+
+        # logentropy_model.LogEntropyModel should throw a value error                                
+        self.assertNotEqual(model, 'Other', "Invalid error state.")
+        self.assertEqual(model, 'None')
 
     def testTransform(self):
         # create the transformation model

--- a/gensim/test/test_logentropy_model.py
+++ b/gensim/test/test_logentropy_model.py
@@ -29,8 +29,8 @@ class TestLogEntropyModel(unittest.TestCase):
     def testGeneratorFail(self):
         # attempt to create model generator
         def get_generator(test_corpus=TestLogEntropyModel.TEST_CORPUS):
-            for iter in test_corpus:
-                yield iter
+            for test_doc in test_corpus:
+                yield test_doc
         
         try:
             model = logentropy_model.LogEntropyModel(get_generator())

--- a/gensim/test/test_logentropy_model.py
+++ b/gensim/test/test_logentropy_model.py
@@ -31,14 +31,12 @@ class TestLogEntropyModel(unittest.TestCase):
         def get_generator(test_corpus=TestLogEntropyModel.TEST_CORPUS):
             for test_doc in test_corpus:
                 yield test_doc
-        
         try:
             model = logentropy_model.LogEntropyModel(get_generator())
-        except ValueError as val_err:
+        except ValueError:
             model = 'None'
-        except Exception as val_err:
+        except Exception:
             model = 'Other'
-            
         # logentropy_model.LogEntropyModel should throw a value error
         self.assertNotEqual(model, 'Other', "Invalid error state.")
         self.assertEqual(model, 'None')
@@ -47,12 +45,11 @@ class TestLogEntropyModel(unittest.TestCase):
         # attempt to create model with empty corpus
         try:
             model = logentropy_model.LogEntropyModel(self.corpus_empty)
-        except ValueError as val_err:
+        except ValueError:
             model = 'None'
-        except Exception as val_err:
+        except Exception:
             model = 'Other'
-
-        # logentropy_model.LogEntropyModel should throw a value error                                
+        # logentropy_model.LogEntropyModel should throw a value error
         self.assertNotEqual(model, 'Other', "Invalid error state.")
         self.assertEqual(model, 'None')
 

--- a/gensim/test/test_logentropy_model.py
+++ b/gensim/test/test_logentropy_model.py
@@ -27,18 +27,15 @@ class TestLogEntropyModel(unittest.TestCase):
         self.corpus_empty = []
 
     def test_generator_fail(self):
-        """Test creating a model using a generator as input; should fail.
-        """
+        """Test creating a model using a generator as input; should fail."""
         def get_generator(test_corpus=TestLogEntropyModel.TEST_CORPUS):
             for test_doc in test_corpus:
                 yield test_doc
-        
-        self.assertRaises(ValueError, logentropy_model.LogEntropyModel, get_generator())
+        self.assertRaises(ValueError, logentropy_model.LogEntropyModel, corpus=get_generator())
 
     def test_empty_fail(self):
-        """Test creating a model using an empty input; should fail.
-        """
-        self.assertRaises(ValueError, logentropy_model.LogEntropyModel, self.corpus_empty)
+        """Test creating a model using an empty input; should fail."""
+        self.assertRaises(ValueError, logentropy_model.LogEntropyModel, corpus=self.corpus_empty)
 
     def testTransform(self):
         # create the transformation model


### PR DESCRIPTION
Fix #2670: Initialize doc_no2 variable because it is not initialized when the 'corpus' is empty.