### PR TITLE
[trial] pin keras=2.3.1 because 2.4.3 causes KerasWord2VecWrappper test failure in Py 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ if sys.version_info >= (3, 7):
     # See https://github.com/RaRe-Technologies/gensim/pull/2814#issuecomment-621477948
     linux_testenv += [
         'tensorflow',
-        'keras',
+        'keras==2.3.1',
     ]
 
 NUMPY_STR = 'numpy >= 1.11.3'


### PR DESCRIPTION
May serve as work-around for #2865.