### PR TITLE
Warn when BM25.average_idf < 0

### DIFF
--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -37,6 +37,7 @@ Data:
 """
 
 
+import logging
 import math
 from six import iteritems
 from six.moves import range
@@ -47,6 +48,8 @@ from ..utils import effective_n_jobs
 PARAM_K1 = 1.5
 PARAM_B = 0.75
 EPSILON = 0.25
+
+logger = logging.getLogger(__name__)
 
 
 class BM25(object):
@@ -115,6 +118,13 @@ class BM25(object):
             if idf < 0:
                 negative_idfs.append(word)
         self.average_idf = float(idf_sum) / len(self.idf)
+
+        if self.average_idf < 0:
+            logger.warning(
+                'Average inverse document frequency is less than zero. Your corpus of {} documents'
+                ' is either too small or it does not originate from natural text. BM25 may produce'
+                ' unintuitive results.'.format(self.corpus_size)
+            )
 
         eps = EPSILON * self.average_idf
         for word in negative_idfs:


### PR DESCRIPTION
When the BM25 model is trained on a corpus that is too small or artificially created from non-textual data, many words can occur in more than a half of the entire corpus, making the average inverse document frequency (IDF) negative. This breaks the assumptions of BM25 and may produce confusing results, see #2684. This PR adds a warning that informs the user that a corpus breaks the assumptions of BM25:
```python
>> import logging
>>
>> logging.basicConfig(level=logging.INFO)
>>
>> from gensim.summarization.bm25 import BM25
>>
>> text1 = \
>>     'A constellation is a group of stars that are considered to form imaginary outlines'
>>     ' or meaningful patterns on the celestial sphere.'
>> text2 = \
>>     'The 88 modern constellations are formally defined regions of the sky together'
>>     ' covering the entire celestial sphere.'
>> corpus = [text1.split(' '), text2.split(' ')]
>> bm25 = BM25(corpus)
```
    WARNING:gensim.summarization.bm25:Average inverse document frequency is less than zero.
    Your corpus of 2 documents is either too small or it does not originate from natural text.
    BM25 will likely produce unintuitive results.