### PR TITLE
Update get_keras_embedding for tf2

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -1522,7 +1522,7 @@ class Word2VecKeyedVectors(WordEmbeddingsKeyedVectors):
 
         """
         try:
-            from keras.layers import Embedding
+            from tensorflow.keras.layers import Embedding
         except ImportError:
             raise ImportError("Please install Keras to use this function")
         weights = self.vectors


### PR DESCRIPTION
importing direct from keras raises error 
> 
AttributeError: module 'tensorflow' has no attribute 'get_default_graph'

as recommended by the tf community, we should import keras as tensorflow.keras