### PR TITLE
Clarify that license is LGPL-2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -354,7 +354,7 @@ setup(
     url='http://radimrehurek.com/gensim',
     download_url='http://pypi.python.org/pypi/gensim',
 
-    license='LGPLv2.1',
+    license='LGPL-2.1-only',
 
     keywords='Singular Value Decomposition, SVD, Latent Semantic Indexing, '
         'LSA, LSI, Latent Dirichlet Allocation, LDA, '
@@ -369,7 +369,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Use only the license attribute with an SPDX license id for V2.1 of the
LGPL.

The setup.py classifier was inconsistent with the license attribute as 
one pointed to LGPL-2.0-or-later and one to LGPL-2.1-only which seems 
to be otherwise the correct license based on header comments and
documentation. Classifiers do not support the LGPL v2.1 and are 
eventually being subsumed by the license field [1]

[1] https://discuss.python.org/t/improving-license-clarity-with-better-package-metadata/2154

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>