### PR TITLE
Fix broken documentation link to mycorpus.txt

### DIFF
--- a/docs/src/auto_examples/core/run_corpora_and_vector_spaces.ipynb
+++ b/docs/src/auto_examples/core/run_corpora_and_vector_spaces.ipynb
@@ -1,439 +1,838 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "%matplotlib inline"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "\nCorpora and Vector Spaces\n=========================\n\nDemonstrates transforming text into a vector space representation.\n\nAlso introduces corpus streaming and persistence to disk in various formats.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "import logging\nlogging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "First, let\u2019s create a small corpus of nine short documents [1]_:\n\n\nFrom Strings to Vectors\n------------------------\n\nThis time, let's start from documents represented as strings:\n\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "documents = [\n    \"Human machine interface for lab abc computer applications\",\n    \"A survey of user opinion of computer system response time\",\n    \"The EPS user interface management system\",\n    \"System and human system engineering testing of EPS\",\n    \"Relation of user perceived response time to error measurement\",\n    \"The generation of random binary unordered trees\",\n    \"The intersection graph of paths in trees\",\n    \"Graph minors IV Widths of trees and well quasi ordering\",\n    \"Graph minors A survey\",\n]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "This is a tiny corpus of nine documents, each consisting of only a single sentence.\n\nFirst, let's tokenize the documents, remove common words (using a toy stoplist)\nas well as words that only appear once in the corpus:\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "from pprint import pprint  # pretty-printer\nfrom collections import defaultdict\n\n# remove common words and tokenize\nstoplist = set('for a of the and to in'.split())\ntexts = [\n    [word for word in document.lower().split() if word not in stoplist]\n    for document in documents\n]\n\n# remove words that appear only once\nfrequency = defaultdict(int)\nfor text in texts:\n    for token in text:\n        frequency[token] += 1\n\ntexts = [\n    [token for token in text if frequency[token] > 1]\n    for text in texts\n]\n\npprint(texts)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Your way of processing the documents will likely vary; here, I only split on whitespace\nto tokenize, followed by lowercasing each word. In fact, I use this particular\n(simplistic and inefficient) setup to mimic the experiment done in Deerwester et al.'s\noriginal LSA article [1]_.\n\nThe ways to process documents are so varied and application- and language-dependent that I\ndecided to *not* constrain them by any interface. Instead, a document is represented\nby the features extracted from it, not by its \"surface\" string form: how you get to\nthe features is up to you. Below I describe one common, general-purpose approach (called\n:dfn:`bag-of-words`), but keep in mind that different application domains call for\ndifferent features, and, as always, it's `garbage in, garbage out <http://en.wikipedia.org/wiki/Garbage_In,_Garbage_Out>`_...\n\nTo convert documents to vectors, we'll use a document representation called\n`bag-of-words <http://en.wikipedia.org/wiki/Bag_of_words>`_. In this representation,\neach document is represented by one vector where each vector element represents\na question-answer pair, in the style of:\n\n- Question: How many times does the word `system` appear in the document?\n- Answer: Once.\n\nIt is advantageous to represent the questions only by their (integer) ids. The mapping\nbetween the questions and ids is called a dictionary:\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "from gensim import corpora\ndictionary = corpora.Dictionary(texts)\ndictionary.save('/tmp/deerwester.dict')  # store the dictionary, for future reference\nprint(dictionary)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Here we assigned a unique integer id to all words appearing in the corpus with the\n:class:`gensim.corpora.dictionary.Dictionary` class. This sweeps across the texts, collecting word counts\nand relevant statistics. In the end, we see there are twelve distinct words in the\nprocessed corpus, which means each document will be represented by twelve numbers (ie., by a 12-D vector).\nTo see the mapping between words and their ids:\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "print(dictionary.token2id)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "To actually convert tokenized documents to vectors:\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "new_doc = \"Human computer interaction\"\nnew_vec = dictionary.doc2bow(new_doc.lower().split())\nprint(new_vec)  # the word \"interaction\" does not appear in the dictionary and is ignored"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "The function :func:`doc2bow` simply counts the number of occurrences of\neach distinct word, converts the word to its integer word id\nand returns the result as a sparse vector. The sparse vector ``[(0, 1), (1, 1)]``\ntherefore reads: in the document `\"Human computer interaction\"`, the words `computer`\n(id 0) and `human` (id 1) appear once; the other ten dictionary words appear (implicitly) zero times.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "corpus = [dictionary.doc2bow(text) for text in texts]\ncorpora.MmCorpus.serialize('/tmp/deerwester.mm', corpus)  # store to disk, for later use\nprint(corpus)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "By now it should be clear that the vector feature with ``id=10`` stands for the question \"How many\ntimes does the word `graph` appear in the document?\" and that the answer is \"zero\" for\nthe first six documents and \"one\" for the remaining three.\n\n\nCorpus Streaming -- One Document at a Time\n-------------------------------------------\n\nNote that `corpus` above resides fully in memory, as a plain Python list.\nIn this simple example, it doesn't matter much, but just to make things clear,\nlet's assume there are millions of documents in the corpus. Storing all of them in RAM won't do.\nInstead, let's assume the documents are stored in a file on disk, one document per line. Gensim\nonly requires that a corpus must be able to return one document vector at a time:\n\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "from smart_open import open  # for transparently opening remote files\n\n\nclass MyCorpus(object):\n    def __iter__(self):\n        for line in open('https://radimrehurek.com/gensim/mycorpus.txt'):\n            # assume there's one document per line, tokens separated by whitespace\n            yield dictionary.doc2bow(line.lower().split())"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "The full power of Gensim comes from the fact that a corpus doesn't have to be\na ``list``, or a ``NumPy`` array, or a ``Pandas`` dataframe, or whatever.\nGensim *accepts any object that, when iterated over, successively yields\ndocuments*.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "# This flexibility allows you to create your own corpus classes that stream the\n# documents directly from disk, network, database, dataframes... The models\n# in Gensim are implemented such that they don't require all vectors to reside\n# in RAM at once. You can even create the documents on the fly!"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Download the sample `mycorpus.txt file here <./mycorpus.txt>`_. The assumption that\neach document occupies one line in a single file is not important; you can mold\nthe `__iter__` function to fit your input format, whatever it is.\nWalking directories, parsing XML, accessing the network...\nJust parse your input to retrieve a clean list of tokens in each document,\nthen convert the tokens via a dictionary to their ids and yield the resulting sparse vector inside `__iter__`.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "corpus_memory_friendly = MyCorpus()  # doesn't load the corpus into memory!\nprint(corpus_memory_friendly)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Corpus is now an object. We didn't define any way to print it, so `print` just outputs address\nof the object in memory. Not very useful. To see the constituent vectors, let's\niterate over the corpus and print each document vector (one at a time):\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "for vector in corpus_memory_friendly:  # load one vector into memory at a time\n    print(vector)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Although the output is the same as for the plain Python list, the corpus is now much\nmore memory friendly, because at most one vector resides in RAM at a time. Your\ncorpus can now be as large as you want.\n\nSimilarly, to construct the dictionary without loading all texts into memory:\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "from six import iteritems\n# collect statistics about all tokens\ndictionary = corpora.Dictionary(line.lower().split() for line in open('https://radimrehurek.com/gensim/mycorpus.txt'))\n# remove stop words and words that appear only once\nstop_ids = [\n    dictionary.token2id[stopword]\n    for stopword in stoplist\n    if stopword in dictionary.token2id\n]\nonce_ids = [tokenid for tokenid, docfreq in iteritems(dictionary.dfs) if docfreq == 1]\ndictionary.filter_tokens(stop_ids + once_ids)  # remove stop words and words that appear only once\ndictionary.compactify()  # remove gaps in id sequence after words that were removed\nprint(dictionary)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "And that is all there is to it! At least as far as bag-of-words representation is concerned.\nOf course, what we do with such a corpus is another question; it is not at all clear\nhow counting the frequency of distinct words could be useful. As it turns out, it isn't, and\nwe will need to apply a transformation on this simple representation first, before\nwe can use it to compute any meaningful document vs. document similarities.\nTransformations are covered in the next tutorial\n(`sphx_glr_auto_examples_core_run_topics_and_transformations.py`),\nbut before that, let's briefly turn our attention to *corpus persistency*.\n\n\nCorpus Formats\n---------------\n\nThere exist several file formats for serializing a Vector Space corpus (~sequence of vectors) to disk.\n`Gensim` implements them via the *streaming corpus interface* mentioned earlier:\ndocuments are read from (resp. stored to) disk in a lazy fashion, one document at\na time, without the whole corpus being read into main memory at once.\n\nOne of the more notable file formats is the `Market Matrix format <http://math.nist.gov/MatrixMarket/formats.html>`_.\nTo save a corpus in the Matrix Market format:\n\ncreate a toy corpus of 2 documents, as a plain Python list\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "corpus = [[(1, 0.5)], []]  # make one document empty, for the heck of it\n\ncorpora.MmCorpus.serialize('/tmp/corpus.mm', corpus)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Other formats include `Joachim's SVMlight format <http://svmlight.joachims.org/>`_,\n`Blei's LDA-C format <http://www.cs.princeton.edu/~blei/lda-c/>`_ and\n`GibbsLDA++ format <http://gibbslda.sourceforge.net/>`_.\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "corpora.SvmLightCorpus.serialize('/tmp/corpus.svmlight', corpus)\ncorpora.BleiCorpus.serialize('/tmp/corpus.lda-c', corpus)\ncorpora.LowCorpus.serialize('/tmp/corpus.low', corpus)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Conversely, to load a corpus iterator from a Matrix Market file:\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "corpus = corpora.MmCorpus('/tmp/corpus.mm')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Corpus objects are streams, so typically you won't be able to print them directly:\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "print(corpus)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Instead, to view the contents of a corpus:\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "# one way of printing a corpus: load it entirely into memory\nprint(list(corpus))  # calling list() will convert any sequence to a plain Python list"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "or\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "# another way of doing it: print one document at a time, making use of the streaming interface\nfor doc in corpus:\n    print(doc)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "The second way is obviously more memory-friendly, but for testing and development\npurposes, nothing beats the simplicity of calling ``list(corpus)``.\n\nTo save the same Matrix Market document stream in Blei's LDA-C format,\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "corpora.BleiCorpus.serialize('/tmp/corpus.lda-c', corpus)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "In this way, `gensim` can also be used as a memory-efficient **I/O format conversion tool**:\njust load a document stream using one format and immediately save it in another format.\nAdding new formats is dead easy, check out the `code for the SVMlight corpus\n<https://github.com/piskvorky/gensim/blob/develop/gensim/corpora/svmlightcorpus.py>`_ for an example.\n\nCompatibility with NumPy and SciPy\n----------------------------------\n\nGensim also contains `efficient utility functions <http://radimrehurek.com/gensim/matutils.html>`_\nto help converting from/to numpy matrices\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "import gensim\nimport numpy as np\nnumpy_matrix = np.random.randint(10, size=[5, 2])  # random matrix as an example\ncorpus = gensim.matutils.Dense2Corpus(numpy_matrix)\n# numpy_matrix = gensim.matutils.corpus2dense(corpus, num_terms=number_of_corpus_features)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "and from/to `scipy.sparse` matrices\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "import scipy.sparse\nscipy_sparse_matrix = scipy.sparse.random(5, 2)  # random sparse matrix as example\ncorpus = gensim.matutils.Sparse2Corpus(scipy_sparse_matrix)\nscipy_csc_matrix = gensim.matutils.corpus2csc(corpus)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "What Next\n---------\n\nRead about `sphx_glr_auto_examples_core_run_topics_and_transformations.py`.\n\nReferences\n----------\n\nFor a complete reference (Want to prune the dictionary to a smaller size?\nOptimize converting between corpora and NumPy/SciPy arrays?), see the `apiref`.\n\n.. [1] This is the same corpus as used in\n       `Deerwester et al. (1990): Indexing by Latent Semantic Analysis <http://www.cs.bham.ac.uk/~pxt/IDA/lsa_ind.pdf>`_, Table 2.\n\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Here we show a pretty fastText logo so that our gallery picks it up as a thumbnail.\n\n\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false
-      },
-      "outputs": [],
-      "source": [
-        "import matplotlib.pyplot as plt\nimport matplotlib.image as mpimg\nimg = mpimg.imread('run_corpora_and_vector_spaces.png')\nimgplot = plt.imshow(img)\nplt.axis('off')\nplt.show()"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.7.1"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Corpora and Vector Spaces\n",
+    "=========================\n",
+    "\n",
+    "Demonstrates transforming text into a vector space representation.\n",
+    "\n",
+    "Also introduces corpus streaming and persistence to disk in various formats.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, let’s create a small corpus of nine short documents [1]_:\n",
+    "\n",
+    "\n",
+    "From Strings to Vectors\n",
+    "------------------------\n",
+    "\n",
+    "This time, let's start from documents represented as strings:\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "documents = [\n",
+    "    \"Human machine interface for lab abc computer applications\",\n",
+    "    \"A survey of user opinion of computer system response time\",\n",
+    "    \"The EPS user interface management system\",\n",
+    "    \"System and human system engineering testing of EPS\",\n",
+    "    \"Relation of user perceived response time to error measurement\",\n",
+    "    \"The generation of random binary unordered trees\",\n",
+    "    \"The intersection graph of paths in trees\",\n",
+    "    \"Graph minors IV Widths of trees and well quasi ordering\",\n",
+    "    \"Graph minors A survey\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a tiny corpus of nine documents, each consisting of only a single sentence.\n",
+    "\n",
+    "First, let's tokenize the documents, remove common words (using a toy stoplist)\n",
+    "as well as words that only appear once in the corpus:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['human', 'interface', 'computer'],\n",
+      " ['survey', 'user', 'computer', 'system', 'response', 'time'],\n",
+      " ['eps', 'user', 'interface', 'system'],\n",
+      " ['system', 'human', 'system', 'eps'],\n",
+      " ['user', 'response', 'time'],\n",
+      " ['trees'],\n",
+      " ['graph', 'trees'],\n",
+      " ['graph', 'minors', 'trees'],\n",
+      " ['graph', 'minors', 'survey']]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pprint import pprint  # pretty-printer\n",
+    "from collections import defaultdict\n",
+    "\n",
+    "# remove common words and tokenize\n",
+    "stoplist = set('for a of the and to in'.split())\n",
+    "texts = [\n",
+    "    [word for word in document.lower().split() if word not in stoplist]\n",
+    "    for document in documents\n",
+    "]\n",
+    "\n",
+    "# remove words that appear only once\n",
+    "frequency = defaultdict(int)\n",
+    "for text in texts:\n",
+    "    for token in text:\n",
+    "        frequency[token] += 1\n",
+    "\n",
+    "texts = [\n",
+    "    [token for token in text if frequency[token] > 1]\n",
+    "    for text in texts\n",
+    "]\n",
+    "\n",
+    "pprint(texts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your way of processing the documents will likely vary; here, I only split on whitespace\n",
+    "to tokenize, followed by lowercasing each word. In fact, I use this particular\n",
+    "(simplistic and inefficient) setup to mimic the experiment done in Deerwester et al.'s\n",
+    "original LSA article [1]_.\n",
+    "\n",
+    "The ways to process documents are so varied and application- and language-dependent that I\n",
+    "decided to *not* constrain them by any interface. Instead, a document is represented\n",
+    "by the features extracted from it, not by its \"surface\" string form: how you get to\n",
+    "the features is up to you. Below I describe one common, general-purpose approach (called\n",
+    ":dfn:`bag-of-words`), but keep in mind that different application domains call for\n",
+    "different features, and, as always, it's `garbage in, garbage out <http://en.wikipedia.org/wiki/Garbage_In,_Garbage_Out>`_...\n",
+    "\n",
+    "To convert documents to vectors, we'll use a document representation called\n",
+    "`bag-of-words <http://en.wikipedia.org/wiki/Bag_of_words>`_. In this representation,\n",
+    "each document is represented by one vector where each vector element represents\n",
+    "a question-answer pair, in the style of:\n",
+    "\n",
+    "- Question: How many times does the word `system` appear in the document?\n",
+    "- Answer: Once.\n",
+    "\n",
+    "It is advantageous to represent the questions only by their (integer) ids. The mapping\n",
+    "between the questions and ids is called a dictionary:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-07-06 17:45:48,927 : INFO : adding document #0 to Dictionary(0 unique tokens: [])\n",
+      "2020-07-06 17:45:48,928 : INFO : built Dictionary(12 unique tokens: ['computer', 'human', 'interface', 'response', 'survey']...) from 9 documents (total 29 corpus positions)\n",
+      "2020-07-06 17:45:48,929 : INFO : saving Dictionary object under /tmp/deerwester.dict, separately None\n",
+      "2020-07-06 17:45:48,930 : INFO : saved /tmp/deerwester.dict\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dictionary(12 unique tokens: ['computer', 'human', 'interface', 'response', 'survey']...)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from gensim import corpora\n",
+    "dictionary = corpora.Dictionary(texts)\n",
+    "dictionary.save('/tmp/deerwester.dict')  # store the dictionary, for future reference\n",
+    "print(dictionary)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we assigned a unique integer id to all words appearing in the corpus with the\n",
+    ":class:`gensim.corpora.dictionary.Dictionary` class. This sweeps across the texts, collecting word counts\n",
+    "and relevant statistics. In the end, we see there are twelve distinct words in the\n",
+    "processed corpus, which means each document will be represented by twelve numbers (ie., by a 12-D vector).\n",
+    "To see the mapping between words and their ids:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'computer': 0, 'human': 1, 'interface': 2, 'response': 3, 'survey': 4, 'system': 5, 'time': 6, 'user': 7, 'eps': 8, 'trees': 9, 'graph': 10, 'minors': 11}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dictionary.token2id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To actually convert tokenized documents to vectors:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(0, 1), (1, 1)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_doc = \"Human computer interaction\"\n",
+    "new_vec = dictionary.doc2bow(new_doc.lower().split())\n",
+    "print(new_vec)  # the word \"interaction\" does not appear in the dictionary and is ignored"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function :func:`doc2bow` simply counts the number of occurrences of\n",
+    "each distinct word, converts the word to its integer word id\n",
+    "and returns the result as a sparse vector. The sparse vector ``[(0, 1), (1, 1)]``\n",
+    "therefore reads: in the document `\"Human computer interaction\"`, the words `computer`\n",
+    "(id 0) and `human` (id 1) appear once; the other ten dictionary words appear (implicitly) zero times.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-07-06 17:45:53,635 : INFO : storing corpus in Matrix Market format to /tmp/deerwester.mm\n",
+      "2020-07-06 17:45:53,636 : INFO : saving sparse matrix to /tmp/deerwester.mm\n",
+      "2020-07-06 17:45:53,637 : INFO : PROGRESS: saving document #0\n",
+      "2020-07-06 17:45:53,638 : INFO : saved 9x12 matrix, density=25.926% (28/108)\n",
+      "2020-07-06 17:45:53,639 : INFO : saving MmCorpus index to /tmp/deerwester.mm.index\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[(0, 1), (1, 1), (2, 1)], [(0, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1)], [(2, 1), (5, 1), (7, 1), (8, 1)], [(1, 1), (5, 2), (8, 1)], [(3, 1), (6, 1), (7, 1)], [(9, 1)], [(9, 1), (10, 1)], [(9, 1), (10, 1), (11, 1)], [(4, 1), (10, 1), (11, 1)]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "corpus = [dictionary.doc2bow(text) for text in texts]\n",
+    "corpora.MmCorpus.serialize('/tmp/deerwester.mm', corpus)  # store to disk, for later use\n",
+    "print(corpus)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By now it should be clear that the vector feature with ``id=10`` stands for the question \"How many\n",
+    "times does the word `graph` appear in the document?\" and that the answer is \"zero\" for\n",
+    "the first six documents and \"one\" for the remaining three.\n",
+    "\n",
+    "\n",
+    "Corpus Streaming -- One Document at a Time\n",
+    "-------------------------------------------\n",
+    "\n",
+    "Note that `corpus` above resides fully in memory, as a plain Python list.\n",
+    "In this simple example, it doesn't matter much, but just to make things clear,\n",
+    "let's assume there are millions of documents in the corpus. Storing all of them in RAM won't do.\n",
+    "Instead, let's assume the documents are stored in a file on disk, one document per line. Gensim\n",
+    "only requires that a corpus must be able to return one document vector at a time:\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Create Sample Document to Read From - We can assume it is stored on disk ## \n",
+    "with open('/tmp/mycorpus.txt', 'w') as the_file:\n",
+    "    the_file.write(\n",
+    "        \"\"\"Human machine interface for lab abc computer applications\n",
+    "A survey of user opinion of computer system response time\n",
+    "The EPS user interface management system\n",
+    "System and human system engineering testing of EPS\n",
+    "Relation of user perceived response time to error measurement\n",
+    "The generation of random binary unordered trees\n",
+    "The intersection graph of paths in trees\n",
+    "Graph minors IV Widths of trees and well quasi ordering\n",
+    "Graph minors A survey\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from smart_open import open  # for transparently opening remote files\n",
+    "\n",
+    "class MyCorpus(object):\n",
+    "    def __iter__(self):\n",
+    "        for line in open('/tmp/mycorpus.txt'):\n",
+    "            # assume there's one document per line, tokens separated by whitespace\n",
+    "            yield dictionary.doc2bow(line.lower().split())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The full power of Gensim comes from the fact that a corpus doesn't have to be\n",
+    "a ``list``, or a ``NumPy`` array, or a ``Pandas`` dataframe, or whatever.\n",
+    "Gensim *accepts any object that, when iterated over, successively yields\n",
+    "documents*.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This flexibility allows you to create your own corpus classes that stream the\n",
+    "# documents directly from disk, network, database, dataframes... The models\n",
+    "# in Gensim are implemented such that they don't require all vectors to reside\n",
+    "# in RAM at once. You can even create the documents on the fly!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The assumption that each document occupies one line in a single file is not important; you can mold\n",
+    "the `__iter__` function to fit your input format, whatever it is.\n",
+    "Walking directories, parsing XML, accessing the network...\n",
+    "Just parse your input to retrieve a clean list of tokens in each document,\n",
+    "then convert the tokens via a dictionary to their ids and yield the resulting sparse vector inside `__iter__`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<__main__.MyCorpus object at 0x1a17fbb190>\n"
+     ]
+    }
+   ],
+   "source": [
+    "corpus_memory_friendly = MyCorpus()  # doesn't load the corpus into memory!\n",
+    "print(corpus_memory_friendly)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Corpus is now an object. We didn't define any way to print it, so `print` just outputs address\n",
+    "of the object in memory. Not very useful. To see the constituent vectors, let's\n",
+    "iterate over the corpus and print each document vector (one at a time):\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(0, 1), (1, 1), (2, 1)]\n",
+      "[(0, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1)]\n",
+      "[(2, 1), (5, 1), (7, 1), (8, 1)]\n",
+      "[(1, 1), (5, 2), (8, 1)]\n",
+      "[(3, 1), (6, 1), (7, 1)]\n",
+      "[(9, 1)]\n",
+      "[(9, 1), (10, 1)]\n",
+      "[(9, 1), (10, 1), (11, 1)]\n",
+      "[(4, 1), (10, 1), (11, 1)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for vector in corpus_memory_friendly:  # load one vector into memory at a time\n",
+    "    print(vector)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Although the output is the same as for the plain Python list, the corpus is now much\n",
+    "more memory friendly, because at most one vector resides in RAM at a time. Your\n",
+    "corpus can now be as large as you want.\n",
+    "\n",
+    "Similarly, to construct the dictionary without loading all texts into memory:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-07-06 17:46:33,867 : INFO : adding document #0 to Dictionary(0 unique tokens: [])\n",
+      "2020-07-06 17:46:33,869 : INFO : built Dictionary(42 unique tokens: ['abc', 'applications', 'computer', 'for', 'human']...) from 9 documents (total 69 corpus positions)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dictionary(12 unique tokens: ['computer', 'human', 'interface', 'response', 'survey']...)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from six import iteritems\n",
+    "# collect statistics about all tokens\n",
+    "dictionary = corpora.Dictionary(line.lower().split() for line in open('/tmp/mycorpus.txt'))\n",
+    "# remove stop words and words that appear only once\n",
+    "stop_ids = [\n",
+    "    dictionary.token2id[stopword]\n",
+    "    for stopword in stoplist\n",
+    "    if stopword in dictionary.token2id\n",
+    "]\n",
+    "once_ids = [tokenid for tokenid, docfreq in iteritems(dictionary.dfs) if docfreq == 1]\n",
+    "dictionary.filter_tokens(stop_ids + once_ids)  # remove stop words and words that appear only once\n",
+    "dictionary.compactify()  # remove gaps in id sequence after words that were removed\n",
+    "print(dictionary)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And that is all there is to it! At least as far as bag-of-words representation is concerned.\n",
+    "Of course, what we do with such a corpus is another question; it is not at all clear\n",
+    "how counting the frequency of distinct words could be useful. As it turns out, it isn't, and\n",
+    "we will need to apply a transformation on this simple representation first, before\n",
+    "we can use it to compute any meaningful document vs. document similarities.\n",
+    "Transformations are covered in the next tutorial\n",
+    "(`sphx_glr_auto_examples_core_run_topics_and_transformations.py`),\n",
+    "but before that, let's briefly turn our attention to *corpus persistency*.\n",
+    "\n",
+    "\n",
+    "Corpus Formats\n",
+    "---------------\n",
+    "\n",
+    "There exist several file formats for serializing a Vector Space corpus (~sequence of vectors) to disk.\n",
+    "`Gensim` implements them via the *streaming corpus interface* mentioned earlier:\n",
+    "documents are read from (resp. stored to) disk in a lazy fashion, one document at\n",
+    "a time, without the whole corpus being read into main memory at once.\n",
+    "\n",
+    "One of the more notable file formats is the `Market Matrix format <http://math.nist.gov/MatrixMarket/formats.html>`_.\n",
+    "To save a corpus in the Matrix Market format:\n",
+    "\n",
+    "create a toy corpus of 2 documents, as a plain Python list\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-07-06 17:46:38,624 : INFO : storing corpus in Matrix Market format to /tmp/corpus.mm\n",
+      "2020-07-06 17:46:38,626 : INFO : saving sparse matrix to /tmp/corpus.mm\n",
+      "2020-07-06 17:46:38,626 : INFO : PROGRESS: saving document #0\n",
+      "2020-07-06 17:46:38,627 : INFO : saved 2x2 matrix, density=25.000% (1/4)\n",
+      "2020-07-06 17:46:38,628 : INFO : saving MmCorpus index to /tmp/corpus.mm.index\n"
+     ]
+    }
+   ],
+   "source": [
+    "corpus = [[(1, 0.5)], []]  # make one document empty, for the heck of it\n",
+    "\n",
+    "corpora.MmCorpus.serialize('/tmp/corpus.mm', corpus)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Other formats include `Joachim's SVMlight format <http://svmlight.joachims.org/>`_,\n",
+    "`Blei's LDA-C format <http://www.cs.princeton.edu/~blei/lda-c/>`_ and\n",
+    "`GibbsLDA++ format <http://gibbslda.sourceforge.net/>`_.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-07-06 17:46:39,612 : INFO : converting corpus to SVMlight format: /tmp/corpus.svmlight\n",
+      "2020-07-06 17:46:39,614 : INFO : saving SvmLightCorpus index to /tmp/corpus.svmlight.index\n",
+      "2020-07-06 17:46:39,615 : INFO : no word id mapping provided; initializing from corpus\n",
+      "2020-07-06 17:46:39,615 : INFO : storing corpus in Blei's LDA-C format into /tmp/corpus.lda-c\n",
+      "2020-07-06 17:46:39,617 : INFO : saving vocabulary of 2 words to /tmp/corpus.lda-c.vocab\n",
+      "2020-07-06 17:46:39,618 : INFO : saving BleiCorpus index to /tmp/corpus.lda-c.index\n",
+      "2020-07-06 17:46:39,619 : INFO : no word id mapping provided; initializing from corpus\n",
+      "2020-07-06 17:46:39,620 : INFO : storing corpus in List-Of-Words format into /tmp/corpus.low\n",
+      "2020-07-06 17:46:39,621 : WARNING : List-of-words format can only save vectors with integer elements; 1 float entries were truncated to integer value\n",
+      "2020-07-06 17:46:39,622 : INFO : saving LowCorpus index to /tmp/corpus.low.index\n"
+     ]
+    }
+   ],
+   "source": [
+    "corpora.SvmLightCorpus.serialize('/tmp/corpus.svmlight', corpus)\n",
+    "corpora.BleiCorpus.serialize('/tmp/corpus.lda-c', corpus)\n",
+    "corpora.LowCorpus.serialize('/tmp/corpus.low', corpus)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Conversely, to load a corpus iterator from a Matrix Market file:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-07-06 17:46:40,761 : INFO : loaded corpus index from /tmp/corpus.mm.index\n",
+      "2020-07-06 17:46:40,762 : INFO : initializing cython corpus reader from /tmp/corpus.mm\n",
+      "2020-07-06 17:46:40,763 : INFO : accepted corpus with 2 documents, 2 features, 1 non-zero entries\n"
+     ]
+    }
+   ],
+   "source": [
+    "corpus = corpora.MmCorpus('/tmp/corpus.mm')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Corpus objects are streams, so typically you won't be able to print them directly:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MmCorpus(2 documents, 2 features, 1 non-zero entries)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(corpus)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instead, to view the contents of a corpus:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[(1, 0.5)], []]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# one way of printing a corpus: load it entirely into memory\n",
+    "print(list(corpus))  # calling list() will convert any sequence to a plain Python list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(1, 0.5)]\n",
+      "[]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# another way of doing it: print one document at a time, making use of the streaming interface\n",
+    "for doc in corpus:\n",
+    "    print(doc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The second way is obviously more memory-friendly, but for testing and development\n",
+    "purposes, nothing beats the simplicity of calling ``list(corpus)``.\n",
+    "\n",
+    "To save the same Matrix Market document stream in Blei's LDA-C format,\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-07-06 17:46:45,360 : INFO : no word id mapping provided; initializing from corpus\n",
+      "2020-07-06 17:46:45,362 : INFO : storing corpus in Blei's LDA-C format into /tmp/corpus.lda-c\n",
+      "2020-07-06 17:46:45,363 : INFO : saving vocabulary of 2 words to /tmp/corpus.lda-c.vocab\n",
+      "2020-07-06 17:46:45,364 : INFO : saving BleiCorpus index to /tmp/corpus.lda-c.index\n"
+     ]
+    }
+   ],
+   "source": [
+    "corpora.BleiCorpus.serialize('/tmp/corpus.lda-c', corpus)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this way, `gensim` can also be used as a memory-efficient **I/O format conversion tool**:\n",
+    "just load a document stream using one format and immediately save it in another format.\n",
+    "Adding new formats is dead easy, check out the `code for the SVMlight corpus\n",
+    "<https://github.com/piskvorky/gensim/blob/develop/gensim/corpora/svmlightcorpus.py>`_ for an example.\n",
+    "\n",
+    "Compatibility with NumPy and SciPy\n",
+    "----------------------------------\n",
+    "\n",
+    "Gensim also contains `efficient utility functions <http://radimrehurek.com/gensim/matutils.html>`_\n",
+    "to help converting from/to numpy matrices\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gensim\n",
+    "import numpy as np\n",
+    "numpy_matrix = np.random.randint(10, size=[5, 2])  # random matrix as an example\n",
+    "corpus = gensim.matutils.Dense2Corpus(numpy_matrix)\n",
+    "# numpy_matrix = gensim.matutils.corpus2dense(corpus, num_terms=number_of_corpus_features)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and from/to `scipy.sparse` matrices\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipy.sparse\n",
+    "scipy_sparse_matrix = scipy.sparse.random(5, 2)  # random sparse matrix as example\n",
+    "corpus = gensim.matutils.Sparse2Corpus(scipy_sparse_matrix)\n",
+    "scipy_csc_matrix = gensim.matutils.corpus2csc(corpus)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What Next\n",
+    "---------\n",
+    "\n",
+    "Read about `sphx_glr_auto_examples_core_run_topics_and_transformations.py`.\n",
+    "\n",
+    "References\n",
+    "----------\n",
+    "\n",
+    "For a complete reference (Want to prune the dictionary to a smaller size?\n",
+    "Optimize converting between corpora and NumPy/SciPy arrays?), see the `apiref`.\n",
+    "\n",
+    ".. [1] This is the same corpus as used in\n",
+    "       `Deerwester et al. (1990): Indexing by Latent Semantic Analysis <http://www.cs.bham.ac.uk/~pxt/IDA/lsa_ind.pdf>`_, Table 2.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we show a pretty fastText logo so that our gallery picks it up as a thumbnail.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: 'run_corpora_and_vector_spaces.png'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-37-1d77770397c2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mmatplotlib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpyplot\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mplt\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mmatplotlib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mimage\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mmpimg\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mimg\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmpimg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mimread\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'run_corpora_and_vector_spaces.png'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mimgplot\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mplt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mimshow\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mimg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mplt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0maxis\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'off'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/lib/python3.7/site-packages/matplotlib/image.py\u001b[0m in \u001b[0;36mimread\u001b[0;34m(fname, format)\u001b[0m\n\u001b[1;32m   1431\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mhandler\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfd\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1432\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1433\u001b[0;31m             \u001b[0;32mwith\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'rb'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mfd\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1434\u001b[0m                 \u001b[0;32mreturn\u001b[0m \u001b[0mhandler\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfd\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1435\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'run_corpora_and_vector_spaces.png'"
+     ]
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.image as mpimg\n",
+    "img = mpimg.imread('run_corpora_and_vector_spaces.png')\n",
+    "imgplot = plt.imshow(img)\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/docs/src/auto_examples/core/run_corpora_and_vector_spaces.ipynb
+++ b/docs/src/auto_examples/core/run_corpora_and_vector_spaces.ipynb
@@ -1,838 +1,439 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%matplotlib inline"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "Corpora and Vector Spaces\n",
-    "=========================\n",
-    "\n",
-    "Demonstrates transforming text into a vector space representation.\n",
-    "\n",
-    "Also introduces corpus streaming and persistence to disk in various formats.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import logging\n",
-    "logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "First, let’s create a small corpus of nine short documents [1]_:\n",
-    "\n",
-    "\n",
-    "From Strings to Vectors\n",
-    "------------------------\n",
-    "\n",
-    "This time, let's start from documents represented as strings:\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "documents = [\n",
-    "    \"Human machine interface for lab abc computer applications\",\n",
-    "    \"A survey of user opinion of computer system response time\",\n",
-    "    \"The EPS user interface management system\",\n",
-    "    \"System and human system engineering testing of EPS\",\n",
-    "    \"Relation of user perceived response time to error measurement\",\n",
-    "    \"The generation of random binary unordered trees\",\n",
-    "    \"The intersection graph of paths in trees\",\n",
-    "    \"Graph minors IV Widths of trees and well quasi ordering\",\n",
-    "    \"Graph minors A survey\",\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This is a tiny corpus of nine documents, each consisting of only a single sentence.\n",
-    "\n",
-    "First, let's tokenize the documents, remove common words (using a toy stoplist)\n",
-    "as well as words that only appear once in the corpus:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[['human', 'interface', 'computer'],\n",
-      " ['survey', 'user', 'computer', 'system', 'response', 'time'],\n",
-      " ['eps', 'user', 'interface', 'system'],\n",
-      " ['system', 'human', 'system', 'eps'],\n",
-      " ['user', 'response', 'time'],\n",
-      " ['trees'],\n",
-      " ['graph', 'trees'],\n",
-      " ['graph', 'minors', 'trees'],\n",
-      " ['graph', 'minors', 'survey']]\n"
-     ]
-    }
-   ],
-   "source": [
-    "from pprint import pprint  # pretty-printer\n",
-    "from collections import defaultdict\n",
-    "\n",
-    "# remove common words and tokenize\n",
-    "stoplist = set('for a of the and to in'.split())\n",
-    "texts = [\n",
-    "    [word for word in document.lower().split() if word not in stoplist]\n",
-    "    for document in documents\n",
-    "]\n",
-    "\n",
-    "# remove words that appear only once\n",
-    "frequency = defaultdict(int)\n",
-    "for text in texts:\n",
-    "    for token in text:\n",
-    "        frequency[token] += 1\n",
-    "\n",
-    "texts = [\n",
-    "    [token for token in text if frequency[token] > 1]\n",
-    "    for text in texts\n",
-    "]\n",
-    "\n",
-    "pprint(texts)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Your way of processing the documents will likely vary; here, I only split on whitespace\n",
-    "to tokenize, followed by lowercasing each word. In fact, I use this particular\n",
-    "(simplistic and inefficient) setup to mimic the experiment done in Deerwester et al.'s\n",
-    "original LSA article [1]_.\n",
-    "\n",
-    "The ways to process documents are so varied and application- and language-dependent that I\n",
-    "decided to *not* constrain them by any interface. Instead, a document is represented\n",
-    "by the features extracted from it, not by its \"surface\" string form: how you get to\n",
-    "the features is up to you. Below I describe one common, general-purpose approach (called\n",
-    ":dfn:`bag-of-words`), but keep in mind that different application domains call for\n",
-    "different features, and, as always, it's `garbage in, garbage out <http://en.wikipedia.org/wiki/Garbage_In,_Garbage_Out>`_...\n",
-    "\n",
-    "To convert documents to vectors, we'll use a document representation called\n",
-    "`bag-of-words <http://en.wikipedia.org/wiki/Bag_of_words>`_. In this representation,\n",
-    "each document is represented by one vector where each vector element represents\n",
-    "a question-answer pair, in the style of:\n",
-    "\n",
-    "- Question: How many times does the word `system` appear in the document?\n",
-    "- Answer: Once.\n",
-    "\n",
-    "It is advantageous to represent the questions only by their (integer) ids. The mapping\n",
-    "between the questions and ids is called a dictionary:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2020-07-06 17:45:48,927 : INFO : adding document #0 to Dictionary(0 unique tokens: [])\n",
-      "2020-07-06 17:45:48,928 : INFO : built Dictionary(12 unique tokens: ['computer', 'human', 'interface', 'response', 'survey']...) from 9 documents (total 29 corpus positions)\n",
-      "2020-07-06 17:45:48,929 : INFO : saving Dictionary object under /tmp/deerwester.dict, separately None\n",
-      "2020-07-06 17:45:48,930 : INFO : saved /tmp/deerwester.dict\n"
-     ]
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "%matplotlib inline"
+      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dictionary(12 unique tokens: ['computer', 'human', 'interface', 'response', 'survey']...)\n"
-     ]
-    }
-   ],
-   "source": [
-    "from gensim import corpora\n",
-    "dictionary = corpora.Dictionary(texts)\n",
-    "dictionary.save('/tmp/deerwester.dict')  # store the dictionary, for future reference\n",
-    "print(dictionary)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here we assigned a unique integer id to all words appearing in the corpus with the\n",
-    ":class:`gensim.corpora.dictionary.Dictionary` class. This sweeps across the texts, collecting word counts\n",
-    "and relevant statistics. In the end, we see there are twelve distinct words in the\n",
-    "processed corpus, which means each document will be represented by twelve numbers (ie., by a 12-D vector).\n",
-    "To see the mapping between words and their ids:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'computer': 0, 'human': 1, 'interface': 2, 'response': 3, 'survey': 4, 'system': 5, 'time': 6, 'user': 7, 'eps': 8, 'trees': 9, 'graph': 10, 'minors': 11}\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(dictionary.token2id)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To actually convert tokenized documents to vectors:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[(0, 1), (1, 1)]\n"
-     ]
-    }
-   ],
-   "source": [
-    "new_doc = \"Human computer interaction\"\n",
-    "new_vec = dictionary.doc2bow(new_doc.lower().split())\n",
-    "print(new_vec)  # the word \"interaction\" does not appear in the dictionary and is ignored"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The function :func:`doc2bow` simply counts the number of occurrences of\n",
-    "each distinct word, converts the word to its integer word id\n",
-    "and returns the result as a sparse vector. The sparse vector ``[(0, 1), (1, 1)]``\n",
-    "therefore reads: in the document `\"Human computer interaction\"`, the words `computer`\n",
-    "(id 0) and `human` (id 1) appear once; the other ten dictionary words appear (implicitly) zero times.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2020-07-06 17:45:53,635 : INFO : storing corpus in Matrix Market format to /tmp/deerwester.mm\n",
-      "2020-07-06 17:45:53,636 : INFO : saving sparse matrix to /tmp/deerwester.mm\n",
-      "2020-07-06 17:45:53,637 : INFO : PROGRESS: saving document #0\n",
-      "2020-07-06 17:45:53,638 : INFO : saved 9x12 matrix, density=25.926% (28/108)\n",
-      "2020-07-06 17:45:53,639 : INFO : saving MmCorpus index to /tmp/deerwester.mm.index\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\nCorpora and Vector Spaces\n=========================\n\nDemonstrates transforming text into a vector space representation.\n\nAlso introduces corpus streaming and persistence to disk in various formats.\n"
+      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[(0, 1), (1, 1), (2, 1)], [(0, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1)], [(2, 1), (5, 1), (7, 1), (8, 1)], [(1, 1), (5, 2), (8, 1)], [(3, 1), (6, 1), (7, 1)], [(9, 1)], [(9, 1), (10, 1)], [(9, 1), (10, 1), (11, 1)], [(4, 1), (10, 1), (11, 1)]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "corpus = [dictionary.doc2bow(text) for text in texts]\n",
-    "corpora.MmCorpus.serialize('/tmp/deerwester.mm', corpus)  # store to disk, for later use\n",
-    "print(corpus)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "By now it should be clear that the vector feature with ``id=10`` stands for the question \"How many\n",
-    "times does the word `graph` appear in the document?\" and that the answer is \"zero\" for\n",
-    "the first six documents and \"one\" for the remaining three.\n",
-    "\n",
-    "\n",
-    "Corpus Streaming -- One Document at a Time\n",
-    "-------------------------------------------\n",
-    "\n",
-    "Note that `corpus` above resides fully in memory, as a plain Python list.\n",
-    "In this simple example, it doesn't matter much, but just to make things clear,\n",
-    "let's assume there are millions of documents in the corpus. Storing all of them in RAM won't do.\n",
-    "Instead, let's assume the documents are stored in a file on disk, one document per line. Gensim\n",
-    "only requires that a corpus must be able to return one document vector at a time:\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "## Create Sample Document to Read From - We can assume it is stored on disk ## \n",
-    "with open('/tmp/mycorpus.txt', 'w') as the_file:\n",
-    "    the_file.write(\n",
-    "        \"\"\"Human machine interface for lab abc computer applications\n",
-    "A survey of user opinion of computer system response time\n",
-    "The EPS user interface management system\n",
-    "System and human system engineering testing of EPS\n",
-    "Relation of user perceived response time to error measurement\n",
-    "The generation of random binary unordered trees\n",
-    "The intersection graph of paths in trees\n",
-    "Graph minors IV Widths of trees and well quasi ordering\n",
-    "Graph minors A survey\"\"\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from smart_open import open  # for transparently opening remote files\n",
-    "\n",
-    "class MyCorpus(object):\n",
-    "    def __iter__(self):\n",
-    "        for line in open('/tmp/mycorpus.txt'):\n",
-    "            # assume there's one document per line, tokens separated by whitespace\n",
-    "            yield dictionary.doc2bow(line.lower().split())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The full power of Gensim comes from the fact that a corpus doesn't have to be\n",
-    "a ``list``, or a ``NumPy`` array, or a ``Pandas`` dataframe, or whatever.\n",
-    "Gensim *accepts any object that, when iterated over, successively yields\n",
-    "documents*.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# This flexibility allows you to create your own corpus classes that stream the\n",
-    "# documents directly from disk, network, database, dataframes... The models\n",
-    "# in Gensim are implemented such that they don't require all vectors to reside\n",
-    "# in RAM at once. You can even create the documents on the fly!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The assumption that each document occupies one line in a single file is not important; you can mold\n",
-    "the `__iter__` function to fit your input format, whatever it is.\n",
-    "Walking directories, parsing XML, accessing the network...\n",
-    "Just parse your input to retrieve a clean list of tokens in each document,\n",
-    "then convert the tokens via a dictionary to their ids and yield the resulting sparse vector inside `__iter__`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<__main__.MyCorpus object at 0x1a17fbb190>\n"
-     ]
-    }
-   ],
-   "source": [
-    "corpus_memory_friendly = MyCorpus()  # doesn't load the corpus into memory!\n",
-    "print(corpus_memory_friendly)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Corpus is now an object. We didn't define any way to print it, so `print` just outputs address\n",
-    "of the object in memory. Not very useful. To see the constituent vectors, let's\n",
-    "iterate over the corpus and print each document vector (one at a time):\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[(0, 1), (1, 1), (2, 1)]\n",
-      "[(0, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1)]\n",
-      "[(2, 1), (5, 1), (7, 1), (8, 1)]\n",
-      "[(1, 1), (5, 2), (8, 1)]\n",
-      "[(3, 1), (6, 1), (7, 1)]\n",
-      "[(9, 1)]\n",
-      "[(9, 1), (10, 1)]\n",
-      "[(9, 1), (10, 1), (11, 1)]\n",
-      "[(4, 1), (10, 1), (11, 1)]\n"
-     ]
-    }
-   ],
-   "source": [
-    "for vector in corpus_memory_friendly:  # load one vector into memory at a time\n",
-    "    print(vector)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Although the output is the same as for the plain Python list, the corpus is now much\n",
-    "more memory friendly, because at most one vector resides in RAM at a time. Your\n",
-    "corpus can now be as large as you want.\n",
-    "\n",
-    "Similarly, to construct the dictionary without loading all texts into memory:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2020-07-06 17:46:33,867 : INFO : adding document #0 to Dictionary(0 unique tokens: [])\n",
-      "2020-07-06 17:46:33,869 : INFO : built Dictionary(42 unique tokens: ['abc', 'applications', 'computer', 'for', 'human']...) from 9 documents (total 69 corpus positions)\n"
-     ]
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "import logging\nlogging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)"
+      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dictionary(12 unique tokens: ['computer', 'human', 'interface', 'response', 'survey']...)\n"
-     ]
-    }
-   ],
-   "source": [
-    "from six import iteritems\n",
-    "# collect statistics about all tokens\n",
-    "dictionary = corpora.Dictionary(line.lower().split() for line in open('/tmp/mycorpus.txt'))\n",
-    "# remove stop words and words that appear only once\n",
-    "stop_ids = [\n",
-    "    dictionary.token2id[stopword]\n",
-    "    for stopword in stoplist\n",
-    "    if stopword in dictionary.token2id\n",
-    "]\n",
-    "once_ids = [tokenid for tokenid, docfreq in iteritems(dictionary.dfs) if docfreq == 1]\n",
-    "dictionary.filter_tokens(stop_ids + once_ids)  # remove stop words and words that appear only once\n",
-    "dictionary.compactify()  # remove gaps in id sequence after words that were removed\n",
-    "print(dictionary)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And that is all there is to it! At least as far as bag-of-words representation is concerned.\n",
-    "Of course, what we do with such a corpus is another question; it is not at all clear\n",
-    "how counting the frequency of distinct words could be useful. As it turns out, it isn't, and\n",
-    "we will need to apply a transformation on this simple representation first, before\n",
-    "we can use it to compute any meaningful document vs. document similarities.\n",
-    "Transformations are covered in the next tutorial\n",
-    "(`sphx_glr_auto_examples_core_run_topics_and_transformations.py`),\n",
-    "but before that, let's briefly turn our attention to *corpus persistency*.\n",
-    "\n",
-    "\n",
-    "Corpus Formats\n",
-    "---------------\n",
-    "\n",
-    "There exist several file formats for serializing a Vector Space corpus (~sequence of vectors) to disk.\n",
-    "`Gensim` implements them via the *streaming corpus interface* mentioned earlier:\n",
-    "documents are read from (resp. stored to) disk in a lazy fashion, one document at\n",
-    "a time, without the whole corpus being read into main memory at once.\n",
-    "\n",
-    "One of the more notable file formats is the `Market Matrix format <http://math.nist.gov/MatrixMarket/formats.html>`_.\n",
-    "To save a corpus in the Matrix Market format:\n",
-    "\n",
-    "create a toy corpus of 2 documents, as a plain Python list\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "First, let\u2019s create a small corpus of nine short documents [1]_:\n\n\nFrom Strings to Vectors\n------------------------\n\nThis time, let's start from documents represented as strings:\n\n\n"
+      ]
+    },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2020-07-06 17:46:38,624 : INFO : storing corpus in Matrix Market format to /tmp/corpus.mm\n",
-      "2020-07-06 17:46:38,626 : INFO : saving sparse matrix to /tmp/corpus.mm\n",
-      "2020-07-06 17:46:38,626 : INFO : PROGRESS: saving document #0\n",
-      "2020-07-06 17:46:38,627 : INFO : saved 2x2 matrix, density=25.000% (1/4)\n",
-      "2020-07-06 17:46:38,628 : INFO : saving MmCorpus index to /tmp/corpus.mm.index\n"
-     ]
-    }
-   ],
-   "source": [
-    "corpus = [[(1, 0.5)], []]  # make one document empty, for the heck of it\n",
-    "\n",
-    "corpora.MmCorpus.serialize('/tmp/corpus.mm', corpus)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Other formats include `Joachim's SVMlight format <http://svmlight.joachims.org/>`_,\n",
-    "`Blei's LDA-C format <http://www.cs.princeton.edu/~blei/lda-c/>`_ and\n",
-    "`GibbsLDA++ format <http://gibbslda.sourceforge.net/>`_.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "documents = [\n    \"Human machine interface for lab abc computer applications\",\n    \"A survey of user opinion of computer system response time\",\n    \"The EPS user interface management system\",\n    \"System and human system engineering testing of EPS\",\n    \"Relation of user perceived response time to error measurement\",\n    \"The generation of random binary unordered trees\",\n    \"The intersection graph of paths in trees\",\n    \"Graph minors IV Widths of trees and well quasi ordering\",\n    \"Graph minors A survey\",\n]"
+      ]
+    },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2020-07-06 17:46:39,612 : INFO : converting corpus to SVMlight format: /tmp/corpus.svmlight\n",
-      "2020-07-06 17:46:39,614 : INFO : saving SvmLightCorpus index to /tmp/corpus.svmlight.index\n",
-      "2020-07-06 17:46:39,615 : INFO : no word id mapping provided; initializing from corpus\n",
-      "2020-07-06 17:46:39,615 : INFO : storing corpus in Blei's LDA-C format into /tmp/corpus.lda-c\n",
-      "2020-07-06 17:46:39,617 : INFO : saving vocabulary of 2 words to /tmp/corpus.lda-c.vocab\n",
-      "2020-07-06 17:46:39,618 : INFO : saving BleiCorpus index to /tmp/corpus.lda-c.index\n",
-      "2020-07-06 17:46:39,619 : INFO : no word id mapping provided; initializing from corpus\n",
-      "2020-07-06 17:46:39,620 : INFO : storing corpus in List-Of-Words format into /tmp/corpus.low\n",
-      "2020-07-06 17:46:39,621 : WARNING : List-of-words format can only save vectors with integer elements; 1 float entries were truncated to integer value\n",
-      "2020-07-06 17:46:39,622 : INFO : saving LowCorpus index to /tmp/corpus.low.index\n"
-     ]
-    }
-   ],
-   "source": [
-    "corpora.SvmLightCorpus.serialize('/tmp/corpus.svmlight', corpus)\n",
-    "corpora.BleiCorpus.serialize('/tmp/corpus.lda-c', corpus)\n",
-    "corpora.LowCorpus.serialize('/tmp/corpus.low', corpus)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Conversely, to load a corpus iterator from a Matrix Market file:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "This is a tiny corpus of nine documents, each consisting of only a single sentence.\n\nFirst, let's tokenize the documents, remove common words (using a toy stoplist)\nas well as words that only appear once in the corpus:\n\n"
+      ]
+    },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2020-07-06 17:46:40,761 : INFO : loaded corpus index from /tmp/corpus.mm.index\n",
-      "2020-07-06 17:46:40,762 : INFO : initializing cython corpus reader from /tmp/corpus.mm\n",
-      "2020-07-06 17:46:40,763 : INFO : accepted corpus with 2 documents, 2 features, 1 non-zero entries\n"
-     ]
-    }
-   ],
-   "source": [
-    "corpus = corpora.MmCorpus('/tmp/corpus.mm')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Corpus objects are streams, so typically you won't be able to print them directly:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "from pprint import pprint  # pretty-printer\nfrom collections import defaultdict\n\n# remove common words and tokenize\nstoplist = set('for a of the and to in'.split())\ntexts = [\n    [word for word in document.lower().split() if word not in stoplist]\n    for document in documents\n]\n\n# remove words that appear only once\nfrequency = defaultdict(int)\nfor text in texts:\n    for token in text:\n        frequency[token] += 1\n\ntexts = [\n    [token for token in text if frequency[token] > 1]\n    for text in texts\n]\n\npprint(texts)"
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MmCorpus(2 documents, 2 features, 1 non-zero entries)\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(corpus)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Instead, to view the contents of a corpus:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Your way of processing the documents will likely vary; here, I only split on whitespace\nto tokenize, followed by lowercasing each word. In fact, I use this particular\n(simplistic and inefficient) setup to mimic the experiment done in Deerwester et al.'s\noriginal LSA article [1]_.\n\nThe ways to process documents are so varied and application- and language-dependent that I\ndecided to *not* constrain them by any interface. Instead, a document is represented\nby the features extracted from it, not by its \"surface\" string form: how you get to\nthe features is up to you. Below I describe one common, general-purpose approach (called\n:dfn:`bag-of-words`), but keep in mind that different application domains call for\ndifferent features, and, as always, it's `garbage in, garbage out <http://en.wikipedia.org/wiki/Garbage_In,_Garbage_Out>`_...\n\nTo convert documents to vectors, we'll use a document representation called\n`bag-of-words <http://en.wikipedia.org/wiki/Bag_of_words>`_. In this representation,\neach document is represented by one vector where each vector element represents\na question-answer pair, in the style of:\n\n- Question: How many times does the word `system` appear in the document?\n- Answer: Once.\n\nIt is advantageous to represent the questions only by their (integer) ids. The mapping\nbetween the questions and ids is called a dictionary:\n\n"
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[(1, 0.5)], []]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# one way of printing a corpus: load it entirely into memory\n",
-    "print(list(corpus))  # calling list() will convert any sequence to a plain Python list"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "or\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "from gensim import corpora\ndictionary = corpora.Dictionary(texts)\ndictionary.save('/tmp/deerwester.dict')  # store the dictionary, for future reference\nprint(dictionary)"
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[(1, 0.5)]\n",
-      "[]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# another way of doing it: print one document at a time, making use of the streaming interface\n",
-    "for doc in corpus:\n",
-    "    print(doc)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The second way is obviously more memory-friendly, but for testing and development\n",
-    "purposes, nothing beats the simplicity of calling ``list(corpus)``.\n",
-    "\n",
-    "To save the same Matrix Market document stream in Blei's LDA-C format,\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Here we assigned a unique integer id to all words appearing in the corpus with the\n:class:`gensim.corpora.dictionary.Dictionary` class. This sweeps across the texts, collecting word counts\nand relevant statistics. In the end, we see there are twelve distinct words in the\nprocessed corpus, which means each document will be represented by twelve numbers (ie., by a 12-D vector).\nTo see the mapping between words and their ids:\n\n"
+      ]
+    },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2020-07-06 17:46:45,360 : INFO : no word id mapping provided; initializing from corpus\n",
-      "2020-07-06 17:46:45,362 : INFO : storing corpus in Blei's LDA-C format into /tmp/corpus.lda-c\n",
-      "2020-07-06 17:46:45,363 : INFO : saving vocabulary of 2 words to /tmp/corpus.lda-c.vocab\n",
-      "2020-07-06 17:46:45,364 : INFO : saving BleiCorpus index to /tmp/corpus.lda-c.index\n"
-     ]
-    }
-   ],
-   "source": [
-    "corpora.BleiCorpus.serialize('/tmp/corpus.lda-c', corpus)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In this way, `gensim` can also be used as a memory-efficient **I/O format conversion tool**:\n",
-    "just load a document stream using one format and immediately save it in another format.\n",
-    "Adding new formats is dead easy, check out the `code for the SVMlight corpus\n",
-    "<https://github.com/piskvorky/gensim/blob/develop/gensim/corpora/svmlightcorpus.py>`_ for an example.\n",
-    "\n",
-    "Compatibility with NumPy and SciPy\n",
-    "----------------------------------\n",
-    "\n",
-    "Gensim also contains `efficient utility functions <http://radimrehurek.com/gensim/matutils.html>`_\n",
-    "to help converting from/to numpy matrices\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import gensim\n",
-    "import numpy as np\n",
-    "numpy_matrix = np.random.randint(10, size=[5, 2])  # random matrix as an example\n",
-    "corpus = gensim.matutils.Dense2Corpus(numpy_matrix)\n",
-    "# numpy_matrix = gensim.matutils.corpus2dense(corpus, num_terms=number_of_corpus_features)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "and from/to `scipy.sparse` matrices\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import scipy.sparse\n",
-    "scipy_sparse_matrix = scipy.sparse.random(5, 2)  # random sparse matrix as example\n",
-    "corpus = gensim.matutils.Sparse2Corpus(scipy_sparse_matrix)\n",
-    "scipy_csc_matrix = gensim.matutils.corpus2csc(corpus)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "What Next\n",
-    "---------\n",
-    "\n",
-    "Read about `sphx_glr_auto_examples_core_run_topics_and_transformations.py`.\n",
-    "\n",
-    "References\n",
-    "----------\n",
-    "\n",
-    "For a complete reference (Want to prune the dictionary to a smaller size?\n",
-    "Optimize converting between corpora and NumPy/SciPy arrays?), see the `apiref`.\n",
-    "\n",
-    ".. [1] This is the same corpus as used in\n",
-    "       `Deerwester et al. (1990): Indexing by Latent Semantic Analysis <http://www.cs.bham.ac.uk/~pxt/IDA/lsa_ind.pdf>`_, Table 2.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here we show a pretty fastText logo so that our gallery picks it up as a thumbnail.\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "print(dictionary.token2id)"
+      ]
+    },
     {
-     "ename": "FileNotFoundError",
-     "evalue": "[Errno 2] No such file or directory: 'run_corpora_and_vector_spaces.png'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-37-1d77770397c2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mmatplotlib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpyplot\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mplt\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mmatplotlib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mimage\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mmpimg\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mimg\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmpimg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mimread\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'run_corpora_and_vector_spaces.png'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mimgplot\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mplt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mimshow\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mimg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mplt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0maxis\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'off'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/opt/anaconda3/lib/python3.7/site-packages/matplotlib/image.py\u001b[0m in \u001b[0;36mimread\u001b[0;34m(fname, format)\u001b[0m\n\u001b[1;32m   1431\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mhandler\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfd\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1432\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1433\u001b[0;31m             \u001b[0;32mwith\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'rb'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mfd\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1434\u001b[0m                 \u001b[0;32mreturn\u001b[0m \u001b[0mhandler\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfd\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1435\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'run_corpora_and_vector_spaces.png'"
-     ]
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "To actually convert tokenized documents to vectors:\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "new_doc = \"Human computer interaction\"\nnew_vec = dictionary.doc2bow(new_doc.lower().split())\nprint(new_vec)  # the word \"interaction\" does not appear in the dictionary and is ignored"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The function :func:`doc2bow` simply counts the number of occurrences of\neach distinct word, converts the word to its integer word id\nand returns the result as a sparse vector. The sparse vector ``[(0, 1), (1, 1)]``\ntherefore reads: in the document `\"Human computer interaction\"`, the words `computer`\n(id 0) and `human` (id 1) appear once; the other ten dictionary words appear (implicitly) zero times.\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "corpus = [dictionary.doc2bow(text) for text in texts]\ncorpora.MmCorpus.serialize('/tmp/deerwester.mm', corpus)  # store to disk, for later use\nprint(corpus)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "By now it should be clear that the vector feature with ``id=10`` stands for the question \"How many\ntimes does the word `graph` appear in the document?\" and that the answer is \"zero\" for\nthe first six documents and \"one\" for the remaining three.\n\n\nCorpus Streaming -- One Document at a Time\n-------------------------------------------\n\nNote that `corpus` above resides fully in memory, as a plain Python list.\nIn this simple example, it doesn't matter much, but just to make things clear,\nlet's assume there are millions of documents in the corpus. Storing all of them in RAM won't do.\nInstead, let's assume the documents are stored in a file on disk, one document per line. Gensim\nonly requires that a corpus must be able to return one document vector at a time:\n\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "from smart_open import open  # for transparently opening remote files\n\n\nclass MyCorpus(object):\n    def __iter__(self):\n        for line in open('https://radimrehurek.com/gensim/mycorpus.txt'):\n            # assume there's one document per line, tokens separated by whitespace\n            yield dictionary.doc2bow(line.lower().split())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The full power of Gensim comes from the fact that a corpus doesn't have to be\na ``list``, or a ``NumPy`` array, or a ``Pandas`` dataframe, or whatever.\nGensim *accepts any object that, when iterated over, successively yields\ndocuments*.\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "# This flexibility allows you to create your own corpus classes that stream the\n# documents directly from disk, network, database, dataframes... The models\n# in Gensim are implemented such that they don't require all vectors to reside\n# in RAM at once. You can even create the documents on the fly!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Download the sample `mycorpus.txt file here <./mycorpus.txt>`_. The assumption that\neach document occupies one line in a single file is not important; you can mold\nthe `__iter__` function to fit your input format, whatever it is.\nWalking directories, parsing XML, accessing the network...\nJust parse your input to retrieve a clean list of tokens in each document,\nthen convert the tokens via a dictionary to their ids and yield the resulting sparse vector inside `__iter__`.\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "corpus_memory_friendly = MyCorpus()  # doesn't load the corpus into memory!\nprint(corpus_memory_friendly)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Corpus is now an object. We didn't define any way to print it, so `print` just outputs address\nof the object in memory. Not very useful. To see the constituent vectors, let's\niterate over the corpus and print each document vector (one at a time):\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "for vector in corpus_memory_friendly:  # load one vector into memory at a time\n    print(vector)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Although the output is the same as for the plain Python list, the corpus is now much\nmore memory friendly, because at most one vector resides in RAM at a time. Your\ncorpus can now be as large as you want.\n\nSimilarly, to construct the dictionary without loading all texts into memory:\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "from six import iteritems\n# collect statistics about all tokens\ndictionary = corpora.Dictionary(line.lower().split() for line in open('https://radimrehurek.com/gensim/mycorpus.txt'))\n# remove stop words and words that appear only once\nstop_ids = [\n    dictionary.token2id[stopword]\n    for stopword in stoplist\n    if stopword in dictionary.token2id\n]\nonce_ids = [tokenid for tokenid, docfreq in iteritems(dictionary.dfs) if docfreq == 1]\ndictionary.filter_tokens(stop_ids + once_ids)  # remove stop words and words that appear only once\ndictionary.compactify()  # remove gaps in id sequence after words that were removed\nprint(dictionary)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "And that is all there is to it! At least as far as bag-of-words representation is concerned.\nOf course, what we do with such a corpus is another question; it is not at all clear\nhow counting the frequency of distinct words could be useful. As it turns out, it isn't, and\nwe will need to apply a transformation on this simple representation first, before\nwe can use it to compute any meaningful document vs. document similarities.\nTransformations are covered in the next tutorial\n(`sphx_glr_auto_examples_core_run_topics_and_transformations.py`),\nbut before that, let's briefly turn our attention to *corpus persistency*.\n\n\nCorpus Formats\n---------------\n\nThere exist several file formats for serializing a Vector Space corpus (~sequence of vectors) to disk.\n`Gensim` implements them via the *streaming corpus interface* mentioned earlier:\ndocuments are read from (resp. stored to) disk in a lazy fashion, one document at\na time, without the whole corpus being read into main memory at once.\n\nOne of the more notable file formats is the `Market Matrix format <http://math.nist.gov/MatrixMarket/formats.html>`_.\nTo save a corpus in the Matrix Market format:\n\ncreate a toy corpus of 2 documents, as a plain Python list\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "corpus = [[(1, 0.5)], []]  # make one document empty, for the heck of it\n\ncorpora.MmCorpus.serialize('/tmp/corpus.mm', corpus)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Other formats include `Joachim's SVMlight format <http://svmlight.joachims.org/>`_,\n`Blei's LDA-C format <http://www.cs.princeton.edu/~blei/lda-c/>`_ and\n`GibbsLDA++ format <http://gibbslda.sourceforge.net/>`_.\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "corpora.SvmLightCorpus.serialize('/tmp/corpus.svmlight', corpus)\ncorpora.BleiCorpus.serialize('/tmp/corpus.lda-c', corpus)\ncorpora.LowCorpus.serialize('/tmp/corpus.low', corpus)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Conversely, to load a corpus iterator from a Matrix Market file:\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "corpus = corpora.MmCorpus('/tmp/corpus.mm')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Corpus objects are streams, so typically you won't be able to print them directly:\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "print(corpus)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Instead, to view the contents of a corpus:\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "# one way of printing a corpus: load it entirely into memory\nprint(list(corpus))  # calling list() will convert any sequence to a plain Python list"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "or\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "# another way of doing it: print one document at a time, making use of the streaming interface\nfor doc in corpus:\n    print(doc)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The second way is obviously more memory-friendly, but for testing and development\npurposes, nothing beats the simplicity of calling ``list(corpus)``.\n\nTo save the same Matrix Market document stream in Blei's LDA-C format,\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "corpora.BleiCorpus.serialize('/tmp/corpus.lda-c', corpus)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "In this way, `gensim` can also be used as a memory-efficient **I/O format conversion tool**:\njust load a document stream using one format and immediately save it in another format.\nAdding new formats is dead easy, check out the `code for the SVMlight corpus\n<https://github.com/piskvorky/gensim/blob/develop/gensim/corpora/svmlightcorpus.py>`_ for an example.\n\nCompatibility with NumPy and SciPy\n----------------------------------\n\nGensim also contains `efficient utility functions <http://radimrehurek.com/gensim/matutils.html>`_\nto help converting from/to numpy matrices\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "import gensim\nimport numpy as np\nnumpy_matrix = np.random.randint(10, size=[5, 2])  # random matrix as an example\ncorpus = gensim.matutils.Dense2Corpus(numpy_matrix)\n# numpy_matrix = gensim.matutils.corpus2dense(corpus, num_terms=number_of_corpus_features)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "and from/to `scipy.sparse` matrices\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "import scipy.sparse\nscipy_sparse_matrix = scipy.sparse.random(5, 2)  # random sparse matrix as example\ncorpus = gensim.matutils.Sparse2Corpus(scipy_sparse_matrix)\nscipy_csc_matrix = gensim.matutils.corpus2csc(corpus)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "What Next\n---------\n\nRead about `sphx_glr_auto_examples_core_run_topics_and_transformations.py`.\n\nReferences\n----------\n\nFor a complete reference (Want to prune the dictionary to a smaller size?\nOptimize converting between corpora and NumPy/SciPy arrays?), see the `apiref`.\n\n.. [1] This is the same corpus as used in\n       `Deerwester et al. (1990): Indexing by Latent Semantic Analysis <http://www.cs.bham.ac.uk/~pxt/IDA/lsa_ind.pdf>`_, Table 2.\n\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Here we show a pretty fastText logo so that our gallery picks it up as a thumbnail.\n\n\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false
+      },
+      "outputs": [],
+      "source": [
+        "import matplotlib.pyplot as plt\nimport matplotlib.image as mpimg\nimg = mpimg.imread('run_corpora_and_vector_spaces.png')\nimgplot = plt.imshow(img)\nplt.axis('off')\nplt.show()"
+      ]
     }
