### PR TITLE
use collections.abc for Mapping

### DIFF
--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -8,7 +8,13 @@
 
 from __future__ import with_statement
 
-from collections import Mapping, defaultdict
+from collections import defaultdict
+try:
+    # this is the py3 way
+    from collections.abc import Mapping
+except ImportError:
+    # this is the py2 way, it is deprecated in py3.1 and will be removed in removed in py3.9
+    from collections import Mapping
 import sys
 import logging
 import itertools

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -9,12 +9,7 @@
 from __future__ import with_statement
 
 from collections import defaultdict
-try:
-    # this is the py3 way
-    from collections.abc import Mapping
-except ImportError:
-    # this is the py2 way, it is deprecated in py3.1 and will be removed in removed in py3.9
-    from collections import Mapping
+from collections.abc import Mapping
 import sys
 import logging
 import itertools

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -70,7 +70,8 @@ try:
 except ImportError:
     from Queue import Queue  # noqa:F401
 
-from collections import namedtuple, defaultdict, Iterable
+from collections import namedtuple, defaultdict
+from collections.abc import Iterable
 from timeit import default_timer
 
 from numpy import zeros, float32 as REAL, empty, ones, \

--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -285,7 +285,7 @@ import os
 import numpy as np
 from numpy import ones, vstack, float32 as REAL
 import six
-from collections import Iterable
+from collections.abc import Iterable
 
 import gensim.models._fasttext_bin
 

--- a/gensim/test/test_corpora_dictionary.py
+++ b/gensim/test/test_corpora_dictionary.py
@@ -7,8 +7,10 @@
 Unit tests for the `corpora.Dictionary` class.
 """
 
-
-from collections import Mapping
+try:
+    from collections.abc import Mapping  # py3
+except ImportError:
+    from collections import Mapping  # py2
 from itertools import chain
 import logging
 import unittest

--- a/gensim/test/test_corpora_dictionary.py
+++ b/gensim/test/test_corpora_dictionary.py
@@ -7,10 +7,7 @@
 Unit tests for the `corpora.Dictionary` class.
 """
 
-try:
-    from collections.abc import Mapping  # py3
-except ImportError:
-    from collections import Mapping  # py2
+from collections.abc import Mapping
 from itertools import chain
 import logging
 import unittest


### PR DESCRIPTION
`from collections import Mapping` is deprecated, this PR fixes #2749 