### PR TITLE
[MRG] Make the link to the Gensim 3.8.3 documentation dynamic

### DIFF
--- a/docs/src/sphinx_rtd_theme/notification.html
+++ b/docs/src/sphinx_rtd_theme/notification.html
@@ -1,3 +1,6 @@
 <div class="notification">
-  You're viewing documentation for Gensim 4.0.0. For Gensim 3.8.3, please visit the old <a href="https://radimrehurek.com/gensim_3.8.3">Gensim 3.8.3 documentation</a>.
+  You're viewing documentation for Gensim 4.0.0. For Gensim 3.8.3, please visit the old <a id="notification" href="https://radimrehurek.com/gensim_3.8.3">Gensim 3.8.3 documentation</a>.
+  <script>
+    notification.href += location.pathname.replace(/^\/gensim/, "");
+  </script>
 </div>


### PR DESCRIPTION
This PR closes issue #2995 by making the "Gensim 3.8.3 documentation" link in the header of the Gensim 4.0.0 documentation redirect the user to the corresponding page in the Gensim 3.8.3 documentation instead of the index page. The changes are confined to the `notification.html` document, which makes them easy to undo when we're removing the notification sometime in the future.