-   ],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import matplotlib.image as mpimg\n",
-    "img = mpimg.imread('run_corpora_and_vector_spaces.png')\n",
-    "imgplot = plt.imshow(img)\n",
-    "plt.axis('off')\n",
-    "plt.show()"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.1"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/docs/src/gallery/core/run_corpora_and_vector_spaces.py
+++ b/docs/src/gallery/core/run_corpora_and_vector_spaces.py
@@ -133,12 +133,24 @@ print(corpus)
 # Instead, let's assume the documents are stored in a file on disk, one document per line. Gensim
 # only requires that a corpus must be able to return one document vector at a time:
 #
-from smart_open import open  # for transparently opening remote files
+## Create Sample Document to Read From - We can assume it is stored on disk ## 
+with open('/tmp/mycorpus.txt', 'w') as the_file:
+    the_file.write(
+        """Human machine interface for lab abc computer applications
+A survey of user opinion of computer system response time
+The EPS user interface management system
+System and human system engineering testing of EPS
+Relation of user perceived response time to error measurement
+The generation of random binary unordered trees
+The intersection graph of paths in trees
+Graph minors IV Widths of trees and well quasi ordering
+Graph minors A survey""")
 
+###############################################################################
 
 class MyCorpus(object):
     def __iter__(self):
-        for line in open('https://radimrehurek.com/gensim/mycorpus.txt'):
+        for line in open('/tmp/mycorpus.txt'):
             # assume there's one document per line, tokens separated by whitespace
             yield dictionary.doc2bow(line.lower().split())
 
@@ -181,7 +193,7 @@ for vector in corpus_memory_friendly:  # load one vector into memory at a time
 
 from six import iteritems
 # collect statistics about all tokens
-dictionary = corpora.Dictionary(line.lower().split() for line in open('https://radimrehurek.com/gensim/mycorpus.txt'))
+dictionary = corpora.Dictionary(line.lower().split() for line in open('/tmp/mycorpus.txt'))
 # remove stop words and words that appear only once
 stop_ids = [
     dictionary.token2id[stopword]


### PR DESCRIPTION
Fixes #2872 

Motivation: Old notebook was dependent on a URL for a text file. Wanted to make sure this was able to run locally. No has to download to run the notebook.

Fixes: Creates mycorpus.txt inline. Fixed an image reference at the end of the same notebook.