### PR TITLE
Allow newer versions of the Morfessor module for the tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,7 @@ core_testenv = [
     'mock',
     'cython',
     'testfixtures',
-    'Morfessor==2.0.2a4',
+    'Morfessor>=2.0.2a4',
 ]
 
 if not (sys.platform.lower().startswith("win") and sys.version_info[:2] >= (3, 9)):


### PR DESCRIPTION
The tests that use Morfessor also pass with version 2.0.6,
which is the latest version at this time.

Please also cherry-pick this into the master branch.