### PR TITLE
Fix out of range issue in gensim.summarization.keywords

### DIFF
--- a/gensim/summarization/keywords.py
+++ b/gensim/summarization/keywords.py
@@ -302,7 +302,7 @@ def _extract_tokens(lemmas, scores, ratio, words):
 
     """
     lemmas.sort(key=lambda s: scores[s], reverse=True)
-    length = len(lemmas) * ratio if words is None else words
+    length = len(lemmas) * ratio if words is None else words if words <= len(lemmas) else len(lemmas)
     return [(scores[lemmas[i]], lemmas[i],) for i in range(int(length))]
 
 

--- a/gensim/summarization/keywords.py
+++ b/gensim/summarization/keywords.py
@@ -302,7 +302,7 @@ def _extract_tokens(lemmas, scores, ratio, words):
 
     """
     lemmas.sort(key=lambda s: scores[s], reverse=True)
-    length = len(lemmas) * ratio if words is None else words if words <= len(lemmas) else len(lemmas)
+    length = len(lemmas) * ratio if words is None else min(words, len(lemmas))
     return [(scores[lemmas[i]], lemmas[i],) for i in range(int(length))]
 
 

--- a/gensim/test/test_keywords.py
+++ b/gensim/test/test_keywords.py
@@ -106,6 +106,7 @@ class TestKeywordsTest(unittest.TestCase):
         text = 'Test string small length'
         kwds = keywords(text, words=5, split=True)
         self.assertIsNotNone(kwds)
+        
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)

--- a/gensim/test/test_keywords.py
+++ b/gensim/test/test_keywords.py
@@ -101,6 +101,11 @@ class TestKeywordsTest(unittest.TestCase):
         kwds = keywords(text, deacc=False, scores=True)
         self.assertFalse(len(kwds))
 
+    def test_keywords_with_words_greater_than_lemmas(self):
+        # words parameter is greater than number of words in text variable
+        text = 'Test string small length'
+        kwds = keywords(text, words=5, split=True)
+        self.assertIsNotNone(kwds)
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)

--- a/gensim/test/test_keywords.py
+++ b/gensim/test/test_keywords.py
@@ -106,7 +106,7 @@ class TestKeywordsTest(unittest.TestCase):
         text = 'Test string small length'
         kwds = keywords(text, words=5, split=True)
         self.assertIsNotNone(kwds)
-        
+
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)


### PR DESCRIPTION
Fix #2598 

The issue arises when the parameter `words`, which is defined as _The maximum amount of words to return_, is greater than the number of `lemmas` or keywords found. This caused an index out of range error from line 306 because it wasn't handling the case where `words > len(lemmas)`.

**Before the fix:** 
`length = len(lemmas) * ratio if words is None else words`
`return [(scores[lemmas[i]], lemmas[i],) for i in range(int(length))]`
As one can see, if `words > len(lemmas)`, the return statement will throw an index out of range error because the for loop will continue past the length of the lemmas array.

**Example of reproducing issue:**
`lemmas = ["test", "issue", "reproduction"]`
`words = 5`

Before Fix:
Index out of range in line 306 because length = 5 and len(lemmas) = 3.

After Fix:
No issue because length = len(lemmas) = 3.