### PR TITLE
Use time.time instead of time.clock in gensim/models/hdpmodel.py

### DIFF
--- a/gensim/models/hdpmodel.py
+++ b/gensim/models/hdpmodel.py
@@ -464,7 +464,10 @@ class HdpModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         """
         save_freq = max(1, int(10000 / self.chunksize))  # save every 10k docs, roughly
         chunks_processed = 0
-        start_time = time.clock()
+        try:
+            start_time = time.process_time()
+        except AttributeError:
+            start_time = time.clock()
 
         while True:
             for chunk in utils.grouper(corpus, self.chunksize):
@@ -508,12 +511,16 @@ class HdpModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             If True - model is updated, False otherwise.
 
         """
+        try:
+            start_time = time.process_time()
+        except AttributeError:
+            start_time = time.clock()
         return (
             # chunk limit reached
             (self.max_chunks and chunks_processed == self.max_chunks)
 
             # time limit reached
-            or (self.max_time and time.clock() - start_time > self.max_time)
+            or (self.max_time and start_time - start_time > self.max_time)
 
             # no limits and whole corpus has been processed once
             or (not self.max_chunks and not self.max_time and docs_processed >= self.m_D))

--- a/gensim/models/hdpmodel.py
+++ b/gensim/models/hdpmodel.py
@@ -465,7 +465,7 @@ class HdpModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         save_freq = max(1, int(10000 / self.chunksize))  # save every 10k docs, roughly
         chunks_processed = 0
         try:
-            start_time = time.process_time()
+            start_time = time.time()
         except AttributeError:
             start_time = time.clock()
 
@@ -512,7 +512,7 @@ class HdpModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         """
         try:
-            start_time = time.process_time()
+            start_time = time.time()
         except AttributeError:
             start_time = time.clock()
         return (


### PR DESCRIPTION
`time.clock` has been deprecated since in Python 3.3, and it is no longer available in Python 3.8 (https://github.com/python/cpython/pull/13270).