### PR TITLE
Fix AttributeError in WikiCorpus

### DIFF
--- a/gensim/corpora/wikicorpus.py
+++ b/gensim/corpora/wikicorpus.py
@@ -620,7 +620,7 @@ class WikiCorpus(TextCorpus):
         Unless a dictionary is provided, this scans the corpus once, to determine its vocabulary.
 
         """
-        self.input = fname
+        self.fname = fname
         self.filter_namespaces = filter_namespaces
         self.filter_articles = filter_articles
         self.metadata = False
@@ -638,6 +638,10 @@ class WikiCorpus(TextCorpus):
             self.dictionary = Dictionary(self.get_texts())
         else:
             self.dictionary = dictionary
+
+    @property
+    def input(self):
+        return self.fname
 
     def get_texts(self):
         """Iterate over the dump, yielding a list of tokens for each article that passed
@@ -677,7 +681,7 @@ class WikiCorpus(TextCorpus):
         texts = \
             ((text, self.lemmatize, title, pageid, tokenization_params)
              for title, text, pageid
-             in extract_pages(bz2.BZ2File(self.input), self.filter_namespaces, self.filter_articles))
+             in extract_pages(bz2.BZ2File(self.fname), self.filter_namespaces, self.filter_articles))
         pool = multiprocessing.Pool(self.processes, init_to_ignore_interrupt)
 
         try:

--- a/gensim/corpora/wikicorpus.py
+++ b/gensim/corpora/wikicorpus.py
@@ -620,7 +620,7 @@ class WikiCorpus(TextCorpus):
         Unless a dictionary is provided, this scans the corpus once, to determine its vocabulary.
 
         """
-        self.fname = fname
+        self.input = fname
         self.filter_namespaces = filter_namespaces
         self.filter_articles = filter_articles
         self.metadata = False
@@ -677,7 +677,7 @@ class WikiCorpus(TextCorpus):
         texts = \
             ((text, self.lemmatize, title, pageid, tokenization_params)
              for title, text, pageid
-             in extract_pages(bz2.BZ2File(self.fname), self.filter_namespaces, self.filter_articles))
+             in extract_pages(bz2.BZ2File(self.input), self.filter_namespaces, self.filter_articles))
         pool = multiprocessing.Pool(self.processes, init_to_ignore_interrupt)
 
         try:

--- a/gensim/test/test_corpora.py
+++ b/gensim/test/test_corpora.py
@@ -769,6 +769,11 @@ class TestWikiCorpus(TestTextCorpus):
             for word in table_markup:
                 self.assertTrue(word not in text)
 
+    def test_get_stream(self):
+        wiki = self.corpus_class(self.enwiki)
+        sample_text_wiki = next(wiki.getstream()).decode()[1:14]
+        self.assertEqual(sample_text_wiki, "mediawiki xml")
+
     # #TODO: sporadic failure to be investigated
     # def test_get_texts_returns_generator_of_lists(self):
     #     corpus = self.corpus_class(self.enwiki)


### PR DESCRIPTION
Fix for : #2744 

`WikiCorpus` subclasses `TextCorpus`.
Renaming the attribute `fname` of  `WikiCorpus` to `input` fixes the `AttributeError`: 'WikiCorpus' object has no attribute 'input'`