### PR TITLE
LdaModel documentation update -remove claim that it accepts CSC matrix as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changes
 * No more wheels for x32 platforms (if you need x32 binaries, please build them yourself).
   (__[menshikh-iv](https://github.com/menshikh-iv)__, [#6](https://github.com/RaRe-Technologies/gensim-wheels/pull/6))
 
+### :books: Tutorial and doc improvements
+
+ * Clear up LdaModel documentation - remove claim that it accepts CSC matrix as input (PR [#2832](https://github.com/RaRe-Technologies/gensim/pull/2832), [@FyzHsn](https://github.com/FyzHsn))
+
 ## :warning: 3.8.x will be the last gensim version to support Py2.7. Starting with 4.0.0, gensim will only support Py3.5 and above
 
 ## 3.8.1, 2019-09-23

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -354,8 +354,10 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         Parameters
         ----------
-        corpus : {iterable of list of (int, float), scipy.sparse.csc}, optional
+        corpus : iterable of list of (int, float), optional
             Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`).
+            If you have a CSC in-memory matrix, you can convert it to a
+            streamed corpus with the help of gensim.matutils.Sparse2Corpus.
             If not given, the model is left untrained (presumably because you want to call
             :meth:`~gensim.models.ldamodel.LdaModel.update` manually).
         num_topics : int, optional
@@ -626,7 +628,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         Parameters
         ----------
-        chunk : {list of list of (int, float), scipy.sparse.csc}
+        chunk : list of list of (int, float)
             The corpus chunk on which the inference step will be performed.
         collect_sstats : bool, optional
             If set to True, also collect (and return) sufficient statistics needed to update the model's topic-word
@@ -725,7 +727,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         Parameters
         ----------
-        chunk : {list of list of (int, float), scipy.sparse.csc}
+        chunk : list of list of (int, float)
             The corpus chunk on which the inference step will be performed.
         state : :class:`~gensim.models.ldamodel.LdaState`, optional
             The state to be updated with the newly accumulated sufficient statistics. If none, the models
@@ -803,7 +805,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         Parameters
         ----------
-        chunk : {list of list of (int, float), scipy.sparse.csc}
+        chunk : list of list of (int, float)
             The corpus chunk on which the inference step will be performed.
         total_docs : int, optional
             Number of docs used for evaluation of the perplexity.
@@ -845,7 +847,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         Parameters
         ----------
-        corpus : {iterable of list of (int, float), scipy.sparse.csc}, optional
+        corpus : iterable of list of (int, float), optional
             Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`) used to update the
             model.
         chunksize :  int, optional
@@ -1060,7 +1062,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         Parameters
         ----------
-        corpus : {iterable of list of (int, float), scipy.sparse.csc}, optional
+        corpus : iterable of list of (int, float), optional
             Stream of document vectors or sparse matrix of shape (`num_documents`, `num_terms`) used to estimate the
             variational bounds.
         gamma : numpy.ndarray, optional


### PR DESCRIPTION
This pull request resolves issue #2769 (category: bug, documentation).  

**Issue**: LdaModel documentation stated that it accepts `scipy.sparse.csc` matrix as an input. However, this is false. LdaModel accepts only standard streamed corpora. For more details on issue, check out: 
https://github.com/RaRe-Technologies/gensim/issues/2769). 

**Fix**: Remove claims that LdaModel accepts CSC matrices as an input. Further mentioned that a CSC in-memory matrix can be converted to a streamed corpus by using `gensim.matutils.Sparse2Corpus`. This issue affects anyone using LDA model and passing `scipy.sparse.csc` matrix as an input because the documentation says that it's accepted.



