### PR TITLE
Clarify random state in ldamulticore.py

### DIFF
--- a/gensim/models/ldamulticore.py
+++ b/gensim/models/ldamulticore.py
@@ -160,7 +160,8 @@ class LdaMulticore(LdaModel):
         minimum_probability : float, optional
             Topics with a probability lower than this threshold will be filtered out.
         random_state : {np.random.RandomState, int}, optional
-            Either a randomState object or a seed to generate one. Useful for reproducibility.
+            Either a randomState object or a seed to generate one. Useful for reproducibility. Note, that
+            results can vary slightly due to the nature of the multiprocessing queue.
         minimum_phi_value : float, optional
             if `per_word_topics` is True, this represents a lower bound on the term probabilities.
         per_word_topics : bool

--- a/gensim/models/ldamulticore.py
+++ b/gensim/models/ldamulticore.py
@@ -160,8 +160,8 @@ class LdaMulticore(LdaModel):
         minimum_probability : float, optional
             Topics with a probability lower than this threshold will be filtered out.
         random_state : {np.random.RandomState, int}, optional
-            Either a randomState object or a seed to generate one. Useful for reproducibility. Note, that
-            results can vary slightly due to the nature of the multiprocessing queue.
+            Either a randomState object or a seed to generate one. Useful for reproducibility. Note, that results can
+            vary slightly due to the nature of the multiprocessing queue.
         minimum_phi_value : float, optional
             if `per_word_topics` is True, this represents a lower bound on the term probabilities.
         per_word_topics : bool

--- a/gensim/models/ldamulticore.py
+++ b/gensim/models/ldamulticore.py
@@ -161,7 +161,7 @@ class LdaMulticore(LdaModel):
             Topics with a probability lower than this threshold will be filtered out.
         random_state : {np.random.RandomState, int}, optional
             Either a randomState object or a seed to generate one. Useful for reproducibility. Note, that results can
-            vary slightly due to the nature of the multiprocessing queue.
+            vary slightly due to the order in which results arrive from the processes.
         minimum_phi_value : float, optional
             if `per_word_topics` is True, this represents a lower bound on the term probabilities.
         per_word_topics : bool

--- a/gensim/models/ldamulticore.py
+++ b/gensim/models/ldamulticore.py
@@ -160,7 +160,8 @@ class LdaMulticore(LdaModel):
         minimum_probability : float, optional
             Topics with a probability lower than this threshold will be filtered out.
         random_state : {np.random.RandomState, int}, optional
-            Either a randomState object or a seed to generate one. Useful for reproducibility. Note, that results can
+            Either a randomState object or a seed to generate one. Useful for reproducibility.
+            Note that results can still vary due to non-determinism in OS scheduling of the worker processes.
             vary slightly due to the order in which results arrive from the processes.
         minimum_phi_value : float, optional
             if `per_word_topics` is True, this represents a lower bound on the term probabilities.

--- a/gensim/models/ldamulticore.py
+++ b/gensim/models/ldamulticore.py
@@ -162,7 +162,6 @@ class LdaMulticore(LdaModel):
         random_state : {np.random.RandomState, int}, optional
             Either a randomState object or a seed to generate one. Useful for reproducibility.
             Note that results can still vary due to non-determinism in OS scheduling of the worker processes.
-            vary slightly due to the order in which results arrive from the processes.
         minimum_phi_value : float, optional
             if `per_word_topics` is True, this represents a lower bound on the term probabilities.
         per_word_topics : bool


### PR DESCRIPTION
The results of ldamulticore models were different with similar random_states, and given more passes the results became more similar, but never equal.

The only difference seems to be the order of how results are pushed to the result_queue.

LdaModel works as expected, the topics are exactly equal (a difference of 0) with the same random_state.

Since I found this rather irritating at first, I thought that maybe this should be reflected in the docstring.

I'd like to properly validate that first though, or maybe you know that this is the reason which ends up saving time.