### PR TITLE
Fix KeyedVectors.add matrix type

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -308,6 +308,7 @@ class BaseKeyedVectors(utils.SaveLoad):
             self.index2entity.append(entity)
 
         # add vectors for new entities
+        self.vectors = self.vectors.astype(weights.dtype)  # cast existing vectors to 'weights' type
         self.vectors = vstack((self.vectors, weights[~in_vocab_mask]))
 
         # change vectors for in_vocab entities if `replace` flag is specified

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -214,8 +214,8 @@ class Vocab(object):
 
 class BaseKeyedVectors(utils.SaveLoad):
     """Abstract base class / interface for various types of word vectors."""
-    def __init__(self, vector_size, dtype=REAL):
-        self.vectors = zeros((0, vector_size), dtype=dtype)
+    def __init__(self, vector_size):
+        self.vectors = zeros((0, vector_size), dtype=REAL)
         self.vocab = {}
         self.vector_size = vector_size
         self.index2entity = []
@@ -376,8 +376,8 @@ class BaseKeyedVectors(utils.SaveLoad):
 
 class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
     """Class containing common methods for operations over word vectors."""
-    def __init__(self, vector_size, dtype=REAL):
-        super(WordEmbeddingsKeyedVectors, self).__init__(vector_size=vector_size, dtype=REAL)
+    def __init__(self, vector_size):
+        super(WordEmbeddingsKeyedVectors, self).__init__(vector_size=vector_size)
         self.vectors_norm = None
         self.index2word = []
 
@@ -1550,8 +1550,8 @@ KeyedVectors = Word2VecKeyedVectors  # alias for backward compatibility
 
 class Doc2VecKeyedVectors(BaseKeyedVectors):
 
-    def __init__(self, vector_size, mapfile_path, dtype=REAL):
-        super(Doc2VecKeyedVectors, self).__init__(vector_size=vector_size, dtype=REAL)
+    def __init__(self, vector_size, mapfile_path):
+        super(Doc2VecKeyedVectors, self).__init__(vector_size=vector_size)
         self.doctags = {}  # string -> Doctag (only filled if necessary)
         self.max_rawint = -1  # highest rawint-indexed doctag
         self.offset2doctag = []  # int offset-past-(max_rawint+1) -> String (only filled if necessary)
@@ -2113,7 +2113,7 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
         elif self.bucket == 0:
             raise KeyError('cannot calculate vector for OOV word without ngrams')
         else:
-            word_vec = np.zeros(self.vectors_ngrams.shape[1], dtype=np.float32)
+            word_vec = np.zeros(self.vectors_ngrams.shape[1], dtype=REAL)
             if use_norm:
                 ngram_weights = self.vectors_ngrams_norm
             else:

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -214,8 +214,8 @@ class Vocab(object):
 
 class BaseKeyedVectors(utils.SaveLoad):
     """Abstract base class / interface for various types of word vectors."""
-    def __init__(self, vector_size):
-        self.vectors = zeros((0, vector_size))
+    def __init__(self, vector_size, dtype=REAL):
+        self.vectors = zeros((0, vector_size), dtype=dtype)
         self.vocab = {}
         self.vector_size = vector_size
         self.index2entity = []
@@ -308,8 +308,7 @@ class BaseKeyedVectors(utils.SaveLoad):
             self.index2entity.append(entity)
 
         # add vectors for new entities
-        self.vectors = self.vectors.astype(weights.dtype)  # cast existing vectors to 'weights' type
-        self.vectors = vstack((self.vectors, weights[~in_vocab_mask]))
+        self.vectors = vstack((self.vectors, weights[~in_vocab_mask].astype(self.vectors.dtype)))
 
         # change vectors for in_vocab entities if `replace` flag is specified
         if replace:
@@ -377,8 +376,8 @@ class BaseKeyedVectors(utils.SaveLoad):
 
 class WordEmbeddingsKeyedVectors(BaseKeyedVectors):
     """Class containing common methods for operations over word vectors."""
-    def __init__(self, vector_size):
-        super(WordEmbeddingsKeyedVectors, self).__init__(vector_size=vector_size)
+    def __init__(self, vector_size, dtype=REAL):
+        super(WordEmbeddingsKeyedVectors, self).__init__(vector_size=vector_size, dtype=REAL)
         self.vectors_norm = None
         self.index2word = []
 
