### PR TITLE
Make docs clearer on `alpha` parameter in LDA model

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -538,7 +538,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
                 * an 1D array of length equal to the number of expected topics,
                 * 'symmetric': Uses a fixed symmetric prior per topic,
-                * 'asymmetric': Uses a fixed normalized asymmetric prior of `1.0 / (topic_index + sqrt(topic_no))`,
+                * 'asymmetric': Uses a fixed normalized asymmetric prior of `1.0 / (topic_index + sqrt(num_topics))`,
                 * 'auto': Learns an asymmetric prior from the corpus.
         name : {'alpha', 'eta'}
             Whether the `prior` is parameterized by the alpha vector (1 parameter per topic)

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -378,7 +378,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             Can be set to an 1D array of length equal to the number of expected topics that expresses
             our a-priori belief for the each topics' probability.
             Alternatively default prior selecting strategies can be employed by supplying a string:
-                
+
                 * 'symmetric': Default; uses a fixed symmetric prior per topic,
                 * 'asymmetric': Uses a fixed normalized asymmetric prior of `1.0 / (topic_index + sqrt(topic_no))`,
                 * 'auto': Learns an asymmetric prior from the corpus (not available if `distributed==True`).

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -380,7 +380,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             Alternatively default prior selecting strategies can be employed by supplying a string:
 
                 * 'symmetric': Default; uses a fixed symmetric prior per topic,
-                * 'asymmetric': Uses a fixed normalized asymmetric prior of `1.0 / (topic_index + sqrt(topic_no))`,
+                * 'asymmetric': Uses a fixed normalized asymmetric prior of `1.0 / (topic_index + sqrt(num_topics))`,
                 * 'auto': Learns an asymmetric prior from the corpus (not available if `distributed==True`).
         eta : {float, np.array, str}, optional
             A-priori belief on word probability, this can be:


### PR DESCRIPTION
### Summary
Modified docstring on `alpha` in LDA model around 'symmetric' and 'asymmetric' options

### Motivation
- When I first read the doc, I saw by default `alpha='symmetric'`, but in the docs, only 'asymmetric' and 'auto' are listed as acceptable strings, so my first instinct was it was a typo. To be clearer, especially to new users, I think we should spell out all possible options, including the default 'symmetric' in the doc
- The current 'asymmetric' description doesn't seem to fit the actual formula in the code