### PR TITLE
[MRG] Fix broken English in unittests

### DIFF
--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -393,7 +393,7 @@ class TestFastTextModel(unittest.TestCase):
         self.assertFalse('nights' in self.test_model.wv.vocab)
         self.assertTrue('nights' in self.test_model.wv)
 
-    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed or have some issues")
+    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
     def test_wm_distance(self):
         doc = ['night', 'payment']
         oov_doc = ['nights', 'forests', 'payments']

--- a/gensim/test/test_fasttext_wrapper.py
+++ b/gensim/test/test_fasttext_wrapper.py
@@ -319,7 +319,7 @@ class TestFastText(unittest.TestCase):
         self.assertFalse('a!@' in self.test_model.wv.vocab)
         self.assertFalse('a!@' in self.test_model)
 
-    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed or have some issues")
+    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
     def testWmdistance(self):
         """Tests wmdistance for docs with in-vocab and out-of-vocab words"""
         doc = ['night', 'payment']

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -86,7 +86,7 @@ class _TestSimilarityABC(object):
 
     def testNumBest(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
-            self.skipTest("pyemd not installed or have some issues")
+            self.skipTest("pyemd not installed")
 
         for num_best in [None, 0, 1, 9, 1000]:
             self.testFull(num_best=num_best)
@@ -117,7 +117,7 @@ class _TestSimilarityABC(object):
     def testEmptyQuery(self):
         index = self.factoryMethod()
         if isinstance(index, similarities.WmdSimilarity) and not PYEMD_EXT:
-            self.skipTest("pyemd not installed or have some issues")
+            self.skipTest("pyemd not installed")
 
         query = []
         try:
@@ -175,7 +175,7 @@ class _TestSimilarityABC(object):
 
     def testPersistency(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
-            self.skipTest("pyemd not installed or have some issues")
+            self.skipTest("pyemd not installed")
 
         fname = get_tmpfile('gensim_similarities.tst.pkl')
         index = self.factoryMethod()
@@ -195,7 +195,7 @@ class _TestSimilarityABC(object):
 
     def testPersistencyCompressed(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
-            self.skipTest("pyemd not installed or have some issues")
+            self.skipTest("pyemd not installed")
 
         fname = get_tmpfile('gensim_similarities.tst.pkl.gz')
         index = self.factoryMethod()
@@ -215,7 +215,7 @@ class _TestSimilarityABC(object):
 
     def testLarge(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
-            self.skipTest("pyemd not installed or have some issues")
+            self.skipTest("pyemd not installed")
 
         fname = get_tmpfile('gensim_similarities.tst.pkl')
         index = self.factoryMethod()
@@ -237,7 +237,7 @@ class _TestSimilarityABC(object):
 
     def testLargeCompressed(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
-            self.skipTest("pyemd not installed or have some issues")
+            self.skipTest("pyemd not installed")
 
         fname = get_tmpfile('gensim_similarities.tst.pkl.gz')
         index = self.factoryMethod()
@@ -259,7 +259,7 @@ class _TestSimilarityABC(object):
 
     def testMmap(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
-            self.skipTest("pyemd not installed or have some issues")
+            self.skipTest("pyemd not installed")
 
         fname = get_tmpfile('gensim_similarities.tst.pkl')
         index = self.factoryMethod()
@@ -282,7 +282,7 @@ class _TestSimilarityABC(object):
 
     def testMmapCompressed(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
-            self.skipTest("pyemd not installed or have some issues")
+            self.skipTest("pyemd not installed")
 
         fname = get_tmpfile('gensim_similarities.tst.pkl.gz')
         index = self.factoryMethod()
@@ -307,7 +307,7 @@ class TestWmdSimilarity(unittest.TestCase, _TestSimilarityABC):
         # Override factoryMethod.
         return self.cls(texts, self.w2v_model)
 
-    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed or have some issues")
+    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
     def testFull(self, num_best=None):
         # Override testFull.
 
@@ -326,7 +326,7 @@ class TestWmdSimilarity(unittest.TestCase, _TestSimilarityABC):
             self.assertTrue(numpy.alltrue(sims[1:] > 0.0))
             self.assertTrue(numpy.alltrue(sims[1:] < 1.0))
 
-    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed or have some issues")
+    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
     def testNonIncreasing(self):
         ''' Check that similarities are non-increasing when `num_best` is not
         `None`.'''
@@ -342,7 +342,7 @@ class TestWmdSimilarity(unittest.TestCase, _TestSimilarityABC):
         cond = sum(numpy.diff(sims2) < 0) == len(sims2) - 1
         self.assertTrue(cond)
 
-    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed or have some issues")
+    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
     def testChunking(self):
         # Override testChunking.
 
@@ -361,7 +361,7 @@ class TestWmdSimilarity(unittest.TestCase, _TestSimilarityABC):
                 self.assertTrue(numpy.alltrue(sim > 0.0))
                 self.assertTrue(numpy.alltrue(sim <= 1.0))
 
-    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed or have some issues")
+    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
     def testIter(self):
         # Override testIter.
 

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -1021,7 +1021,7 @@ class TestWord2VecModel(unittest.TestCase):
 
 class TestWMD(unittest.TestCase):
 
-    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed or have some issues")
+    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
     def testNonzero(self):
         '''Test basic functionality with a test sentence.'''
 
@@ -1033,7 +1033,7 @@ class TestWMD(unittest.TestCase):
         # Check that distance is non-zero.
         self.assertFalse(distance == 0.0)
 
-    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed or have some issues")
+    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
     def testSymmetry(self):
         '''Check that distance is symmetric.'''
 
@@ -1044,7 +1044,7 @@ class TestWMD(unittest.TestCase):
         distance2 = model.wv.wmdistance(sentence2, sentence1)
         self.assertTrue(np.allclose(distance1, distance2))
 
-    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed or have some issues")
+    @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
     def testIdenticalSentences(self):
         '''Check that the distance from a sentence to itself is zero.'''
 


### PR DESCRIPTION
When looking at why our builds are [failing](https://travis-ci.org/github/RaRe-Technologies/gensim/jobs/665569927?utm_medium=notification&utm_source=github_status) (incl. in the main branch = the README badge is red now), I saw some texts in broken English.

This is a minor PR fixing the language.