### PR TITLE
Change num_words to topn in dtm_coherence

### DIFF
--- a/gensim/models/wrappers/dtmmodel.py
+++ b/gensim/models/wrappers/dtmmodel.py
@@ -604,7 +604,7 @@ class DtmModel(utils.SaveLoad):
         """
         coherence_topics = []
         for topic_no in range(0, self.num_topics):
-            topic = self.show_topic(topicid=topic_no, time=time, num_words=num_words)
+            topic = self.show_topic(topicid=topic_no, time=time, topn=num_words)
             coherence_topic = []
             for prob, word in topic:
                 coherence_topic.append(word)


### PR DESCRIPTION
Fixes #2925 

This is a very small change to make `dtm_coherence()` use `topn` instead of `num_words` when calling `show_topic()`. This then avoids triggering an error every time the function is used. 