### PR TITLE
[MRG] Docs: Update Hoffman paper link for Online LDA

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -14,7 +14,7 @@ for online training.
 
 The core estimation code is based on the `onlineldavb.py script
 <https://github.com/blei-lab/onlineldavb/blob/master/onlineldavb.py>`_, by `Hoffman, Blei, Bach:
-Online Learning for Latent Dirichlet Allocation, NIPS 2010 <http://www.cs.princeton.edu/~mdhoffma>`_.
+Online Learning for Latent Dirichlet Allocation, NIPS 2010 <https://scholar.google.com/citations?hl=en&user=IeHKeGYAAAAJ&view_op=list_works>`_.
 
 The algorithm:
 

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -14,7 +14,8 @@ for online training.
 
 The core estimation code is based on the `onlineldavb.py script
 <https://github.com/blei-lab/onlineldavb/blob/master/onlineldavb.py>`_, by `Hoffman, Blei, Bach:
-Online Learning for Latent Dirichlet Allocation, NIPS 2010 <https://scholar.google.com/citations?hl=en&user=IeHKeGYAAAAJ&view_op=list_works>`_.
+Online Learning for Latent Dirichlet Allocation, NIPS 2010
+<https://scholar.google.com/citations?hl=en&user=IeHKeGYAAAAJ&view_op=list_works>`_.
 
 The algorithm:
 


### PR DESCRIPTION
The current link to Hoffman's paper is outdated and results in this page: 
![image](https://user-images.githubusercontent.com/10430241/88401293-73004080-cdc1-11ea-9f4e-bc550eca3bd6.png)

Updating to his papers page as per the link on his website.

If the actual paper's link is desired, it will be this link: http://papers.nips.cc/paper/3902-online-learning-for-latent-dirichlet-allocation.pdf