### PR TITLE
Build/test on Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ matrix:
     - python: '3.6'
       env: TOXENV="flake8,flake8-docs"
 
+    - python: '3.9-dev'
+      env:
+        - TOXENV="py39-linux"
+      dist: focal
+      
     - python: '3.8'
       env:
         - TOXENV="py38-linux"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,9 @@ strategy:
     py38:
       python.version: '3.8'
       TOXENV: "py38-win"
+    py39:
+      python.version: '3.9-dev'
+      TOXENV: "py39-win"
 
 steps:
 - task: UsePythonVersion@0


### PR DESCRIPTION
Python 3.9.0 is expected within a week: https://lwn.net/SubscriberLink/831783/44f4191759587fb7/

I'd tried a 3.9 build target a while back - but errors in other build-related packages made it fail. It might work now, and it'd be good to verify whether our build/unit-tests all work in Python 3.9. 

So, here the Travis CI & Azure pipeline builds get added Python "3.9-dev" targets, to see if all's well. 