### PR TITLE
Fix fastText word_vec() for OOV words with use_norm=True

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -2114,10 +2114,7 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
             raise KeyError('cannot calculate vector for OOV word without ngrams')
         else:
             word_vec = np.zeros(self.vectors_ngrams.shape[1], dtype=np.float32)
-            if use_norm:
-                ngram_weights = self.vectors_ngrams_norm
-            else:
-                ngram_weights = self.vectors_ngrams
+            ngram_weights = self.vectors_ngrams
             ngram_hashes = ft_ngram_hashes(word, self.min_n, self.max_n, self.bucket, self.compatible_hash)
             if len(ngram_hashes) == 0:
                 #
@@ -2132,7 +2129,10 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
                 return word_vec
             for nh in ngram_hashes:
                 word_vec += ngram_weights[nh]
-            return word_vec / len(ngram_hashes)
+            result = word_vec / len(ngram_hashes)
+            if use_norm:
+                result /= sqrt(sum(result ** 2))
+            return result
 
     def init_sims(self, replace=False):
         """Precompute L2-normalized vectors.

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -2114,7 +2114,6 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
             raise KeyError('cannot calculate vector for OOV word without ngrams')
         else:
             word_vec = np.zeros(self.vectors_ngrams.shape[1], dtype=np.float32)
-            ngram_weights = self.vectors_ngrams
             ngram_hashes = ft_ngram_hashes(word, self.min_n, self.max_n, self.bucket, self.compatible_hash)
             if len(ngram_hashes) == 0:
                 #
@@ -2128,7 +2127,7 @@ class FastTextKeyedVectors(WordEmbeddingsKeyedVectors):
                 logger.warning('could not extract any ngrams from %r, returning origin vector', word)
                 return word_vec
             for nh in ngram_hashes:
-                word_vec += ngram_weights[nh]
+                word_vec += self.vectors_ngrams[nh]
             result = word_vec / len(ngram_hashes)
             if use_norm:
                 result /= sqrt(sum(result ** 2))

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -326,6 +326,15 @@ class TestFastTextModel(unittest.TestCase):
         except KeyError:
             self.fail('Unable to access vector for cp-852 word')
 
+    def test_oov_similarity(self):
+        word = 'someoovword'
+        most_similar = self.test_model.wv.most_similar(word)
+        top_neighbor, top_similarity = most_similar[0]
+        v1 = self.test_model.vw[word]
+        v2 = self.test_model.vw[top_neighbor]
+        top_similarity_direct = self.test_model.wv.cosine_similarity(v1, v2.reshape(1, -1))[0]
+        self.assertAlmostEqual(top_similarity, top_similarity_direct)
+
     def test_n_similarity(self):
         # In vocab, sanity check
         self.assertTrue(np.allclose(self.test_model.wv.n_similarity(['the', 'and'], ['and', 'the']), 1.0))

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -333,7 +333,7 @@ class TestFastTextModel(unittest.TestCase):
         v1 = self.test_model.wv[word]
         v2 = self.test_model.wv[top_neighbor]
         top_similarity_direct = self.test_model.wv.cosine_similarities(v1, v2.reshape(1, -1))[0]
-        self.assertAlmostEqual(top_similarity, top_similarity_direct)
+        self.assertAlmostEqual(top_similarity, top_similarity_direct, places=6)
 
     def test_n_similarity(self):
         # In vocab, sanity check

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -332,7 +332,7 @@ class TestFastTextModel(unittest.TestCase):
         top_neighbor, top_similarity = most_similar[0]
         v1 = self.test_model.wv[word]
         v2 = self.test_model.wv[top_neighbor]
-        top_similarity_direct = self.test_model.wv.cosine_similarity(v1, v2.reshape(1, -1))[0]
+        top_similarity_direct = self.test_model.wv.cosine_similarities(v1, v2.reshape(1, -1))[0]
         self.assertAlmostEqual(top_similarity, top_similarity_direct)
 
     def test_n_similarity(self):

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -330,8 +330,8 @@ class TestFastTextModel(unittest.TestCase):
         word = 'someoovword'
         most_similar = self.test_model.wv.most_similar(word)
         top_neighbor, top_similarity = most_similar[0]
-        v1 = self.test_model.vw[word]
-        v2 = self.test_model.vw[top_neighbor]
+        v1 = self.test_model.wv[word]
+        v2 = self.test_model.wv[top_neighbor]
         top_similarity_direct = self.test_model.wv.cosine_similarity(v1, v2.reshape(1, -1))[0]
         self.assertAlmostEqual(top_similarity, top_similarity_direct)
 


### PR DESCRIPTION
Fixes #2763