### PR TITLE
[MRG] Skip common English words in phrases

### DIFF
--- a/docs/src/_static/css/docs.css
+++ b/docs/src/_static/css/docs.css
@@ -3528,3 +3528,7 @@ a, a:visited, a:focus {
         top: 38px;
     }
 }
+
+.rst-content .section ol li>p:not(:first-child) ~ p, .rst-content .section ul li>p:not(:first-child) ~ p {
+    margin-top: 12px !important;
+}

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -463,6 +463,7 @@ class Phrases(_PhrasesTransformation):
             connector words in the middle.
 
             **If your texts are in English, set** ``connector_words=phrases.ENGLISH_CONNECTOR_WORDS``.
+
             This will cause phrases to include common English articles, prepositions and
             conjuctions, such as `bank_of_america` or `eye_of_the_beholder`.
 

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -21,7 +21,7 @@ Examples
 
     >>> from gensim.test.utils import datapath
     >>> from gensim.models.word2vec import Text8Corpus
-    >>> from gensim.models.phrases import Phrases
+    >>> from gensim.models.phrases import Phrases, ENGLISH_COMMON_TERMS
     >>>
     >>> # Create training corpus. Must be a sequence of sentences (e.g. an iterable or a generator).
     >>> sentences = Text8Corpus(datapath('testcorpus.txt'))
@@ -31,7 +31,7 @@ Examples
     ['computer', 'human', 'interface', 'computer', 'response', 'survey', 'system', 'time', 'user', 'interface']
     >>>
     >>> # Train a toy phrase model on our training corpus.
-    >>> phrase_model = Phrases(sentences, delimiter='_', min_count=1, threshold=1)
+    >>> phrase_model = Phrases(sentences, min_count=1, threshold=1, common_terms=ENGLISH_COMMON_TERMS)
     >>>
     >>> # Apply the trained phrases model to a new, unseen sentence.
     >>> new_sentence = ['trees', 'graph', 'minors']
@@ -321,10 +321,10 @@ s        """
 
             >>> from gensim.test.utils import datapath
             >>> from gensim.models.word2vec import Text8Corpus
-            >>> from gensim.models.phrases import Phrases
+            >>> from gensim.models.phrases import Phrases, ENGLISH_COMMON_TERMS
             >>>
             >>> sentences = Text8Corpus(datapath('testcorpus.txt'))
-            >>> phrases = Phrases(sentences, min_count=1, threshold=0.1)
+            >>> phrases = Phrases(sentences, min_count=1, threshold=0.1, common_terms=ENGLISH_COMMON_TERMS)
             >>>
             >>> for phrase, score in phrases.find_phrases(sentences).items():
             ...     print(phrase, score)
@@ -424,7 +424,7 @@ class Phrases(_PhrasesTransformation):
     def __init__(
             self, sentences=None, min_count=5, threshold=10.0,
             max_vocab_size=40000000, delimiter='_', progress_per=10000,
-            scoring='default', common_terms=ENGLISH_COMMON_TERMS,
+            scoring='default', common_terms=frozenset(),
         ):
         """
 
@@ -455,12 +455,14 @@ class Phrases(_PhrasesTransformation):
             #. "default" - :func:`~gensim.models.phrases.original_scorer`.
             #. "npmi" - :func:`~gensim.models.phrases.npmi_scorer`.
         common_terms : set of str, optional
-            Set of "stop words" to include in bigram phrases, without affecting their scoring.
-            Allows detection of expressions like `bank_of_america` or `eye_of_the_beholder`.
+            Set of "stop words" that may be included within a phrase, without affecting its scoring.
 
-            By default, ``common_terms`` includes common English articles and prepositions.
-            **Change this if your corpus is not in English**, or if you have a domain-specific
-            corpus with a different concept of "words irrelevant to phrases".
+            **If your texts are in English, set ``common_terms=phrases.ENGLISH_COMMON_TERMS``.**
+            This will cause phrases to include common English articles and prepositions, such
+            as `bank_of_america` or `eye_of_the_beholder`.
+
+            For other languages or specific applications domains, use custom ``common_terms``
+            that make sense there: ``common_terms=frozenset("der die das".split())`` etc.
 
         Examples
         --------
