### PR TITLE
[MRG] Notification at the top of page in documentation

### DIFF
--- a/docs/src/_static/css/docs.css
+++ b/docs/src/_static/css/docs.css
@@ -3532,3 +3532,25 @@ a, a:visited, a:focus {
 .rst-content .section ol li>p:not(:first-child) ~ p, .rst-content .section ul li>p:not(:first-child) ~ p {
     margin-top: 12px !important;
 }
+
+.notification {
+    width: 100%;
+    height: auto;
+    background-color: #B70431;
+    color: #fff;
+    padding: .675rem;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    font-size: .875rem;
+    line-height: 1.425;
+    text-align: center;
+}
+
+.notification a {
+    color: #FFFFFF;
+    text-decoration: underline;
+}
+
+.notification a:hover {
+    text-decoration: none;
+}

--- a/docs/src/_static/css/erp2.css
+++ b/docs/src/_static/css/erp2.css
@@ -2602,3 +2602,25 @@ a.googlegroups:hover {
 .social_icons a {
     margin: 15px 15px 0 15px;
 }
+
+.notification {
+    width: 100%;
+    height: auto;
+    background-color: #B70431;
+    color: #fff;
+    padding: .675rem;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    font-size: .875rem;
+    line-height: 1.425;
+    text-align: center;
+}
+
+.notification a {
+    color: #FFFFFF;
+    text-decoration: underline;
+}
+
+.notification a:hover {
+    text-decoration: none;
+}

--- a/docs/src/sphinx_rtd_theme/layout.html
+++ b/docs/src/sphinx_rtd_theme/layout.html
@@ -126,6 +126,7 @@
 <body class="wy-body-for-nav page-template-default page color-custom style-default button-round layout-full-width if-zoom no-content-padding header-transparent header-fw minimalist-header-no sticky-header sticky-tb-color ab-hide subheader-title-left menu-link-color menuo-no-borders mobile-tb-center mobile-side-slide mobile-mini-mr-lc tablet-sticky mobile-header-mini mobile-sticky">
 <div id="Wrapper">
   <div id="Header_wrapper" class>
+    {% include "notification.html" %}
     <header id="Header">
       {% include "topbar.html" %}
     </header>

--- a/docs/src/sphinx_rtd_theme/layouthome.html
+++ b/docs/src/sphinx_rtd_theme/layouthome.html
@@ -69,6 +69,7 @@
 <body class="home page-template-default page template-slider color-custom style-default button-round layout-full-width if-zoom no-content-padding header-transparent header-fw minimalist-header-no sticky-header sticky-tb-color ab-hide subheader-title-left menu-link-color menuo-no-borders mobile-tb-center mobile-side-slide mobile-mini-mr-lc tablet-sticky mobile-header-mini mobile-sticky">
 <div id="Wrapper">
   <div id="Header_wrapper" class>
+    {% include "notification.html" %}
     <header id="Header">
       {% include "topbar.html" %}
     </header>

--- a/docs/src/sphinx_rtd_theme/notification.html
+++ b/docs/src/sphinx_rtd_theme/notification.html
@@ -1,3 +1,3 @@
 <div class="notification">
-  This is documentation for the pre-release of Gensim 4.0.0. For Gensim 3.8.3, please visit the <a href="https://radimrehurek.com/gensim_3.8.3">Gensim 3.8.3 documentation</a>.
+  You're viewing documentation for Gensim 4.0.0. For Gensim 3.8.3, please visit the old <a href="https://radimrehurek.com/gensim_3.8.3">Gensim 3.8.3 documentation</a>.
 </div>

--- a/docs/src/sphinx_rtd_theme/notification.html
+++ b/docs/src/sphinx_rtd_theme/notification.html
@@ -1,0 +1,3 @@
+<div class="notification">
+  This is documentation for the pre-release of Gensim 4.0.0. For Gensim 3.8.3, please visit the <a href="https://radimrehurek.com/gensim_3.8.3">Gensim 3.8.3 documentation</a>.
+</div>


### PR DESCRIPTION
Add a website banner with a temporary message, so we can display the 4.0.0-beta and 3.8.3 documentation side by side:

![image](https://user-images.githubusercontent.com/610412/97192076-d8404500-17a7-11eb-9fcb-175908b0f04f.png)

To be removed once we release 4.0.0 proper, by commenting out the content of `notification.html`.