### PR TITLE
Support pretrained word2vec model when train doc2vec

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Use the model
 
 > pretrained_emb = "word2vec_pretrained.txt"  # This is a pretrained word2vec model of C text format
 > 
-> model = gensim.models.doc2vec.Doc2Vec(corpus_train,  # This is the document corpus to be trained which should meet gensim's format  
+> model = gensim.models.doc2vec.Doc2Vec(
+                                       corpus_train,  # This is the document corpus to be trained which should meet gensim's format  
                                        vector_size=50,  
                                        min_count=1, epochs=20,  
                                        dm=0,  

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Use the model
 > pretrained_emb = "word2vec_pretrained.txt"  # This is a pretrained word2vec model of C text format
 > 
 > model = gensim.models.doc2vec.Doc2Vec(  
-                                       corpus_train,  # This is the document corpus to be trained which should meet gensim's format  
+                                       corpus_train,  # This is the documents corpus to be trained which should meet gensim's format  
                                        vector_size=50,  
                                        min_count=1, epochs=20,  
                                        dm=0,  

--- a/README.md
+++ b/README.md
@@ -8,21 +8,45 @@ The default doc2vec model in gensim does't support pretrained word2vec model. Bu
 
 
 
-Features
+Features and notice
+=============
+1.Support pretrained word2vec when train doc2vec.
+2.Support Python 3.
+3.Support gensim 3.8.
+4.The pretrainned word2vec model should be C text format.
+5.The dimension of the pretrained word2vec and doc2vec should be the same.
+
+
+
+
+Use the model
 =============
 
+1.Install the forked gensim
+
+*Clone gensim to your machine
+>git clone 
+
+*install gensim
+python setup.py install
 
 
+2. Train your model 
 
 
-Installation
-=============
+pretrained_emb = "word2vec_pretrained.txt" # This is a pretrained word2vec model of C text format
 
-
-
+model = gensim.models.doc2vec.Doc2Vec(corpus_train,  # This is the document corpus to be trained which should meet gensim's format
+                                      vector_size=50,
+                                      min_count=1, epochs=20, 
+                                      dm=0,
+                                      pretrained_emb=pretrained_emb) 
 
 
 
 Publications
 =============
-Jey Han Lau and Timothy Baldwin (2016). An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation. In Proceedings of the 1st Workshop on Representation Learning for NLP, 2016.
+
+1.Jey Han Lau and Timothy Baldwin (2016). An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation. In Proceedings of the 1st Workshop on Representation Learning for NLP, 2016.
+
+2.[The initial forked gensim version](https://github.com/jhlau/gensim)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Use the model
 
 > pretrained_emb = "word2vec_pretrained.txt"  # This is a pretrained word2vec model of C text format
 > 
-> model = gensim.models.doc2vec.Doc2Vec(
+> model = gensim.models.doc2vec.Doc2Vec(  
                                        corpus_train,  # This is the document corpus to be trained which should meet gensim's format  
                                        vector_size=50,  
                                        min_count=1, epochs=20,  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-gensim – Topic Modelling in Python
+doc2vec model in gensim – support pretrained word2vec model
 ==================================
 
 [![Build Status](https://travis-ci.org/RaRe-Technologies/gensim.svg?branch=develop)](https://travis-ci.org/RaRe-Technologies/gensim)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Use the model
 > 
 > model = gensim.models.doc2vec.Doc2Vec(  
                                        corpus_train,  # This is the documents corpus to be trained which should meet gensim's format  
-                                       vector_size=50,  
+                                       vector_size=300,  
                                        min_count=1, epochs=20,  
                                        dm=0,  
                                        pretrained_emb=pretrained_emb)   

--- a/README.md
+++ b/README.md
@@ -23,16 +23,17 @@ Use the model
 =============
 
 1.Install the forked gensim
+---------------------------
 
-*Clone gensim to your machine
+* Clone gensim to your machine
 >git clone 
 
-*install gensim
+* install gensim
 python setup.py install
 
 
 2. Train your model 
-
+---------------------------
 
 pretrained_emb = "word2vec_pretrained.txt" # This is a pretrained word2vec model of C text format
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features and notice
 * 2.Support Python 3.
 * 3.Support gensim 3.8.
 * 4.The pretrainned word2vec model should be C text format.
-* 5.The dimension of the pretrained word2vec and doc2vec should be the same.
+* 5.The dimension of the pretrained word2vec and the to be trained doc2vec should be the same.
 
 
 
@@ -40,12 +40,12 @@ Use the model
 ---------------------------
 
 > pretrained_emb = "word2vec_pretrained.txt" # This is a pretrained word2vec model of C text format
-
+> 
 > model = gensim.models.doc2vec.Doc2Vec(corpus_train,  # This is the document corpus to be trained which should meet gensim's format
->                                       vector_size=50,
->                                       min_count=1, epochs=20, 
->                                       dm=0,
->                                       pretrained_emb=pretrained_emb) 
+                                       vector_size=50,
+                                       min_count=1, epochs=20,                              
+                                       dm=0,
+                                       pretrained_emb=pretrained_emb) 
 
 
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Use the model
 2.Train your model 
 ---------------------------
 
-> pretrained_emb = "word2vec_pretrained.txt" # This is a pretrained word2vec model of C text format
+> pretrained_emb = "word2vec_pretrained.txt"  # This is a pretrained word2vec model of C text format
 > 
-> model = gensim.models.doc2vec.Doc2Vec(corpus_train,  # This is the document corpus to be trained which should meet gensim's format
-                                       vector_size=50,
-                                       min_count=1, epochs=20,                              
-                                       dm=0,
-                                       pretrained_emb=pretrained_emb) 
+> model = gensim.models.doc2vec.Doc2Vec(corpus_train,  # This is the document corpus to be trained which should meet gensim's format  
+                                       vector_size=50,  
+                                       min_count=1, epochs=20,  
+                                       dm=0,  
+                                       pretrained_emb=pretrained_emb)   
 
 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ doc2vec in gensim – support pretrained word2vec
 
 This is a forked gensim version, which edits the default doc2vec model to support pretrained word2vec during training doc2vec. It forked from gensim 3.8.
 
-The default doc2vec model in gensim does't support pretrained word2vec model. But according to Jey Han Lau and Timothy Baldwin's paper, [An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation(2016)](https://arxiv.org/abs/1607.05368), using pretrained word2vec model usually gets better results in NLP tasks. The author also released a [forked gensim verstion](https://github.com/jhlau/gensim) to perform pretrained embeddings, but it is from a very old Gensim version, which can't be used in gensim 3.8(the latest gensim version when I release this fork).
+The default doc2vec model in gensim does't support pretrained word2vec model. But according to Jey Han Lau and Timothy Baldwin's paper, [An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation(2016)](https://arxiv.org/abs/1607.05368), using pretrained word2vec model usually gets better results in NLP tasks. The author also released a [forked gensim verstion](https://github.com/jhlau/gensim) to perform pretrained embeddings, but it is from a very old gensim version, which can't be used in gensim 3.8(the latest gensim version when I release this fork).
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 doc2vec in gensim – support pretrained word2vec
 ==================================
 
-The default doc2vec model in Gensim does't support pretrained word2vec model. But according to Jey Han Lau and Timothy Baldwin's paper, An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation(2016), using pretrained word2vec model usually gets better results in tasks. The author also released a forked Gensim verstion to perform pretrained embeddings, but it is from a very old Gensim version, which can't be used in the latested Gensim.
+The default doc2vec model in Gensim does't support pretrained word2vec model. But according to Jey Han Lau and Timothy Baldwin's paper, [An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation(2016)](https://arxiv.org/abs/1607.05368), using pretrained word2vec model usually gets better results in NLP tasks. The author also released a [forked Gensim verstion](https://github.com/jhlau/gensim) to perform pretrained embeddings, but it is from a very old Gensim version, which can't be used in Gensim 3.8(which is the latest Gensim version when I release this fork).
 
 
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Use the model
 ---------------------------
 
 * Clone gensim to your machine
->git clone 
+> git clone 
 
 * install gensim
-python setup.py install
+> python setup.py install
 
 
 2. Train your model 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 doc2vec in gensim – support pretrained word2vec
 ==================================
 
-The default doc2vec model in Gensim does't support pretrained word2vec model. But according to Jey Han Lau and Timothy Baldwin's paper, [An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation(2016)](https://arxiv.org/abs/1607.05368), using pretrained word2vec model usually gets better results in NLP tasks. The author also released a [forked Gensim verstion](https://github.com/jhlau/gensim) to perform pretrained embeddings, but it is from a very old Gensim version, which can't be used in Gensim 3.8(which is the latest Gensim version when I release this fork).
+doc2vec model that supports pretrained word2vec and Gensim 3.8.
+
+The default doc2vec model in Gensim does't support pretrained word2vec model. But according to Jey Han Lau and Timothy Baldwin's paper, [An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation(2016)](https://arxiv.org/abs/1607.05368), using pretrained word2vec model usually gets better results in NLP tasks. The author also released a [forked Gensim verstion](https://github.com/jhlau/gensim) to perform pretrained embeddings, but it is from a very old Gensim version, which can't be used in Gensim 3.8(the latest Gensim version when I release this fork).
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 doc2vec in gensim – support pretrained word2vec
 ==================================
 
-doc2vec model that supports pretrained word2vec and Gensim 3.8.
+This is a forked gensim version, which edits the default doc2vec model to support pretrained word2vec during training doc2vec. It forked from gensim 3.8.
 
-The default doc2vec model in Gensim does't support pretrained word2vec model. But according to Jey Han Lau and Timothy Baldwin's paper, [An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation(2016)](https://arxiv.org/abs/1607.05368), using pretrained word2vec model usually gets better results in NLP tasks. The author also released a [forked Gensim verstion](https://github.com/jhlau/gensim) to perform pretrained embeddings, but it is from a very old Gensim version, which can't be used in Gensim 3.8(the latest Gensim version when I release this fork).
+The default doc2vec model in gensim does't support pretrained word2vec model. But according to Jey Han Lau and Timothy Baldwin's paper, [An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation(2016)](https://arxiv.org/abs/1607.05368), using pretrained word2vec model usually gets better results in NLP tasks. The author also released a [forked gensim verstion](https://github.com/jhlau/gensim) to perform pretrained embeddings, but it is from a very old Gensim version, which can't be used in gensim 3.8(the latest gensim version when I release this fork).
 
 
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ Use the model
 Publications
 =============
 
-* 1.Jey Han Lau and Timothy Baldwin (2016). An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation. In Proceedings of the 1st Workshop on Representation Learning for NLP, 2016.
+* 1.Jey Han Lau and Timothy Baldwin (2016). [An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation. In Proceedings of the 1st Workshop on Representation Learning for NLP, 2016.](https://arxiv.org/abs/1607.05368)
 
 * 2.[The initial forked gensim version](https://github.com/jhlau/gensim)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use the model
 > python setup.py install
 
 
-2.Train your model 
+2.Train your doc2vec model 
 ---------------------------
 
 > pretrained_emb = "word2vec_pretrained.txt"  # This is a pretrained word2vec model of C text format

--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ Use the model
 Publications
 =============
 
-* 1.Jey Han Lau and Timothy Baldwin (2016). [An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation. In Proceedings of the 1st Workshop on Representation Learning for NLP, 2016.](https://arxiv.org/abs/1607.05368)
+* 1.Jey Han Lau and Timothy Baldwin. [An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation. In Proceedings of the 1st Workshop on Representation Learning for NLP, 2016.](https://arxiv.org/abs/1607.05368)
 
 * 2.[The initial forked gensim version](https://github.com/jhlau/gensim)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The default doc2vec model in gensim does't support pretrained word2vec model. Bu
 
 
 
+
+
 Features and notice
 =============
 * 1.Support pretrained word2vec when train doc2vec.
@@ -19,6 +21,8 @@ Features and notice
 
 
 
+
+
 Use the model
 =============
 
@@ -26,28 +30,31 @@ Use the model
 ---------------------------
 
 * Clone gensim to your machine
-> git clone 
+> git clone https://github.com/maohbao/gensim.git
 
 * install gensim
 > python setup.py install
 
 
-2. Train your model 
+2.Train your model 
 ---------------------------
 
-pretrained_emb = "word2vec_pretrained.txt" # This is a pretrained word2vec model of C text format
+> pretrained_emb = "word2vec_pretrained.txt" # This is a pretrained word2vec model of C text format
 
-model = gensim.models.doc2vec.Doc2Vec(corpus_train,  # This is the document corpus to be trained which should meet gensim's format
-                                      vector_size=50,
-                                      min_count=1, epochs=20, 
-                                      dm=0,
-                                      pretrained_emb=pretrained_emb) 
+> model = gensim.models.doc2vec.Doc2Vec(corpus_train,  # This is the document corpus to be trained which should meet gensim's format
+>                                       vector_size=50,
+>                                       min_count=1, epochs=20, 
+>                                       dm=0,
+>                                       pretrained_emb=pretrained_emb) 
+
+
+
 
 
 
 Publications
 =============
 
-1.Jey Han Lau and Timothy Baldwin (2016). An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation. In Proceedings of the 1st Workshop on Representation Learning for NLP, 2016.
+* 1.Jey Han Lau and Timothy Baldwin (2016). An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation. In Proceedings of the 1st Workshop on Representation Learning for NLP, 2016.
 
-2.[The initial forked gensim version](https://github.com/jhlau/gensim)
+* 2.[The initial forked gensim version](https://github.com/jhlau/gensim)

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The default doc2vec model in gensim does't support pretrained word2vec model. Bu
 
 Features and notice
 =============
-1.Support pretrained word2vec when train doc2vec.
-2.Support Python 3.
-3.Support gensim 3.8.
-4.The pretrainned word2vec model should be C text format.
-5.The dimension of the pretrained word2vec and doc2vec should be the same.
+* 1.Support pretrained word2vec when train doc2vec.
+* 2.Support Python 3.
+* 3.Support gensim 3.8.
+* 4.The pretrainned word2vec model should be C text format.
+* 5.The dimension of the pretrained word2vec and doc2vec should be the same.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,177 +1,26 @@
-doc2vec model in gensim – support pretrained word2vec model
+doc2vec in gensim – support pretrained word2vec
 ==================================
 
-[![Build Status](https://travis-ci.org/RaRe-Technologies/gensim.svg?branch=develop)](https://travis-ci.org/RaRe-Technologies/gensim)
-[![GitHub release](https://img.shields.io/github/release/rare-technologies/gensim.svg?maxAge=3600)](https://github.com/RaRe-Technologies/gensim/releases)
-[![Conda-forge Build](https://anaconda.org/conda-forge/gensim/badges/version.svg)](https://anaconda.org/conda-forge/gensim)
-[![Wheel](https://img.shields.io/pypi/wheel/gensim.svg)](https://pypi.python.org/pypi/gensim)
-[![DOI](https://zenodo.org/badge/DOI/10.13140/2.1.2393.1847.svg)](https://doi.org/10.13140/2.1.2393.1847)
-[![Mailing List](https://img.shields.io/badge/-Mailing%20List-brightgreen.svg)](https://groups.google.com/forum/#!forum/gensim)
-[![Gitter](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-09a3d5.svg)](https://gitter.im/RaRe-Technologies/gensim)
-[![Follow](https://img.shields.io/twitter/follow/gensim_py.svg?style=social&label=Follow)](https://twitter.com/gensim_py)
+The default doc2vec model in Gensim does't support pretrained word2vec model. But according to Jey Han Lau and Timothy Baldwin's paper, An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation(2016), using pretrained word2vec model usually gets better results in tasks. The author also released a forked Gensim verstion to perform pretrained embeddings, but it is from a very old Gensim version, which can't be used in the latested Gensim.
 
-Gensim is a Python library for *topic modelling*, *document indexing*
-and *similarity retrieval* with large corpora. Target audience is the
-*natural language processing* (NLP) and *information retrieval* (IR)
-community.
 
-<!--
-## :pizza: Hacktoberfest 2019 :beer:
 
-We are accepting PRs for Hacktoberfest!
-See [here](HACKTOBERFEST.md) for details.
--->
 
 Features
---------
+=============
 
--   All algorithms are **memory-independent** w.r.t. the corpus size
-    (can process input larger than RAM, streamed, out-of-core),
--   **Intuitive interfaces**
-    -   easy to plug in your own input corpus/datastream (trivial
-        streaming API)
-    -   easy to extend with other Vector Space algorithms (trivial
-        transformation API)
--   Efficient multicore implementations of popular algorithms, such as
-    online **Latent Semantic Analysis (LSA/LSI/SVD)**, **Latent
-    Dirichlet Allocation (LDA)**, **Random Projections (RP)**,
-    **Hierarchical Dirichlet Process (HDP)** or **word2vec deep
-    learning**.
--   **Distributed computing**: can run *Latent Semantic Analysis* and
-    *Latent Dirichlet Allocation* on a cluster of computers.
--   Extensive [documentation and Jupyter Notebook tutorials].
 
-If this feature list left you scratching your head, you can first read
-more about the [Vector Space Model] and [unsupervised document analysis]
-on Wikipedia.
 
-Support
-------------
 
-Ask open-ended or research questions on the [Gensim Mailing List](https://groups.google.com/forum/#!forum/gensim).
-
-Raise bugs on [Github](https://github.com/RaRe-Technologies/gensim/blob/develop/CONTRIBUTING.md) but **make sure you follow the [issue template](https://github.com/RaRe-Technologies/gensim/blob/develop/ISSUE_TEMPLATE.md)**. Issues that are not bugs or fail to follow the issue template will be closed without inspection.
 
 Installation
-------------
+=============
 
-This software depends on [NumPy and Scipy], two Python packages for
-scientific computing. You must have them installed prior to installing
-gensim.
 
-It is also recommended you install a fast BLAS library before installing
-NumPy. This is optional, but using an optimized BLAS such as [ATLAS] or
-[OpenBLAS] is known to improve performance by as much as an order of
-magnitude. On OS X, NumPy picks up the BLAS that comes with it
-automatically, so you don’t need to do anything special.
 
-The simple way to install gensim is:
 
-    pip install -U gensim
 
-Or, if you have instead downloaded and unzipped the [source tar.gz]
-package, you’d run:
 
-    python setup.py test
-    python setup.py install
-
-For alternative modes of installation (without root privileges,
-development installation, optional install features), see the
-[documentation].
-
-This version has been tested under Python 2.7, 3.5 and 3.6. Gensim’s github repo is hooked
-against [Travis CI for automated testing] on every commit push and pull
-request. Support for Python 2.6, 3.3 and 3.4 was dropped in gensim 1.0.0. Install gensim 0.13.4 if you *must* use Python 2.6, 3.3 or 3.4. Support for Python 2.5 was dropped in gensim 0.10.0; install gensim 0.9.1 if you *must* use Python 2.5). 
-
-How come gensim is so fast and memory efficient? Isn’t it pure Python, and isn’t Python slow and greedy?
---------------------------------------------------------------------------------------------------------
-
-Many scientific algorithms can be expressed in terms of large matrix
-operations (see the BLAS note above). Gensim taps into these low-level
-BLAS libraries, by means of its dependency on NumPy. So while
-gensim-the-top-level-code is pure Python, it actually executes highly
-optimized Fortran/C under the hood, including multithreading (if your
-BLAS is so configured).
-
-Memory-wise, gensim makes heavy use of Python’s built-in generators and
-iterators for streamed data processing. Memory efficiency was one of
-gensim’s [design goals], and is a central feature of gensim, rather than
-something bolted on as an afterthought.
-
-Documentation
--------------
-
--   [QuickStart]
--   [Tutorials]
--   [Official API Documentation]
-
-  [QuickStart]: https://radimrehurek.com/gensim/auto_examples/core/run_core_concepts.html
-  [Tutorials]: https://radimrehurek.com/gensim/auto_examples/
-  [Official Documentation and Walkthrough]: http://radimrehurek.com/gensim/
-  [Official API Documentation]: http://radimrehurek.com/gensim/apiref.html
-  
----------
-
-Adopters
---------
-
-| Company | Logo | Industry | Use of Gensim |
-|---------|------|----------|---------------|                          
-| [RARE Technologies](http://rare-technologies.com) | ![rare](docs/src/readme_images/rare.png) | ML & NLP consulting | Creators of Gensim – this is us! |
-| [Amazon](http://www.amazon.com/) |  ![amazon](docs/src/readme_images/amazon.png) | Retail |  Document similarity. |
-| [National Institutes of Health](https://github.com/NIHOPA/pipeline_word2vec) | ![nih](docs/src/readme_images/nih.png) | Health | Processing grants and publications with word2vec. |
-| [Cisco Security](http://www.cisco.com/c/en/us/products/security/index.html) | ![cisco](docs/src/readme_images/cisco.png) | Security |  Large-scale fraud detection. |
-| [Mindseye](http://www.mindseyesolutions.com/) | ![mindseye](docs/src/readme_images/mindseye.png) | Legal | Similarities in legal documents. |
-| [Channel 4](http://www.channel4.com/) | ![channel4](docs/src/readme_images/channel4.png) | Media | Recommendation engine. |
-| [Talentpair](http://talentpair.com) | ![talent-pair](docs/src/readme_images/talent-pair.png) | HR | Candidate matching in high-touch recruiting. |
-| [Juju](http://www.juju.com/)  | ![juju](docs/src/readme_images/juju.png) | HR | Provide non-obvious related job suggestions. |
-| [Tailwind](https://www.tailwindapp.com/) | ![tailwind](docs/src/readme_images/tailwind.png) | Media | Post interesting and relevant content to Pinterest. |
-| [Issuu](https://issuu.com/) | ![issuu](docs/src/readme_images/issuu.png) | Media | Gensim's LDA module lies at the very core of the analysis we perform on each uploaded publication to figure out what it's all about. |
-| [Search Metrics](http://www.searchmetrics.com/) | ![search-metrics](docs/src/readme_images/search-metrics.png) | Content Marketing | Gensim word2vec used for entity disambiguation in Search Engine Optimisation. |
-| [12K Research](https://12k.co/) | ![12k](docs/src/readme_images/12k.png)| Media |   Document similarity analysis on media articles. |
-| [Stillwater Supercomputing](http://www.stillwater-sc.com/) | ![stillwater](docs/src/readme_images/stillwater.png) | Hardware | Document comprehension and association with word2vec. |
-| [SiteGround](https://www.siteground.com/) |  ![siteground](docs/src/readme_images/siteground.png) | Web hosting | An ensemble search engine which uses different embeddings models and similarities, including word2vec, WMD, and LDA. |
-| [Capital One](https://www.capitalone.com/) | ![capitalone](docs/src/readme_images/capitalone.png) | Finance | Topic modeling for customer complaints exploration. |
-
--------
-
-Citing gensim
-------------
-
-When [citing gensim in academic papers and theses], please use this
-BibTeX entry:
-
-    @inproceedings{rehurek_lrec,
-          title = {{Software Framework for Topic Modelling with Large Corpora}},
-          author = {Radim {\v R}eh{\r u}{\v r}ek and Petr Sojka},
-          booktitle = {{Proceedings of the LREC 2010 Workshop on New
-               Challenges for NLP Frameworks}},
-          pages = {45--50},
-          year = 2010,
-          month = May,
-          day = 22,
-          publisher = {ELRA},
-          address = {Valletta, Malta},
-          note={\url{http://is.muni.cz/publication/884893/en}},
-          language={English}
-    }
-
-  [citing gensim in academic papers and theses]: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=9vG_kV0AAAAJ&citation_for_view=9vG_kV0AAAAJ:NaGl4SEjCO4C
-
-  [Travis CI for automated testing]: https://travis-ci.org/RaRe-Technologies/gensim
-  [design goals]: http://radimrehurek.com/gensim/about.html
-  [RaRe Technologies]: http://rare-technologies.com/wp-content/uploads/2016/02/rare_image_only.png%20=10x20
-  [rare\_tech]: //rare-technologies.com
-  [Talentpair]: https://avatars3.githubusercontent.com/u/8418395?v=3&s=100
-  [citing gensim in academic papers and theses]: https://scholar.google.cz/citations?view_op=view_citation&hl=en&user=9vG_kV0AAAAJ&citation_for_view=9vG_kV0AAAAJ:u-x6o8ySG0sC
-
-  
-  
-  [documentation and Jupyter Notebook tutorials]: https://github.com/RaRe-Technologies/gensim/#documentation
-  [Vector Space Model]: http://en.wikipedia.org/wiki/Vector_space_model
-  [unsupervised document analysis]: http://en.wikipedia.org/wiki/Latent_semantic_indexing
-  [NumPy and Scipy]: http://www.scipy.org/Download
-  [ATLAS]: http://math-atlas.sourceforge.net/
-  [OpenBLAS]: http://xianyi.github.io/OpenBLAS/
-  [source tar.gz]: http://pypi.python.org/pypi/gensim
-  [documentation]: http://radimrehurek.com/gensim/install.html
+Publications
+=============
+Jey Han Lau and Timothy Baldwin (2016). An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation. In Proceedings of the 1st Workshop on Representation Learning for NLP, 2016.

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -210,8 +210,7 @@ class Doc2Vec(BaseWordEmbeddingsModel):
     """
     def __init__(self, documents=None, corpus_file=None, dm_mean=None, dm=1, dbow_words=0, dm_concat=0,
                  dm_tag_count=1, docvecs=None, docvecs_mapfile=None, comment=None, trim_rule=None, 
-                 pretrained_emb=None, 
-                 callbacks=(), **kwargs):
+                 callbacks=(), pretrained_emb=None, **kwargs):
         """
 
         `pretrained_emb` = takes in pre-trained embedding for word vectors; format = original C word2vec-tool non-binary format (i.e. one embedding per word)
@@ -1177,7 +1176,7 @@ class Doc2VecVocab(Word2VecVocab):
 
 class Doc2VecTrainables(Word2VecTrainables):
     """Represents the inner shallow neural network used to train :class:`~gensim.models.doc2vec.Doc2Vec`."""
-    def __init__(self, pretrained_emb, dm=1, dm_concat=0, dm_tag_count=1, vector_size=100, seed=1, hashfxn=hash, window=5):
+    def __init__(self, pretrained_emb=None, dm=1, dm_concat=0, dm_tag_count=1, vector_size=100, seed=1, hashfxn=hash, window=5):
 
         self.pretrained_emb=pretrained_emb
 

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -210,7 +210,7 @@ class Doc2Vec(BaseWordEmbeddingsModel):
     """
     def __init__(self, documents=None, corpus_file=None, dm_mean=None, dm=1, dbow_words=0, dm_concat=0,
                  dm_tag_count=1, docvecs=None, docvecs_mapfile=None, comment=None, trim_rule=None, 
-                 pretrained_emb=None, # maohbao
+                 pretrained_emb=None, 
                  callbacks=(), **kwargs):
         """
 
@@ -322,10 +322,10 @@ class Doc2Vec(BaseWordEmbeddingsModel):
             sg=(1 + dm) % 2,
             null_word=dm_concat,
             callbacks=callbacks,
-            pretrained_emb=pretrained_emb, # maohbao
+            pretrained_emb=pretrained_emb, 
             **kwargs)
 
-        self.pretrained_emb=pretrained_emb  # maohbao
+        self.pretrained_emb=pretrained_emb  
 
         self.load = call_on_class_only
 
@@ -1182,7 +1182,7 @@ class Doc2VecTrainables(Word2VecTrainables):
         self.pretrained_emb=pretrained_emb
 
         super(Doc2VecTrainables, self).__init__(
-            self.pretrained_emb, #maohbao
+            self.pretrained_emb, 
             vector_size=vector_size, seed=seed, hashfxn=hashfxn)
         if dm and dm_concat:
             self.layer1_size = (dm_tag_count + (2 * window)) * vector_size

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -130,8 +130,8 @@ from collections import defaultdict
 import threading
 import itertools
 import warnings
-import time # maohbao
-import smart_open # maohbao
+import time 
+import smart_open 
 
 from gensim.utils import keep_vocab_item, call_on_class_only
 from gensim.models.keyedvectors import Vocab, Word2VecKeyedVectors
@@ -144,7 +144,7 @@ except ImportError:
 
 from numpy import exp, dot, zeros, random, dtype, float32 as REAL,\
     uint32, seterr, array, uint8, vstack, fromstring, sqrt,\
-    empty, sum as np_sum, ones, logaddexp, log, outer, concatenate  #maohbao
+    empty, sum as np_sum, ones, logaddexp, log, outer, concatenate  
 
 from scipy.special import expit
 
@@ -481,7 +481,7 @@ class Word2Vec(BaseWordEmbeddingsModel):
                  sg=0, hs=0, negative=5, ns_exponent=0.75, cbow_mean=1, hashfxn=hash, iter=5, null_word=0,
                  trim_rule=None, sorted_vocab=1, batch_words=MAX_WORDS_IN_BATCH, compute_loss=False, callbacks=(),
                  max_final_vocab=None,
-                 pretrained_emb=None #maohbao
+                 pretrained_emb=None 
                  ):
         """
 
@@ -596,9 +596,9 @@ class Word2Vec(BaseWordEmbeddingsModel):
         self.vocabulary = Word2VecVocab(
             max_vocab_size=max_vocab_size, min_count=min_count, sample=sample, sorted_vocab=bool(sorted_vocab),
             null_word=null_word, max_final_vocab=max_final_vocab, ns_exponent=ns_exponent)
-        self.trainables = Word2VecTrainables(pretrained_emb=pretrained_emb, seed=seed, vector_size=size, hashfxn=hashfxn) #maohbao
+        self.trainables = Word2VecTrainables(pretrained_emb=pretrained_emb, seed=seed, vector_size=size, hashfxn=hashfxn) 
 
-        self.pretrained_emb = pretrained_emb #maohbao
+        self.pretrained_emb = pretrained_emb 
 
         super(Word2Vec, self).__init__(
             sentences=sentences, corpus_file=corpus_file, workers=workers, vector_size=size, epochs=iter,
@@ -1681,13 +1681,13 @@ def _assign_binary_codes(vocab):
 
 class Word2VecTrainables(utils.SaveLoad):
     """Represents the inner shallow neural network used to train :class:`~gensim.models.word2vec.Word2Vec`."""
-    def __init__(self, pretrained_emb, vector_size=100, seed=1, hashfxn=hash): #maohbao
+    def __init__(self, pretrained_emb, vector_size=100, seed=1, hashfxn=hash): 
         self.hashfxn = hashfxn
         self.layer1_size = vector_size
         self.seed = seed
 
-        self.pretrained_emb=pretrained_emb  #maohbao
-        self.vector_size=vector_size #maohbao
+        self.pretrained_emb=pretrained_emb  
+        self.vector_size=vector_size 
 
     def prepare_weights(self, hs, negative, wv, update=False, vocabulary=None):
         """Build tables and model weights based on final vocabulary settings."""
@@ -1707,11 +1707,7 @@ class Word2VecTrainables(utils.SaveLoad):
         """Reset all projection weights to an initial (untrained) state, but keep the existing vocabulary."""
         logger.info("resetting layer weights")
         wv.vectors = empty((len(wv.vocab), wv.vector_size), dtype=REAL)
-
-
-
-
-        # maohbao
+        
         #if pre-trained embedding file is given, load it
         p_emb = {}
         syn0_oov = []
@@ -1746,21 +1742,14 @@ class Word2VecTrainables(utils.SaveLoad):
                             logger.info(str(line_no+1) + " lines processed (" + str(time.time()-t) + "s); " + str(len(p_emb)) + " embeddings collected")
                             t = time.time()
 
-
-
-
-
-
-        #maohbao
         '''
         # randomize weights vector by vector, rather than materializing a huge random matrix in RAM at once
         for i in range(len(wv.vocab)):
             # construct deterministic seed from word AND seed argument
             wv.vectors[i] = self.seeded_vector(wv.index2word[i] + str(self.seed), wv.vector_size)
         '''
-
-
-        #maohbao  change xrange to range
+        
+        #change xrange to range
         for i in range(len(wv.vocab)-len(syn0_oov)):
             word = wv.index2word[i]
             if (len(p_emb) > 0) and (word in p_emb):
@@ -1770,9 +1759,6 @@ class Word2VecTrainables(utils.SaveLoad):
                 # construct deterministic seed from word AND seed argument
                 wv.syn0[i] = self.seeded_vector(word + str(self.seed), self.vector_size)
 
-
-
-
         if hs:
             self.syn1 = zeros((len(wv.vocab), self.layer1_size), dtype=REAL)
         if negative:
@@ -1781,8 +1767,6 @@ class Word2VecTrainables(utils.SaveLoad):
 
         self.vectors_lockf = ones(len(wv.vocab), dtype=REAL)  # zeros suppress learning
 
-
-        #maohbao
         # append the oov syn0 weights to syn0
         if len(syn0_oov) > 0:
             wv.syn0 = concatenate((wv.syn0, syn0_oov), axis=0)
@@ -1840,9 +1824,7 @@ if __name__ == "__main__":
     seterr(all='raise')  # don't ignore numpy errors
 
     parser = argparse.ArgumentParser()
-    #maohbao
     parser.add_argument("-pretrained_emb", help="Use pre-trained embeddings; format = original C word2vec-tool non-binary format (i.e. one embedding per word)")
-
     parser.add_argument("-train", help="Use text data from file TRAIN to train the model", required=True)
     parser.add_argument("-output", help="Use file OUTPUT to save the resulting word vectors")
     parser.add_argument("-window", help="Set max skip length WINDOW between words; default is 5", type=int, default=5)
@@ -1887,8 +1869,6 @@ if __name__ == "__main__":
 
     corpus = LineSentence(args.train)
 
-
-    #maohbao
     model = Word2Vec(
     corpus, size=args.size, min_count=args.min_count, workers=args.threads,
     window=args.window, sample=args.sample, sg=skipgram, hs=args.hs,

--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -1873,7 +1873,7 @@ if __name__ == "__main__":
     corpus, size=args.size, min_count=args.min_count, workers=args.threads,
     window=args.window, sample=args.sample, sg=skipgram, hs=args.hs,
     negative=args.negative, cbow_mean=1, iter=args.iter,
-    pretrained_emb=args.pretrained_emb #maohbao
+    pretrained_emb=args.pretrained_emb 
     )
 
     if args.output:


### PR DESCRIPTION
The default doc2vec model in gensim does't support pretrained word2vec model. But according to Jey Han Lau and Timothy Baldwin's paper, [An Empirical Evaluation of doc2vec with Practical Insights into Document Embedding Generation(2016)](https://arxiv.org/abs/1607.05368), using pretrained word2vec model usually gets better results in NLP tasks. The author also released a forked gensim verstion to perform pretrained embeddings, but it is from a very old gensim version, which can't be used in gensim 3.8.

Now I edited two files to support pretrained word embeddings for doc2vec.