@@ -468,11 +470,11 @@ class Phrases(_PhrasesTransformation):
 
             >>> from gensim.test.utils import datapath
             >>> from gensim.models.word2vec import Text8Corpus
-            >>> from gensim.models.phrases import Phrases
+            >>> from gensim.models.phrases import Phrases, ENGLISH_COMMON_TERMS
             >>>
             >>> # Load corpus and train a model.
             >>> sentences = Text8Corpus(datapath('testcorpus.txt'))
-            >>> phrases = Phrases(sentences, min_count=1, threshold=1)
+            >>> phrases = Phrases(sentences, min_count=1, threshold=1, common_terms=ENGLISH_COMMON_TERMS)
             >>>
             >>> # Use the model to detect phrases in a new sentence.
             >>> sent = [u'trees', u'graph', u'minors']
@@ -481,7 +483,7 @@ class Phrases(_PhrasesTransformation):
             >>>
             >>> # Or transform multiple sentences at once.
             >>> sents = [[u'trees', u'graph', u'minors'], [u'graph', u'minors']]
-            >>> for phrase in frozen_phrases[sents]:
+            >>> for phrase in phrases[sents]:
             ...     print(phrase)
             [u'trees_graph', u'minors']
             [u'graph_minors']
@@ -643,11 +645,11 @@ class Phrases(_PhrasesTransformation):
 
             >>> from gensim.test.utils import datapath
             >>> from gensim.models.word2vec import Text8Corpus
-            >>> from gensim.models.phrases import Phrases
+            >>> from gensim.models.phrases import Phrases, ENGLISH_COMMON_TERMS
             >>>
             >>> # Train a phrase detector from a text corpus.
             >>> sentences = Text8Corpus(datapath('testcorpus.txt'))
