### PR TITLE
Apply <> for delimiting instance params in `str` function of Vocab class

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -209,7 +209,7 @@ class Vocab(object):
 
     def __str__(self):
         vals = ['%s:%r' % (key, self.__dict__[key]) for key in sorted(self.__dict__) if not key.startswith('_')]
-        return "%s(%s)" % (self.__class__.__name__, ', '.join(vals))
+        return "%s<%s>" % (self.__class__.__name__, ', '.join(vals))
 
 
 class BaseKeyedVectors(utils.SaveLoad):


### PR DESCRIPTION
Fixes #2890

Please ignore the name of the branch- I was working on another idea when I noticed the open issue above.

Replaced double quotes with <>. This fix does not change the behavior of the 'str' function within the Vocab class of keyedvectors.py. It is only intended to address the change in conventions for delimiting instance parameters.