### PR TITLE
Update utils.py

### DIFF
--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -42,7 +42,7 @@ import scipy.sparse
 from six import iterkeys, iteritems, itervalues, u, string_types, unichr
 from six.moves import range
 
-from smart_open import open
+from smart_open import smart_open
 
 from multiprocessing import cpu_count
 


### PR DESCRIPTION
most recent version of smart_open does not have 'open' method. Instead it has 'smart_open'. Have changed in my utils file and am offering my change to the community.