### PR TITLE
Bug Fix: Uninitialized dictionary.id2token used in CoherenceModel

### DIFF
--- a/gensim/models/coherencemodel.py
+++ b/gensim/models/coherencemodel.py
@@ -447,7 +447,7 @@ class CoherenceModel(interfaces.TransformationABC):
         try:
             return np.array([self.dictionary.token2id[token] for token in topic])
         except KeyError:  # might be a list of token ids already, but let's verify all in dict
-            topic = (self.dictionary.id2token[_id] for _id in topic)
+            topic = (self.dictionary[_id] for _id in topic)
             return np.array([self.dictionary.token2id[token] for token in topic])
 
     def _update_accumulator(self, new_topics):


### PR DESCRIPTION
This PR addresses issue: https://github.com/RaRe-Technologies/gensim/issues/2919 

Changes mentioned in the issue have been done.

https://github.com/RaRe-Technologies/gensim/blob/817cac99422a255001034203dc0720f7d0df0ce6/gensim/models/coherencemodel.py#L447

has been replaced with: 
```python
topic = (self.dictionary[_id] for _id in topic)
```

