### PR TITLE
Add osx+py38 case for avoid multiprocessing issue

### DIFF
--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1265,7 +1265,7 @@ if os.name == 'nt' or (sys.platform == "darwin" and sys.version_info >= (3, 8)):
         """
         if maxsize > 0:
             entity = "Windows" if os.name == 'nt' else "OSX with python3.8+"
-            warnings.warn("detected {entity}; aliasing chunkize to chunkize_serial".format(entity=entity))
+            warnings.warn("detected %s; aliasing chunkize to chunkize_serial" % entity)
         for chunk in chunkize_serial(corpus, chunksize, as_numpy=as_numpy):
             yield chunk
 else:

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1238,7 +1238,7 @@ class InputQueue(multiprocessing.Process):
             self.q.put(wrapped_chunk.pop(), block=True)
 
 
-if os.name == 'nt':
+if os.name == 'nt' or (sys.platform == "darwin" and sys.version_info >= (3, 8)):
     def chunkize(corpus, chunksize, maxsize=0, as_numpy=False):
         """Split `corpus` into fixed-sized chunks, using :func:`~gensim.utils.chunkize_serial`.
 

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1238,7 +1238,10 @@ class InputQueue(multiprocessing.Process):
             self.q.put(wrapped_chunk.pop(), block=True)
 
 
-# Avoid multiprocessing issue on Windows and OSX with python3.8+
+# Multiprocessing on Windows (and on OSX with python3.8+) uses "spawn" mode, which
+# causes issues with pickling.
+# So for these two platforms, use simpler serial processing in `chunkize`.
+# See https://github.com/RaRe-Technologies/gensim/pull/2800/files#r410890171
 if os.name == 'nt' or (sys.platform == "darwin" and sys.version_info >= (3, 8)):
     def chunkize(corpus, chunksize, maxsize=0, as_numpy=False):
         """Split `corpus` into fixed-sized chunks, using :func:`~gensim.utils.chunkize_serial`.

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1238,6 +1238,7 @@ class InputQueue(multiprocessing.Process):
             self.q.put(wrapped_chunk.pop(), block=True)
 
 
+# Avoid multiprocessing issue on Windows and OSX with python3.8+
 if os.name == 'nt' or (sys.platform == "darwin" and sys.version_info >= (3, 8)):
     def chunkize(corpus, chunksize, maxsize=0, as_numpy=False):
         """Split `corpus` into fixed-sized chunks, using :func:`~gensim.utils.chunkize_serial`.
@@ -1260,7 +1261,8 @@ if os.name == 'nt' or (sys.platform == "darwin" and sys.version_info >= (3, 8)):
 
         """
         if maxsize > 0:
-            warnings.warn("detected Windows; aliasing chunkize to chunkize_serial")
+            entity = "Windows" if os.name == 'nt' else "OSX with python3.8+"
+            warnings.warn("detected {entity}; aliasing chunkize to chunkize_serial".format(entity=entity))
         for chunk in chunkize_serial(corpus, chunksize, as_numpy=as_numpy):
             yield chunk
 else:

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -1241,7 +1241,7 @@ class InputQueue(multiprocessing.Process):
 # Multiprocessing on Windows (and on OSX with python3.8+) uses "spawn" mode, which
 # causes issues with pickling.
 # So for these two platforms, use simpler serial processing in `chunkize`.
-# See https://github.com/RaRe-Technologies/gensim/pull/2800/files#r410890171
+# See https://github.com/RaRe-Technologies/gensim/pull/2800#discussion_r410890171
 if os.name == 'nt' or (sys.platform == "darwin" and sys.version_info >= (3, 8)):
     def chunkize(corpus, chunksize, maxsize=0, as_numpy=False):
         """Split `corpus` into fixed-sized chunks, using :func:`~gensim.utils.chunkize_serial`.


### PR DESCRIPTION
**Current PR shouldn't be merged until https://github.com/MacPython/gensim-wheels/pull/23 build successfully.**


# Problem

I'm adding py38 to wheel building (see https://github.com/MacPython/gensim-wheels/pull/23) and stuck with several issues.

If I trying to build `OSX` wheel with `py38` I got some issues on the testing stage

```
Traceback (most recent call last):
  File "/Users/travis/build/MacPython/gensim-wheels/venv/lib/python3.8/site-packages/gensim/test/test_corpora.py", line 787, in test_custom_filterfunction
    corpus = self.corpus_class(self.enwiki, filter_articles=reject_all)
  File "/Users/travis/build/MacPython/gensim-wheels/venv/lib/python3.8/site-packages/gensim/corpora/wikicorpus.py", line 637, in __init__
    self.dictionary = Dictionary(self.get_texts())
  File "/Users/travis/build/MacPython/gensim-wheels/venv/lib/python3.8/site-packages/gensim/corpora/dictionary.py", line 88, in __init__
    self.add_documents(documents, prune_at=prune_at)
  File "/Users/travis/build/MacPython/gensim-wheels/venv/lib/python3.8/site-packages/gensim/corpora/dictionary.py", line 201, in add_documents
    for docno, document in enumerate(documents):
  File "/Users/travis/build/MacPython/gensim-wheels/venv/lib/python3.8/site-packages/gensim/corpora/wikicorpus.py", line 685, in get_texts
    for group in utils.chunkize(texts, chunksize=10 * self.processes, maxsize=1):
  File "/Users/travis/build/MacPython/gensim-wheels/venv/lib/python3.8/site-packages/gensim/utils.py", line 1311, in chunkize
    worker.start()
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/context.py", line 224, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/context.py", line 283, in _Popen
    return Popen(process_obj)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/popen_spawn_posix.py", line 47, in _launch
    reduction.dump(process_obj, fp)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
TypeError: cannot pickle 'generator' object
```
In addition, some tests (related to multiprocessing) are stuck.

# Solution

Issue was with `chunkize` function, let's fallback to `chunksize_serial` (in same way as @piskvorky done for windows)

