### PR TITLE
Fix TypeError when using the -m flag with segment_wiki.py

### DIFF
--- a/gensim/scripts/segment_wiki.py
+++ b/gensim/scripts/segment_wiki.py
@@ -376,6 +376,7 @@ if __name__ == "__main__":
     parser.add_argument(
         '-m', '--min-article-character',
         help="Ignore articles with fewer characters than this (article stubs). Default: %(default)s.",
+        type=int,
         default=200
     )
     parser.add_argument(


### PR DESCRIPTION
Currently, if you attempt to use the `segment_wiki` script as described [here](https://radimrehurek.com/gensim/scripts/segment_wiki.html) with the --min-article-character you get an error because it gets parsed a string and the functions expect an int. This fix addresses the issue.

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.6/dist-packages/gensim/scripts/segment_wiki.py", line 385, in <module>
    include_interlinks=args.include_interlinks
  File "/usr/local/lib/python3.6/dist-packages/gensim/scripts/segment_wiki.py", line 141, in segment_and_write_all_articles
    for idx, article in enumerate(article_stream):
  File "/usr/local/lib/python3.6/dist-packages/gensim/scripts/segment_wiki.py", line 100, in segment_all_articles
    for article in wiki_sections_text:
  File "/usr/local/lib/python3.6/dist-packages/gensim/scripts/segment_wiki.py", line 332, in get_texts_with_sections
    if sum(len(body.strip()) for (_, body) in sections) < self.min_article_character:
TypeError: '<' not supported between instances of 'int' and 'str'```