-            >>> phrases = Phrases(sentences)  # train model
+            >>> phrases = Phrases(sentences, common_words=ENGLISH_COMMON_TERMS)  # train model
             >>> assert len(phrases.vocab) == 37
             >>>
             >>> more_sentences = [
@@ -774,11 +776,11 @@ class FrozenPhrases(_PhrasesTransformation):
 
             >>> from gensim.test.utils import datapath
             >>> from gensim.models.word2vec import Text8Corpus
-            >>> from gensim.models.phrases import Phrases
+            >>> from gensim.models.phrases import Phrases, ENGLISH_COMMON_TERMS
             >>>
             >>> # Load corpus and train a model.
             >>> sentences = Text8Corpus(datapath('testcorpus.txt'))
-            >>> phrases = Phrases(sentences, min_count=1, threshold=1)
+            >>> phrases = Phrases(sentences, min_count=1, threshold=1, common_terms=ENGLISH_COMMON_TERMS)
             >>>
             >>> # Export a FrozenPhrases object that is more efficient but doesn't allow further training.
             >>> frozen_phrases = phrases.freeze()

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -87,6 +87,7 @@ ENGLISH_COMMON_TERMS = frozenset(
     .split()
 )
 
+
 def original_scorer(worda_count, wordb_count, bigram_count, len_vocab, min_count, corpus_word_count):
     r"""Bigram scoring function, based on the original `Mikolov, et. al: "Distributed Representations
     of Words and Phrases and their Compositionality" <https://arxiv.org/abs/1310.4546>`_.
@@ -463,7 +464,7 @@ class Phrases(_PhrasesTransformation):
             corpus with a different concept of "words irrelevant to phrases".
 
         Examples
-        ----------
+        --------
         .. sourcecode:: pycon
 
             >>> from gensim.test.utils import datapath
@@ -491,22 +492,22 @@ class Phrases(_PhrasesTransformation):
             >>> print(frozen_phrases[sent])
             [u'trees_graph', u'minors']
 
-        Notes on collocation scoring
-        ----------------------------
+        Notes
+        -----
 
         The ``scoring="npmi"`` is more robust when dealing with common words that form part of common bigrams, and
-        ranges from -1 to 1, but is slower to calculate than the default ``scoring=="default"``.
+        ranges from -1 to 1, but is slower to calculate than the default``scoring="default"``.
         The default is the PMI-like scoring as described in `Mikolov, et. al: "Distributed
         Representations of Words and Phrases and their Compositionality" <https://arxiv.org/abs/1310.4546>`_.
 
         To use your own custom ``scoring`` function, pass in a function with the following signature:
 
-        * `worda_count` - number of corpus occurrences in `sentences` of the first token in the bigram being scored
-        * `wordb_count` - number of corpus occurrences in `sentences` of the second token in the bigram being scored
-        * `bigram_count` - number of occurrences in `sentences` of the whole bigram
-        * `len_vocab` - the number of unique tokens in `sentences`
-        * `min_count` - the `min_count` setting of the Phrases class
-        * `corpus_word_count` - the total number of tokens (non-unique) in `sentences`
+        * ``worda_count`` - number of corpus occurrences in `sentences` of the first token in the bigram being scored
+        * ``wordb_count`` - number of corpus occurrences in `sentences` of the second token in the bigram being scored
+        * ``bigram_count`` - number of occurrences in `sentences` of the whole bigram
+        * ``len_vocab`` - the number of unique tokens in `sentences`
+        * ``min_count`` - the `min_count` setting of the Phrases class
+        * ``corpus_word_count`` - the total number of tokens (non-unique) in `sentences`
 
         The scoring function must accept all these parameters, even if it doesn't use them in its scoring.
 

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -75,8 +75,7 @@ logger = logging.getLogger(__name__)
 
 NEGATIVE_INFINITY = float('-inf')
 
-#: Set of common English prepositions and articles. Tokens from this set
-# are "ignored" during phrase detection:
+# Set of common English words. Tokens from this set are "ignored" during phrase detection:
 # 1) Phrases may not start with these words.
 # 2) Phrases may include any number of these words inside.
 ENGLISH_COMMON_TERMS = frozenset(
@@ -649,7 +648,7 @@ class Phrases(_PhrasesTransformation):
             >>>
             >>> # Train a phrase detector from a text corpus.
             >>> sentences = Text8Corpus(datapath('testcorpus.txt'))
-            >>> phrases = Phrases(sentences, common_words=ENGLISH_COMMON_TERMS)  # train model
+            >>> phrases = Phrases(sentences, common_terms=ENGLISH_COMMON_TERMS)  # train model
             >>> assert len(phrases.vocab) == 37
             >>>
             >>> more_sentences = [

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -462,7 +462,7 @@ class Phrases(_PhrasesTransformation):
             No phrase can start nor end with a connector word; a phrase may contain any number of
             connector words in the middle.
 
-            **If your texts are in English, set ``connector_words=phrases.ENGLISH_CONNECTOR_WORDS``.**
+            **If your texts are in English, set** ``connector_words=phrases.ENGLISH_CONNECTOR_WORDS``.
             This will cause phrases to include common English articles, prepositions and
             conjuctions, such as `bank_of_america` or `eye_of_the_beholder`.
 

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -77,6 +77,15 @@ logger = logging.getLogger(__name__)
 
 NEGATIVE_INFINITY = float('-inf')
 
+#: Set of common English prepositions and articles. Tokens from this set
+# are "ignored" during phrase detection:
+# 1) Phrases may not start with these words.
+# 2) Phrases may include any number of these words inside.
+ENGLISH_COMMON_TERMS = frozenset(
+    " a an the "  # articles; we never care about these in MWEs
+    " for of with without at from to in on by "  # prepositions; incomplete on purpose, to minimize FNs
+    .split()
+)
 
 def original_scorer(worda_count, wordb_count, bigram_count, len_vocab, min_count, corpus_word_count):
     r"""Bigram scoring function, based on the original `Mikolov, et. al: "Distributed Representations
@@ -415,7 +424,7 @@ class Phrases(_PhrasesTransformation):
     def __init__(
             self, sentences=None, min_count=5, threshold=10.0,
             max_vocab_size=40000000, delimiter='_', progress_per=10000,
-            scoring='default', common_terms=frozenset(),
+            scoring='default', common_terms=ENGLISH_COMMON_TERMS,
         ):
         """
 
@@ -448,6 +457,10 @@ class Phrases(_PhrasesTransformation):
         common_terms : set of str, optional
             Set of "stop words" to include in bigram phrases, without affecting their scoring.
             Allows detection of expressions like `bank_of_america` or `eye_of_the_beholder`.
+
+            By default, ``common_terms`` includes common English articles and prepositions.
+            **Change this if your corpus is not in English**, or if you have a domain-specific
+            corpus with a different concept of "words irrelevant to phrases".
 
         Examples
         ----------

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -502,7 +502,7 @@ class Phrases(_PhrasesTransformation):
         -----
 
         The ``scoring="npmi"`` is more robust when dealing with common words that form part of common bigrams, and
-        ranges from -1 to 1, but is slower to calculate than the default``scoring="default"``.
+        ranges from -1 to 1, but is slower to calculate than the default ``scoring="default"``.
         The default is the PMI-like scoring as described in `Mikolov, et. al: "Distributed
         Representations of Words and Phrases and their Compositionality" <https://arxiv.org/abs/1310.4546>`_.
 

--- a/gensim/sklearn_api/phrases.py
+++ b/gensim/sklearn_api/phrases.py
@@ -32,7 +32,7 @@ from sklearn.base import TransformerMixin, BaseEstimator
 from sklearn.exceptions import NotFittedError
 
 from gensim import models
-from gensim.models.phrases import FrozenPhrases, ENGLISH_CONNECTOR_WORDS
+from gensim.models.phrases import FrozenPhrases, ENGLISH_CONNECTOR_WORDS  # noqa:F401
 
 
 class PhrasesTransformer(TransformerMixin, BaseEstimator):

--- a/gensim/sklearn_api/phrases.py
+++ b/gensim/sklearn_api/phrases.py
@@ -32,7 +32,7 @@ from sklearn.base import TransformerMixin, BaseEstimator
 from sklearn.exceptions import NotFittedError
 
 from gensim import models
-from gensim.models.phrases import FrozenPhrases
+from gensim.models.phrases import FrozenPhrases, ENGLISH_CONNECTOR_WORDS
 
 
 class PhrasesTransformer(TransformerMixin, BaseEstimator):
@@ -46,7 +46,7 @@ class PhrasesTransformer(TransformerMixin, BaseEstimator):
     """
     def __init__(
             self, min_count=5, threshold=10.0, max_vocab_size=40000000,
-            delimiter='_', progress_per=10000, scoring='default', common_terms=frozenset(),
+            delimiter='_', progress_per=10000, scoring='default', connector_words=frozenset(),
         ):
         """
 
@@ -90,9 +90,17 @@ class PhrasesTransformer(TransformerMixin, BaseEstimator):
 
             A scoring function without any of these parameters (even if the parameters are not used) will
             raise a ValueError on initialization of the Phrases class. The scoring function must be pickleable.
-        common_terms : set of str, optional
-            List of "stop words" that won't affect frequency count of expressions containing them.
-            Allow to detect expressions like "bank_of_america" or "eye_of_the_beholder".
+        connector_words : set of str, optional
+            Set of words that may be included within a phrase, without affecting its scoring.
+            No phrase can start nor end with a connector word; a phrase may contain any number of
+            connector words in the middle.
+
+            **If your texts are in English, set ``connector_words=phrases.ENGLISH_CONNECTOR_WORDS``.**
+            This will cause phrases to include common English articles, prepositions and
+            conjuctions, such as `bank_of_america` or `eye_of_the_beholder`.
+
+            For other languages or specific applications domains, use custom ``connector_words``
+            that make sense there: ``connector_words=frozenset("der die das".split())`` etc.
 
         """
         self.gensim_model = None
@@ -103,11 +111,11 @@ class PhrasesTransformer(TransformerMixin, BaseEstimator):
         self.delimiter = delimiter
         self.progress_per = progress_per
         self.scoring = scoring
-        self.common_terms = common_terms
+        self.connector_words = connector_words
 
     def __setstate__(self, state):
         self.__dict__ = state
-        self.common_terms = frozenset()
+        self.connector_words = frozenset()
         self.phraser = None
 
     def fit(self, X, y=None):
@@ -127,7 +135,7 @@ class PhrasesTransformer(TransformerMixin, BaseEstimator):
         self.gensim_model = models.Phrases(
             sentences=X, min_count=self.min_count, threshold=self.threshold,
             max_vocab_size=self.max_vocab_size, delimiter=self.delimiter,
-            progress_per=self.progress_per, scoring=self.scoring, common_terms=self.common_terms
+            progress_per=self.progress_per, scoring=self.scoring, connector_words=self.connector_words,
         )
         self.phraser = FrozenPhrases(self.gensim_model)
         return self
@@ -184,7 +192,7 @@ class PhrasesTransformer(TransformerMixin, BaseEstimator):
             self.gensim_model = models.Phrases(
                 sentences=X, min_count=self.min_count, threshold=self.threshold,
                 max_vocab_size=self.max_vocab_size, delimiter=self.delimiter,
-                progress_per=self.progress_per, scoring=self.scoring, common_terms=self.common_terms
+                progress_per=self.progress_per, scoring=self.scoring, connector_words=self.connector_words,
             )
 
         self.gensim_model.add_vocab(X)

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -215,7 +215,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
     def testExportPhrases(self):
         """Test Phrases bigram export phrases."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
-        seen_bigrams = set(bigram.export_phrases(self.sentences).keys())
+        seen_bigrams = set(bigram.find_phrases(self.sentences).keys())
 
         assert seen_bigrams == {
             'response time',
@@ -227,7 +227,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
         """Test a single entry produces multiple bigrams."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface']]
-        seen_bigrams = set(bigram.export_phrases(test_sentences).keys())
+        seen_bigrams = set(bigram.find_phrases(test_sentences).keys())
 
         assert seen_bigrams == {'graph minors', 'human interface'}
 
@@ -235,7 +235,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
         """Test the default scoring, from the mikolov word2vec paper."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface']]
-        seen_scores = set(round(score, 3) for score in bigram.export_phrases(test_sentences).values())
+        seen_scores = set(round(score, 3) for score in bigram.find_phrases(test_sentences).values())
 
         assert seen_scores == {
             5.167,  # score for graph minors
@@ -254,7 +254,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
         """Test normalized pointwise mutual information scoring."""
         bigram = Phrases(self.sentences, min_count=1, threshold=.5, scoring='npmi')
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface']]
-        seen_scores = set(round(score, 3) for score in bigram.export_phrases(test_sentences).values())
+        seen_scores = set(round(score, 3) for score in bigram.find_phrases(test_sentences).values())
 
         assert seen_scores == {
             .882,  # score for graph minors
@@ -265,7 +265,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
         """Test using a custom scoring function."""
         bigram = Phrases(self.sentences, min_count=1, threshold=.001, scoring=dumb_scorer)
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
-        seen_scores = list(bigram.export_phrases(test_sentences).values())
+        seen_scores = list(bigram.find_phrases(test_sentences).values())
 
         assert all(score == 1 for score in seen_scores)
         assert len(seen_scores) == 3  # 'graph minors' and 'survey human' and 'interface system'
@@ -294,7 +294,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
             bigram.save(fpath)
             bigram_loaded = Phrases.load(fpath)
             test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
-            seen_scores = list(bigram_loaded.export_phrases(test_sentences).values())
+            seen_scores = list(bigram_loaded.find_phrases(test_sentences).values())
 
             assert all(score == 1 for score in seen_scores)
             assert len(seen_scores) == 3  # 'graph minors' and 'survey human' and 'interface system'
@@ -306,7 +306,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
             bigram.save(fpath)
             bigram_loaded = Phrases.load(fpath)
             test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
-            seen_scores = set(round(score, 3) for score in bigram_loaded.export_phrases(test_sentences).values())
+            seen_scores = set(round(score, 3) for score in bigram_loaded.find_phrases(test_sentences).values())
 
             assert seen_scores == set([
                 5.167,  # score for graph minors
@@ -317,7 +317,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
         """Test backwards compatibility with a previous version of Phrases with custom scoring."""
         bigram_loaded = Phrases.load(datapath("phrases-scoring-str.pkl"))
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
-        seen_scores = set(round(score, 3) for score in bigram_loaded.export_phrases(test_sentences).values())
+        seen_scores = set(round(score, 3) for score in bigram_loaded.find_phrases(test_sentences).values())
 
         assert seen_scores == set([
             5.167,  # score for graph minors
@@ -328,7 +328,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
         """Test backwards compatibility with old versions of Phrases with no scoring parameter."""
         bigram_loaded = Phrases.load(datapath("phrases-no-scoring.pkl"))
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
-        seen_scores = set(round(score, 3) for score in bigram_loaded.export_phrases(test_sentences).values())
+        seen_scores = set(round(score, 3) for score in bigram_loaded.find_phrases(test_sentences).values())
 
         assert seen_scores == set([
             5.167,  # score for graph minors
@@ -434,7 +434,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
         """Test a single entry produces multiple bigrams."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, common_terms=self.common_terms, delimiter=' ')
         test_sentences = [['data', 'and', 'graph', 'survey', 'for', 'human', 'interface']]
-        seen_bigrams = set(bigram.export_phrases(test_sentences).keys())
+        seen_bigrams = set(bigram.find_phrases(test_sentences).keys())
 
         assert seen_bigrams == set([
             'data and graph',
@@ -444,7 +444,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
     def testExportPhrases(self):
         """Test Phrases bigram export phrases."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, common_terms=self.common_terms, delimiter=' ')
-        seen_bigrams = set(bigram.export_phrases(self.sentences).keys())
+        seen_bigrams = set(bigram.find_phrases(self.sentences).keys())
 
         assert seen_bigrams == set([
             'human interface',
@@ -457,7 +457,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
         """ test the default scoring, from the mikolov word2vec paper """
         bigram = Phrases(self.sentences, min_count=1, threshold=1, common_terms=self.common_terms)
         test_sentences = [['data', 'and', 'graph', 'survey', 'for', 'human', 'interface']]
-        seen_scores = set(round(score, 3) for score in bigram.export_phrases(test_sentences).values())
+        seen_scores = set(round(score, 3) for score in bigram.find_phrases(test_sentences).values())
 
         min_count = float(bigram.min_count)
         len_vocab = float(len(bigram.vocab))
@@ -482,7 +482,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             scoring='npmi', common_terms=self.common_terms,
         )
         test_sentences = [['data', 'and', 'graph', 'survey', 'for', 'human', 'interface']]
-        seen_scores = set(round(score, 3) for score in bigram.export_phrases(test_sentences).values())
+        seen_scores = set(round(score, 3) for score in bigram.find_phrases(test_sentences).values())
 
         assert seen_scores == set([
             .74,  # score for data and graph
@@ -496,7 +496,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             scoring=dumb_scorer, common_terms=self.common_terms,
         )
         test_sentences = [['data', 'and', 'graph', 'survey', 'for', 'human', 'interface']]
-        seen_scores = list(bigram.export_phrases(test_sentences).values())
+        seen_scores = list(bigram.find_phrases(test_sentences).values())
 
         assert all(seen_scores)  # all scores 1
         assert len(seen_scores) == 2  # 'data and graph' 'survey for human'

--- a/gensim/test/test_sklearn_api.py
+++ b/gensim/test/test_sklearn_api.py
@@ -280,7 +280,7 @@ w2v_texts = [
      'technologies', 'that', 'arise', 'from', 'theoretical', 'breakthroughs'],
     ['advances', 'in', 'the', 'understanding', 'of', 'electromagnetism', 'or', 'nuclear', 'physics',
      'led', 'directly', 'to', 'the', 'development', 'of', 'new', 'products', 'that', 'have', 'dramatically',
-     'transformed', 'modern', 'day', 'society']
+     'transformed', 'modern', 'day', 'society'],
 ]
 
 d2v_sentences = [models.doc2vec.TaggedDocument(words, [i]) for i, words in enumerate(w2v_texts)]
@@ -288,15 +288,15 @@ d2v_sentences = [models.doc2vec.TaggedDocument(words, [i]) for i, words in enume
 dict_texts = [' '.join(text) for text in common_texts]
 
 phrases_sentences = common_texts + [
-    ['graph', 'minors', 'survey', 'human', 'interface']
+    ['graph', 'minors', 'survey', 'human', 'interface'],
 ]
 
-common_terms = ["of", "the", "was", "are"]
-phrases_w_common_terms = [
+connector_words = ["of", "the", "was", "are"]
+phrases_w_connector_words = [
     [u'the', u'mayor', u'of', u'new', u'york', u'was', u'there'],
     [u'the', u'mayor', u'of', u'new', u'orleans', u'was', u'there'],
     [u'the', u'bank', u'of', u'america', u'offices', u'are', u'open'],
-    [u'the', u'bank', u'of', u'america', u'offices', u'are', u'closed']
+    [u'the', u'bank', u'of', u'america', u'offices', u'are', u'closed'],
 ]
 
 
@@ -1174,7 +1174,7 @@ class TestPhrasesTransformer(unittest.TestCase):
 
 class TestPhrasesTransformerCommonTerms(unittest.TestCase):
     def setUp(self):
-        self.model = PhrasesTransformer(min_count=1, threshold=1, common_terms=common_terms)
+        self.model = PhrasesTransformer(min_count=1, threshold=1, connector_words=connector_words)
         self.expected_transformations = [
             [u'the', u'mayor_of_new', u'york', u'was', u'there'],
             [u'the', u'mayor_of_new', u'orleans', u'was', u'there'],
@@ -1183,18 +1183,18 @@ class TestPhrasesTransformerCommonTerms(unittest.TestCase):
         ]
 
     def testFitAndTransform(self):
-        self.model.fit(phrases_w_common_terms)
+        self.model.fit(phrases_w_connector_words)
 
-        transformed = self.model.transform(phrases_w_common_terms)
+        transformed = self.model.transform(phrases_w_connector_words)
         self.assertEqual(transformed, self.expected_transformations)
 
     def testFitTransform(self):
-        transformed = self.model.fit_transform(phrases_w_common_terms)
+        transformed = self.model.fit_transform(phrases_w_connector_words)
         self.assertEqual(transformed, self.expected_transformations)
 
     def testPartialFit(self):
         # fit half of the sentences
-        self.model.fit(phrases_w_common_terms[:2])
+        self.model.fit(phrases_w_connector_words[:2])
 
         expected_transformations_0 = [
             [u'the', u'mayor_of_new', u'york', u'was', u'there'],
@@ -1203,12 +1203,12 @@ class TestPhrasesTransformerCommonTerms(unittest.TestCase):
             [u'the', u'bank', u'of', u'america', u'offices', u'are', u'closed']
         ]
         # transform all sentences, second half should be same as original
-        transformed_0 = self.model.transform(phrases_w_common_terms)
+        transformed_0 = self.model.transform(phrases_w_connector_words)
         self.assertEqual(transformed_0, expected_transformations_0)
 
         # fit remaining sentences, result should be the same as in the other tests
-        self.model.partial_fit(phrases_w_common_terms[2:])
-        transformed_1 = self.model.fit_transform(phrases_w_common_terms)
+        self.model.partial_fit(phrases_w_connector_words[2:])
+        transformed_1 = self.model.fit_transform(phrases_w_connector_words)
         self.assertEqual(transformed_1, self.expected_transformations)
 
         new_phrases = [[u'offices', u'are', u'open'], [u'offices', u'are', u'closed']]
@@ -1219,7 +1219,7 @@ class TestPhrasesTransformerCommonTerms(unittest.TestCase):
             [u'the', u'bank_of_america', u'offices_are_open'],
             [u'the', u'bank_of_america', u'offices_are_closed']
         ]
-        transformed_2 = self.model.transform(phrases_w_common_terms)
+        transformed_2 = self.model.transform(phrases_w_connector_words)
         self.assertEqual(transformed_2, expected_transformations_2)
 
 

--- a/release/bump_version.py
+++ b/release/bump_version.py
@@ -29,7 +29,7 @@ def bump_docs_src_conf_py(root, previous_version, new_version):
     path = os.path.join(root, 'docs', 'src', 'conf.py')
 
     short_previous_version = '.'.join(previous_version.split('.')[:2])
-    short_new_version = '.'.join(new_version.split('.')[:2])
+    short_new_version = new_version  # '.'.join(new_version.split('.')[:2])
     pattern = re.compile("^version = '%s'$" % short_previous_version, re.MULTILINE)
     repl = "version = '%s'" % short_new_version
     bump(path, pattern, repl, check=False)  # short version won't always change


### PR DESCRIPTION
Follow up from https://github.com/RaRe-Technologies/gensim/pull/2976#discussion_r502769899 : add a list of English "common words" to skip during phrase construction.

These English words are an optional switch; the default doesn't change.

**Backward incompatible change**: this PR renamed the `common_terms` parameter of `gensim.models.phrases.Phrases()` to `connector_words`, with the same meaning.

Fixes #2520. Fixes #1465.