@@ -1551,8 +1550,8 @@ KeyedVectors = Word2VecKeyedVectors  # alias for backward compatibility
 
 class Doc2VecKeyedVectors(BaseKeyedVectors):
 
-    def __init__(self, vector_size, mapfile_path):
-        super(Doc2VecKeyedVectors, self).__init__(vector_size=vector_size)
+    def __init__(self, vector_size, mapfile_path, dtype=REAL):
+        super(Doc2VecKeyedVectors, self).__init__(vector_size=vector_size, dtype=REAL)
         self.doctags = {}  # string -> Doctag (only filled if necessary)
         self.max_rawint = -1  # highest rawint-indexed doctag
         self.offset2doctag = []  # int offset-past-(max_rawint+1) -> String (only filled if necessary)

--- a/gensim/models/poincare.py
+++ b/gensim/models/poincare.py
@@ -866,8 +866,8 @@ class PoincareKeyedVectors(BaseKeyedVectors):
     Used to perform operations on the vectors such as vector lookup, distance calculations etc.
 
     """
-    def __init__(self, vector_size, dtype=REAL):
-        super(PoincareKeyedVectors, self).__init__(vector_size, dtype=REAL)
+    def __init__(self, vector_size):
+        super(PoincareKeyedVectors, self).__init__(vector_size)
         self.max_distance = 0
         self.index2word = []
         self.vocab = {}

--- a/gensim/models/poincare.py
+++ b/gensim/models/poincare.py
@@ -866,8 +866,8 @@ class PoincareKeyedVectors(BaseKeyedVectors):
     Used to perform operations on the vectors such as vector lookup, distance calculations etc.
 
     """
-    def __init__(self, vector_size):
-        super(PoincareKeyedVectors, self).__init__(vector_size)
+    def __init__(self, vector_size, dtype=REAL):
+        super(PoincareKeyedVectors, self).__init__(vector_size, dtype=REAL)
         self.max_distance = 0
         self.index2word = []
         self.vocab = {}

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -255,6 +255,15 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
         for ent, vector in zip(entities, vectors):
             self.assertTrue(np.allclose(kv[ent], vector))
 
+    def test_add_type(self):
+        kv = EuclideanKeyedVectors(2)
+        words, vectors = ["a"], np.array([1., 1.], dtype=np.float32).reshape(1, -1)
+
+        assert kv.vectors.dtype == np.float64  # default dtype of empty KV
+
+        kv.add(words, vectors)
+        assert kv.vectors.dtype == np.float32  # new dtype of KV (copied from passed vectors)
+
     def test_set_item(self):
         """Test that __setitem__ works correctly."""
         vocab_size = len(self.vectors.vocab)

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -15,7 +15,7 @@ import unittest
 import numpy as np
 
 from gensim.corpora import Dictionary
-from gensim.models.keyedvectors import KeyedVectors as EuclideanKeyedVectors, WordEmbeddingSimilarityIndex, \
+from gensim.models.keyedvectors import KeyedVectors, WordEmbeddingSimilarityIndex, \
     FastTextKeyedVectors
 from gensim.test.utils import datapath
 
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 class TestWordEmbeddingSimilarityIndex(unittest.TestCase):
     def setUp(self):
