### PR TITLE
Fix typo in comments

### DIFF
--- a/gensim/models/callbacks.py
+++ b/gensim/models/callbacks.py
@@ -184,7 +184,7 @@ class CoherenceMetric(Metric):
         Parameters
         ----------
         corpus : {iterable of list of (int, float), scipy.sparse.csc}, optional
-            Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`).
+            Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`).
         texts : list of char (str of length 1), optional
             Tokenized texts needed for coherence models that use sliding window based probability estimator.
         dictionary : :class:`~gensim.corpora.dictionary.Dictionary`, optional
@@ -267,7 +267,7 @@ class PerplexityMetric(Metric):
         Parameters
         ----------
         corpus : {iterable of list of (int, float), scipy.sparse.csc}, optional
-            Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`).
+            Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`).
         logger : {'shell', 'visdom'}, optional
            Monitor training process using one of the available methods. 'shell' will print the perplexity value in
            the active shell, while 'visdom' will visualize the coherence value with increasing epochs using the Visdom

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -355,7 +355,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         Parameters
         ----------
         corpus : {iterable of list of (int, float), scipy.sparse.csc}, optional
-            Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`).
+            Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`).
             If not given, the model is left untrained (presumably because you want to call
             :meth:`~gensim.models.ldamodel.LdaModel.update` manually).
         num_topics : int, optional
@@ -846,7 +846,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         Parameters
         ----------
         corpus : {iterable of list of (int, float), scipy.sparse.csc}, optional
-            Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`) used to update the
+            Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`) used to update the
             model.
         chunksize :  int, optional
             Number of documents to be used in each training chunk.
@@ -1061,7 +1061,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         Parameters
         ----------
         corpus : {iterable of list of (int, float), scipy.sparse.csc}, optional
-            Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`) used to estimate the
+            Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`) used to estimate the
             variational bounds.
         gamma : numpy.ndarray, optional
             Topic weight variational parameters for each document. If not supplied, it will be inferred from the model.

--- a/gensim/models/ldamulticore.py
+++ b/gensim/models/ldamulticore.py
@@ -112,7 +112,7 @@ class LdaMulticore(LdaModel):
         Parameters
         ----------
         corpus : {iterable of list of (int, float), scipy.sparse.csc}, optional
-            Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`).
+            Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`).
             If not given, the model is left untrained (presumably because you want to call
             :meth:`~gensim.models.ldamodel.LdaModel.update` manually).
         num_topics : int, optional
@@ -206,7 +206,7 @@ class LdaMulticore(LdaModel):
         Parameters
         ----------
         corpus : {iterable of list of (int, float), scipy.sparse.csc}, optional
-            Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`) used to update the
+            Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`) used to update the
             model.
         chunks_as_numpy : bool
             Whether each chunk passed to the inference step should be a np.ndarray or not. Numpy can in some settings

--- a/gensim/models/ldaseqmodel.py
+++ b/gensim/models/ldaseqmodel.py
@@ -73,7 +73,7 @@ class LdaSeqModel(utils.SaveLoad):
         Parameters
         ----------
         corpus : {iterable of list of (int, float), scipy.sparse.csc}, optional
-            Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`).
+            Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`).
             If not given, the model is left untrained (presumably because you want to call
             :meth:`~gensim.models.ldamodel.LdaSeqModel.update` manually).
         time_slice : list of int, optional
@@ -225,7 +225,7 @@ class LdaSeqModel(utils.SaveLoad):
         Parameters
         ----------
         corpus : {iterable of list of (int, float), scipy.sparse.csc}
-            Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`).
+            Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`).
         lda_inference_max_iter : int
             Maximum number of iterations for the inference step of LDA.
         em_min_iter : int
@@ -314,7 +314,7 @@ class LdaSeqModel(utils.SaveLoad):
         Parameters
         ----------
         corpus : {iterable of list of (int, float), scipy.sparse.csc}
-            Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`).
+            Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`).
         topic_suffstats : numpy.ndarray
             Sufficient statistics for time slice 0, used for initializing the model if `initialize == 'own'`,
             expected shape (`self.vocab_len`, `num_topics`).
@@ -368,7 +368,7 @@ class LdaSeqModel(utils.SaveLoad):
         Parameters
         ----------
         corpus : {iterable of list of (int, float), scipy.sparse.csc}
-            Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`).
+            Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`).
         topic_suffstats : numpy.ndarray
             Sufficient statistics of the current model, expected shape (`self.vocab_len`, `num_topics`).
         gammas : numpy.ndarray

--- a/gensim/models/lsimodel.py
+++ b/gensim/models/lsimodel.py
@@ -363,7 +363,7 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         Parameters
         ----------
         corpus : {iterable of list of (int, float), scipy.sparse.csc}, optional
-            Stream of document vectors or sparse matrix of shape (`num_terms`, `num_documents`).
+            Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`).
         num_topics : int, optional
             Number of requested factors (latent dimensions)
         id2word : dict of {int: str}, optional

--- a/gensim/sklearn_api/lsimodel.py
+++ b/gensim/sklearn_api/lsimodel.py
@@ -143,7 +143,7 @@ class LsiTransformer(TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : {iterable of list of (int, number), scipy.sparse matrix}
-            Stream of document vectors or sparse matrix of shape: [`num_terms`, `num_documents`].
+            Stream of document vectors or sparse matrix of shape: [`num_documents`, `num_terms`].
 
         Returns
         -------


### PR DESCRIPTION
The rows of the corpus are actually documents, fix the comment to reduce confusion.