### PR TITLE
Bump minimum Python version to 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This release contains a major refactoring.
   (__[menshikh-iv](https://github.com/menshikh-iv)__, [#6](https://github.com/RaRe-Technologies/gensim-wheels/pull/6))
 * Speed up random number generation in word2vec model (PR [#2864](https://github.com/RaRe-Technologies/gensim/pull/2864), __[@zygm0nt](https://github.com/zygm0nt)__)
 * Remove Keras dependency (PR [#2937](https://github.com/RaRe-Technologies/gensim/pull/2937), __[@piskvorky](https://github.com/piskvorky)__)
+* Bump minimum Python version to 3.6 (PR [#2947](https://github.com/RaRe-Technologies/gensim/pull/2947), __[@gojomo](https://github.com/gojomo)__)
 
 ### :books: Tutorial and doc improvements
 

--- a/docs/src/_templates/indexcontent.html
+++ b/docs/src/_templates/indexcontent.html
@@ -156,9 +156,9 @@
           <div class="section" id="code-dependencies">
             <h2>Code dependencies</h2>
             <p>Gensim runs on Linux, Windows and Mac OS X, and should run on any other
-            platform that supports Python 2.7 or 3.5+ and NumPy. Gensim depends on the following software:</p>
+            platform that supports Python 3.6+ and NumPy. Gensim depends on the following software:</p>
             <ul class="simple">
-              <li><a class="reference external" href="https://www.python.org">Python</a>, tested with versions 2.7, 3.5, 3.6 and 3.7.</li>
+              <li><a class="reference external" href="https://www.python.org">Python</a>, tested with versions 3.6, 3.7 and 3.8.</li>
               <li><a class="reference external" href="https://www.numpy.org">NumPy</a> for number crunching.</li>
               <li><a class="reference external" href="https://pypi.org/project/smart_open/">smart_open</a> for transparently opening files on remote storages or compressed files.</li>
             </ul>

--- a/setup.py
+++ b/setup.py
@@ -207,7 +207,7 @@ Or, if you have instead downloaded and unzipped the `source tar.gz <http://pypi.
 
 For alternative modes of installation, see the `documentation <http://radimrehurek.com/gensim/install.html>`_.
 
-Gensim is being `continuously tested <https://travis-ci.org/RaRe-Technologies/gensim>`_ under Python 3.5, 3.6, 3.7 and 3.8.
+Gensim is being `continuously tested <https://travis-ci.org/RaRe-Technologies/gensim>`_ under Python 3.6, 3.7 and 3.8.
 Support for Python 2.7 was dropped in gensim 4.0.0 – install gensim 3.8.3 if you must use Python 2.7.
 
 
@@ -375,7 +375,6 @@ setup(
         'Environment :: Console',
         'Intended Audience :: Science/Research',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -386,7 +385,7 @@ setup(
     ],
 
     test_suite="gensim.test",
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     setup_requires=setup_requires,
     install_requires=install_requires,
     tests_require=linux_testenv,


### PR DESCRIPTION
Brings `setup.py` up to sync with #2713 & #2715 changes.