-        self.vectors = EuclideanKeyedVectors.load_word2vec_format(
+        self.vectors = KeyedVectors.load_word2vec_format(
             datapath('euclidean_vectors.bin'), binary=True, datatype=np.float64)
 
     def test_most_similar(self):
@@ -70,9 +70,9 @@ class TestWordEmbeddingSimilarityIndex(unittest.TestCase):
         self.assertTrue(np.allclose(first_similarities**2.0, second_similarities))
 
 
-class TestEuclideanKeyedVectors(unittest.TestCase):
+class TestKeyedVectors(unittest.TestCase):
     def setUp(self):
-        self.vectors = EuclideanKeyedVectors.load_word2vec_format(
+        self.vectors = KeyedVectors.load_word2vec_format(
             datapath('euclidean_vectors.bin'), binary=True, datatype=np.float64)
 
     def test_similarity_matrix(self):
@@ -227,7 +227,7 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
             self.assertTrue(np.allclose(self.vectors[ent], vector))
 
         # Test `add` on empty kv.
-        kv = EuclideanKeyedVectors(self.vectors.vector_size)
+        kv = KeyedVectors(self.vectors.vector_size)
         for ent, vector in zip(entities, vectors):
             kv.add(ent, vector)
 
@@ -248,7 +248,7 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
             self.assertTrue(np.allclose(self.vectors[ent], vector))
 
         # Test `add` on empty kv.
-        kv = EuclideanKeyedVectors(self.vectors.vector_size)
+        kv = KeyedVectors(self.vectors.vector_size)
         kv[entities] = vectors
         self.assertEqual(len(kv.vocab), len(entities))
 
@@ -256,7 +256,7 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
             self.assertTrue(np.allclose(kv[ent], vector))
 
     def test_add_type(self):
-        kv = EuclideanKeyedVectors(2)
+        kv = KeyedVectors(2)
         words, vectors = ["a"], np.array([1., 1.], dtype=np.float32).reshape(1, -1)
 
         assert kv.vectors.dtype == np.float64  # default dtype of empty KV
@@ -296,7 +296,7 @@ class TestEuclideanKeyedVectors(unittest.TestCase):
             self.assertTrue(np.allclose(self.vectors[ent], vector))
 
     def test_ft_kv_backward_compat_w_360(self):
-        kv = EuclideanKeyedVectors.load(datapath("ft_kv_3.6.0.model.gz"))
+        kv = KeyedVectors.load(datapath("ft_kv_3.6.0.model.gz"))
         ft_kv = FastTextKeyedVectors.load(datapath("ft_kv_3.6.0.model.gz"))
 
         expected = ['trees', 'survey', 'system', 'graph', 'interface']

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from gensim.corpora import Dictionary
 from gensim.models.keyedvectors import KeyedVectors, WordEmbeddingSimilarityIndex, \
-    FastTextKeyedVectors
+    FastTextKeyedVectors, REAL
 from gensim.test.utils import datapath
 
 import gensim.models.keyedvectors
@@ -256,14 +256,13 @@ class TestKeyedVectors(unittest.TestCase):
             self.assertTrue(np.allclose(kv[ent], vector))
 
     def test_add_type(self):
-        dtype = np.float32
-        kv = KeyedVectors(2, dtype=dtype)
-        words, vectors = ["a"], np.array([1., 1.], dtype=np.float16).reshape(1, -1)
+        kv = KeyedVectors(2)
+        assert kv.vectors.dtype == REAL
 
-        assert kv.vectors.dtype == dtype
-
+        words, vectors = ["a"], np.array([1., 1.], dtype=np.float64).reshape(1, -1)
         kv.add(words, vectors)
-        assert kv.vectors.dtype == dtype
+
+        assert kv.vectors.dtype == REAL
 
     def test_set_item(self):
         """Test that __setitem__ works correctly."""

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -256,13 +256,14 @@ class TestKeyedVectors(unittest.TestCase):
             self.assertTrue(np.allclose(kv[ent], vector))
 
     def test_add_type(self):
-        kv = KeyedVectors(2)
-        words, vectors = ["a"], np.array([1., 1.], dtype=np.float32).reshape(1, -1)
+        dtype = np.float32
+        kv = KeyedVectors(2, dtype=dtype)
+        words, vectors = ["a"], np.array([1., 1.], dtype=np.float16).reshape(1, -1)
 
-        assert kv.vectors.dtype == np.float64  # default dtype of empty KV
+        assert kv.vectors.dtype == dtype
 
         kv.add(words, vectors)
-        assert kv.vectors.dtype == np.float32  # new dtype of KV (copied from passed vectors)
+        assert kv.vectors.dtype == dtype
 
     def test_set_item(self):
         """Test that __setitem__ works correctly."""


### PR DESCRIPTION
## Problem

I created empty KV (for fill them later using `add` method) and after this operation I don't expect than datatype of KV internal matrix will be `np.float64`, instead of the type of added vectors.

## Code example

```python
import numpy as np
from gensim.models import KeyedVectors


kv = KeyedVectors(2)
words, vectors = ["a"], np.array([1., 1.], dtype=np.float32).reshape(1, -1)


kv.add(words, vectors)

assert vectors.dtype == np.float32  # correct
assert kv.vectors.dtype == np.float32  # failed here
```

## Solution

Cast internal `KeyedVectors.vectors` attribute to dtype of `add(..., vectors)`