### PR TITLE
Speed up Soft Cosine Measure

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -880,7 +880,10 @@ def softcossim(vec1, vec2, similarity_matrix):
     dtype = similarity_matrix.dtype
     vec1 = np.fromiter((vec1[i] if i in vec1 else 0 for i in word_indices), dtype=dtype, count=len(word_indices))
     vec2 = np.fromiter((vec2[i] if i in vec2 else 0 for i in word_indices), dtype=dtype, count=len(word_indices))
-    dense_matrix = similarity_matrix[[[i] for i in word_indices], word_indices].todense()
+    i = np.matlib.eye(similarity_matrix.shape[0])
+    word_mat_cols = i[:, word_indices]
+    word_mat_rows = word_mat_cols.T
+    dense_matrix = word_mat_rows.dot(similarity_matrix.dot(word_mat_cols))
     vec1len = vec1.T.dot(dense_matrix).dot(vec1)[0, 0]
     vec2len = vec2.T.dot(dense_matrix).dot(vec2)[0, 0]
 

--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -17,6 +17,7 @@ from gensim import utils
 from gensim.utils import deprecated
 
 import numpy as np
+import numpy.matlib
 import scipy.sparse
 from scipy.stats import entropy
 import scipy.linalg

--- a/gensim/similarities/termsim.py
+++ b/gensim/similarities/termsim.py
@@ -311,7 +311,10 @@ class SparseTermSimilarityMatrix(SaveLoad):
             dtype = self.matrix.dtype
             X = np.array([X[i] if i in X else 0 for i in word_indices], dtype=dtype)
             Y = np.array([Y[i] if i in Y else 0 for i in word_indices], dtype=dtype)
-            matrix = self.matrix[word_indices[:, None], word_indices].todense()
+            i = np.matlib.eye(self.matrix.shape[0])
+            word_mat_cols = i[:, word_indices]
+            word_mat_rows = word_mat_cols.T
+            matrix = word_mat_rows.dot(self.matrix.dot(word_mat_cols))
 
             result = X.T.dot(matrix).dot(Y)
 
@@ -343,7 +346,10 @@ class SparseTermSimilarityMatrix(SaveLoad):
             X = dict(X)
             X = np.array([X[i] if i in X else 0 for i in word_indices], dtype=dtype)
             Y = corpus2csc(Y, num_terms=self.matrix.shape[0], dtype=dtype)[word_indices, :].todense()
-            matrix = self.matrix[word_indices[:, None], word_indices].todense()
+            i = np.matlib.eye(self.matrix.shape[0])
+            word_mat_cols = i[:, word_indices]
+            word_mat_rows = word_mat_cols.T
+            matrix = word_mat_rows.dot(self.matrix.dot(word_mat_cols))
             if normalized:
                 # use the following equality: np.diag(A.T.dot(B).dot(A)) == A.T.dot(B).multiply(A.T).sum(axis=1).T
                 X_norm = np.multiply(X.T.dot(matrix), X.T).sum(axis=1).T

--- a/gensim/similarities/termsim.py
+++ b/gensim/similarities/termsim.py
@@ -13,6 +13,7 @@ import logging
 from math import sqrt
 
 import numpy as np
+import numpy.matlib
 from scipy import sparse
 
 from gensim.matutils import corpus2csc


### PR DESCRIPTION
Use selection matrices to speed up matrix slicing.

**Motivation:**
Sometimes `softcossim` needs to be calculated O(N^2) times, e.g. for a distance matrix.

**Results:**
At least 5x speedup of `softcossim` was observed on my machine (110 µs vs 550 µs).
