### PR TITLE
[WIP] Fix "dictionary changed size during iteration" in Phrases

### DIFF
--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -62,7 +62,6 @@ Examples
 """
 
 import logging
-from collections import defaultdict
 import itertools
 from math import log
 import pickle
@@ -412,7 +411,7 @@ s        """
             if not isinstance(word, str):
                 logger.info("old version of %s loaded, upgrading %i words in memory", cls.__name__, len(model.vocab))
                 logger.info("re-save the loaded model to avoid this upgrade in the future")
-                vocab = defaultdict(int)
+                vocab = dict()
                 for key, value in model.vocab.items():  # needs lots of extra RAM temporarily!
                     vocab[str(key, encoding='utf8')] = value
                 model.vocab = vocab
@@ -554,7 +553,7 @@ class Phrases(_PhrasesTransformation):
         self.min_count = min_count
         self.threshold = threshold
         self.max_vocab_size = max_vocab_size
-        self.vocab = defaultdict(int)  # mapping between token => its count
+        self.vocab = dict()  # mapping between token => its count
         self.min_reduce = 1  # ignore any tokens with count smaller than this
         self.delimiter = delimiter
         self.progress_per = progress_per
@@ -579,7 +578,7 @@ class Phrases(_PhrasesTransformation):
     def _learn_vocab(sentences, max_vocab_size, delimiter, connector_words, progress_per):
         """Collect unigram and bigram counts from the `sentences` iterable."""
         sentence_no, total_words, min_reduce = -1, 0, 1
-        vocab = defaultdict(int)
+        vocab = dict()
         logger.info("collecting all words and their counts")
         for sentence_no, sentence in enumerate(sentences):
             if sentence_no % progress_per == 0:
@@ -590,10 +589,11 @@ class Phrases(_PhrasesTransformation):
             start_token, in_between = None, []
             for word in sentence:
                 if word not in connector_words:
-                    vocab[word] += 1
+                    vocab[word] = vocab.get(word, 0)+1
                     if start_token is not None:
                         phrase_tokens = itertools.chain([start_token], in_between, [word])
-                        vocab[delimiter.join(phrase_tokens)] += 1
+                        joined_phrase_token = delimiter.join(phrase_tokens)
+                        vocab[joined_phrase_token] = vocab.get(joined_phrase_token, 0)+1
                     start_token, in_between = word, []  # treat word as both end of a phrase AND beginning of another
                 elif start_token is not None:
                     in_between.append(word)
@@ -654,7 +654,7 @@ class Phrases(_PhrasesTransformation):
             logger.info("merging %i counts into %s", len(vocab), self)
             self.min_reduce = max(self.min_reduce, min_reduce)
             for word, count in vocab.items():
-                self.vocab[word] += count
+                self.vocab[word] = vocab.get(word, 0) + count
             if len(self.vocab) > self.max_vocab_size:
                 utils.prune_vocab(self.vocab, self.min_reduce)
                 self.min_reduce += 1
@@ -666,17 +666,17 @@ class Phrases(_PhrasesTransformation):
 
     def score_candidate(self, word_a, word_b, in_between):
         # Micro optimization: check for quick early-out conditions, before the actual scoring.
-        word_a_cnt = self.vocab[word_a]
+        word_a_cnt = self.vocab.get(word_a, 0)
         if word_a_cnt <= 0:
             return None, None
 
-        word_b_cnt = self.vocab[word_b]
+        word_b_cnt = self.vocab.get(word_b, 0)
         if word_b_cnt <= 0:
             return None, None
 
         phrase = self.delimiter.join([word_a] + in_between + [word_b])
         # XXX: Why do we care about *all* phrase tokens? Why not just score the start+end bigram?
-        phrase_cnt = self.vocab[phrase]
+        phrase_cnt = self.vocab.get(phrase, 0)
         if phrase_cnt <= 0:
             return None, None
 

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -589,11 +589,11 @@ class Phrases(_PhrasesTransformation):
             start_token, in_between = None, []
             for word in sentence:
                 if word not in connector_words:
-                    vocab[word] = vocab.get(word, 0)+1
+                    vocab[word] = vocab.get(word, 0) + 1
                     if start_token is not None:
                         phrase_tokens = itertools.chain([start_token], in_between, [word])
                         joined_phrase_token = delimiter.join(phrase_tokens)
-                        vocab[joined_phrase_token] = vocab.get(joined_phrase_token, 0)+1
+                        vocab[joined_phrase_token] = vocab.get(joined_phrase_token, 0) + 1
                     start_token, in_between = word, []  # treat word as both end of a phrase AND beginning of another
                 elif start_token is not None:
                     in_between.append(word)

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -654,7 +654,7 @@ class Phrases(_PhrasesTransformation):
             logger.info("merging %i counts into %s", len(vocab), self)
             self.min_reduce = max(self.min_reduce, min_reduce)
             for word, count in vocab.items():
-                self.vocab[word] = vocab.get(word, 0) + count
+                self.vocab[word] = self.vocab.get(word, 0) + count
             if len(self.vocab) > self.max_vocab_size:
                 utils.prune_vocab(self.vocab, self.min_reduce)
                 self.min_reduce += 1
@@ -715,7 +715,7 @@ class Phrases(_PhrasesTransformation):
 
         """
         result, source_vocab = {}, self.vocab
-        for token in source_vocab.copy():
+        for token in source_vocab:
             unigrams = token.split(self.delimiter)
             if len(unigrams) < 2:
                 continue  # no phrases here

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -548,7 +548,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
 
 class TestFrozenPhrasesModelCompatibilty(unittest.TestCase):
 
-    def test_compatibilty(self):
+    def test_compatibility(self):
         phrases = Phrases.load(datapath("phrases-3.6.0.model"))
         phraser = FrozenPhrases.load(datapath("phraser-3.6.0.model"))
         test_sentences = ['trees', 'graph', 'minors']

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -214,8 +214,8 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
 
     def testExportPhrases(self):
         """Test Phrases bigram export phrases."""
-        bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
-        trigram = Phrases(bigram[self.sentences], min_count=1, threshold=1, delimiter=' ')
+        bigram = Phrases(self.sentences, min_count = 1, threshold = 1, delimiter = ' ')
+        trigram = Phrases(bigram[self.sentences], min_count = 1, threshold = 1, delimiter = ' ')
         seen_bigrams = set(bigram.export_phrases().keys())
         seen_trigrams = set(trigram.export_phrases().keys())
         assert seen_bigrams == set([
@@ -224,7 +224,6 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
             'graph minors',
             'minors survey',
         ])
-
         assert seen_trigrams == set([
             'human interface',
             'graph minors survey',
@@ -232,7 +231,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
 
     def testFindPhrases(self):
         """Test Phrases bigram find phrases."""
-        bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
+        bigram = Phrases(self.sentences, min_count = 1, threshold = 1, delimiter = ' ')
         seen_bigrams = set(bigram.find_phrases(self.sentences).keys())
 
         assert seen_bigrams == set([
@@ -262,7 +261,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
 
     def test__getitem__(self):
         """Test Phrases[sentences] with a single sentence."""
-        bigram = Phrases(self.sentences, min_count=1, threshold=1)
+        bigram = Phrases(self.sentences, min_count = 1, threshold = 1)
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface']]
         phrased_sentence = next(bigram[test_sentences].__iter__())
 
@@ -450,7 +449,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
 
     def testExportPhrases(self):
         """Test Phrases bigram export phrases."""
-        bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
+        bigram = Phrases(self.sentences, min_count = 1, threshold = 1, delimiter = ' ')
         seen_bigrams = set(bigram.export_phrases().keys())
         assert seen_bigrams == set([
             'and graph',
@@ -476,7 +475,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
 
     def testFindPhrases(self):
         """Test Phrases bigram find phrases."""
-        bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=self.connector_words, delimiter=' ')
+        bigram = Phrases(self.sentences, min_coun = 1, threshold = 1, connector_words = self.connector_words, delimiter = ' ')
         seen_bigrams = set(bigram.find_phrases(self.sentences).keys())
 
         assert seen_bigrams == set([

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -215,6 +215,23 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
     def testExportPhrases(self):
         """Test Phrases bigram export phrases."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
+        trigram = Phrases(bigram[self.sentences], min_count=1, threshold=1, delimiter=' ')
+        seen_bigrams = set(bigram.export_phrases().keys())
+        seen_trigrams = set(trigram.export_phrases().keys())
+        assert seen_bigrams == {
+            'human interface',
+            'response time',
+            'graph minors',
+            'minors survey'}
+
+        assert seen_trigrams == {
+            'human interface',
+            'graph minors survey'
+        }
+
+    def testFindPhrases(self):
+        """Test Phrases bigram find phrases."""
+        bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
         seen_bigrams = set(bigram.find_phrases(self.sentences).keys())
 
         assert seen_bigrams == {
@@ -430,6 +447,20 @@ class CommonTermsPhrasesData:
 class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
     """Test Phrases models with connector words."""
 
+    def testExportPhrases(self):
+        """Test Phrases bigram export phrases."""
+        bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
+        seen_bigrams = set(bigram.export_phrases().keys())
+        assert seen_bigrams == {
+            'and graph',
+            'data and',
+            'graph of',
+            'graph survey',
+            'human interface',
+            'lack of',
+            'of interest',
+            'of trees'}
+
     def testMultipleBigramsSingleEntry(self):
         """Test a single entry produces multiple bigrams."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=self.connector_words, delimiter=' ')
@@ -441,8 +472,8 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             'human interface',
         ])
 
-    def testExportPhrases(self):
-        """Test Phrases bigram export phrases."""
+    def testFindPhrases(self):
+        """Test Phrases bigram find phrases."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=self.connector_words, delimiter=' ')
         seen_bigrams = set(bigram.find_phrases(self.sentences).keys())
 

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -218,27 +218,28 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
         trigram = Phrases(bigram[self.sentences], min_count=1, threshold=1, delimiter=' ')
         seen_bigrams = set(bigram.export_phrases().keys())
         seen_trigrams = set(trigram.export_phrases().keys())
-        assert seen_bigrams == {
+        assert seen_bigrams == set([
             'human interface',
             'response time',
             'graph minors',
-            'minors survey'}
+            'minors survey',
+        ])
 
-        assert seen_trigrams == {
+        assert seen_trigrams == set([
             'human interface',
-            'graph minors survey'
-        }
+            'graph minors survey',
+        ])
 
     def testFindPhrases(self):
         """Test Phrases bigram find phrases."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
         seen_bigrams = set(bigram.find_phrases(self.sentences).keys())
 
-        assert seen_bigrams == {
+        assert seen_bigrams == set([
             'response time',
             'graph minors',
             'human interface',
-        }
+        ])
 
     def testMultipleBigramsSingleEntry(self):
         """Test a single entry produces multiple bigrams."""
@@ -451,7 +452,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
         """Test Phrases bigram export phrases."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
         seen_bigrams = set(bigram.export_phrases().keys())
-        assert seen_bigrams == {
+        assert seen_bigrams == set([
             'and graph',
             'data and',
             'graph of',
@@ -459,7 +460,8 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             'human interface',
             'lack of',
             'of interest',
-            'of trees'}
+            'of trees',
+        ])
 
     def testMultipleBigramsSingleEntry(self):
         """Test a single entry produces multiple bigrams."""

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -18,7 +18,6 @@ from gensim.test.utils import common_texts, temporary_file, datapath
 
 
 class TestPhraseAnalysis(unittest.TestCase):
-
     class AnalysisTester(_PhrasesTransformation):
 
         def __init__(self, scores, threshold):
@@ -91,7 +90,6 @@ class TestPhraseAnalysis(unittest.TestCase):
 
 
 class PhrasesData:
-
     sentences = common_texts + [
         ['graph', 'minors', 'survey', 'human', 'interface'],
     ]
@@ -112,7 +110,7 @@ class PhrasesCommon(PhrasesData):
         self.bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=self.connector_words)
         self.bigram_default = Phrases(self.sentences, connector_words=self.connector_words)
 
-    def testEmptyPhrasifiedSentencesIterator(self):
+    def test_empty_phrasified_sentences_iterator(self):
         bigram_phrases = Phrases(self.sentences)
         bigram_phraser = FrozenPhrases(bigram_phrases)
         trigram_phrases = Phrases(bigram_phraser[self.sentences])
@@ -122,7 +120,7 @@ class PhrasesCommon(PhrasesData):
         self.assertEqual(fst, snd)
         self.assertNotEqual(snd, [])
 
-    def testEmptyInputsOnBigramConstruction(self):
+    def test_empty_inputs_on_bigram_construction(self):
         """Test that empty inputs don't throw errors and return the expected result."""
         # Empty list -> empty list
         self.assertEqual(list(self.bigram_default[[]]), [])
@@ -135,7 +133,7 @@ class PhrasesCommon(PhrasesData):
         # Iterator of empty iterator -> list of empty list
         self.assertEqual(list(self.bigram_default[(iter(()) for i in range(2))]), [[], []])
 
-    def testSentenceGeneration(self):
+    def test_sentence_generation(self):
         """Test basic bigram using a dummy corpus."""
         # test that we generate the same amount of sentences as the input
         self.assertEqual(
@@ -143,14 +141,14 @@ class PhrasesCommon(PhrasesData):
             len(list(self.bigram_default[self.sentences])),
         )
 
-    def testSentenceGenerationWithGenerator(self):
+    def test_sentence_generation_with_generator(self):
         """Test basic bigram production when corpus is a generator."""
         self.assertEqual(
             len(list(self.gen_sentences())),
             len(list(self.bigram_default[self.gen_sentences()])),
         )
 
-    def testBigramConstruction(self):
+    def test_bigram_construction(self):
         """Test Phrases bigram construction."""
         # with this setting we should get response_time and graph_minors
         bigram1_seen = False
@@ -173,7 +171,7 @@ class PhrasesCommon(PhrasesData):
         self.assertTrue(self.bigram2 in self.bigram[self.sentences[-1]])
         self.assertTrue(self.bigram3 in self.bigram[self.sentences[-1]])
 
-    def testBigramConstructionFromGenerator(self):
+    def test_bigram_construction_from_generator(self):
         """Test Phrases bigram construction building when corpus is a generator."""
         bigram1_seen = False
         bigram2_seen = False
@@ -187,7 +185,7 @@ class PhrasesCommon(PhrasesData):
                 break
         self.assertTrue(bigram1_seen and bigram2_seen)
 
-    def testBigramConstructionFromArray(self):
+    def test_bigram_construction_from_array(self):
         """Test Phrases bigram construction building when corpus is a numpy array."""
         bigram1_seen = False
         bigram2_seen = False
@@ -212,26 +210,28 @@ def dumb_scorer(worda_count, wordb_count, bigram_count, len_vocab, min_count, co
 
 class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
 
-    def testExportPhrases(self):
-        """Test Phrases bigram export phrases."""
-        bigram = Phrases(self.sentences, min_count = 1, threshold = 1, delimiter = ' ')
-        trigram = Phrases(bigram[self.sentences], min_count = 1, threshold = 1, delimiter = ' ')
+    def test_export_phrases(self):
+        """Test Phrases bigram and trigram export phrases."""
+        bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
+        trigram = Phrases(bigram[self.sentences], min_count=1, threshold=1, delimiter=' ')
         seen_bigrams = set(bigram.export_phrases().keys())
         seen_trigrams = set(trigram.export_phrases().keys())
+
         assert seen_bigrams == set([
             'human interface',
             'response time',
             'graph minors',
             'minors survey',
         ])
+
         assert seen_trigrams == set([
             'human interface',
             'graph minors survey',
         ])
 
-    def testFindPhrases(self):
+    def test_find_phrases(self):
         """Test Phrases bigram find phrases."""
-        bigram = Phrases(self.sentences, min_count = 1, threshold = 1, delimiter = ' ')
+        bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
         seen_bigrams = set(bigram.find_phrases(self.sentences).keys())
 
         assert seen_bigrams == set([
@@ -240,7 +240,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
             'human interface',
         ])
 
-    def testMultipleBigramsSingleEntry(self):
+    def test_multiple_bigrams_single_entry(self):
         """Test a single entry produces multiple bigrams."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface']]
@@ -248,7 +248,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
 
         assert seen_bigrams == {'graph minors', 'human interface'}
 
-    def testScoringDefault(self):
+    def test_scoring_default(self):
         """Test the default scoring, from the mikolov word2vec paper."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface']]
@@ -261,13 +261,13 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
 
     def test__getitem__(self):
         """Test Phrases[sentences] with a single sentence."""
-        bigram = Phrases(self.sentences, min_count = 1, threshold = 1)
+        bigram = Phrases(self.sentences, min_count=1, threshold=1)
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface']]
         phrased_sentence = next(bigram[test_sentences].__iter__())
 
         assert phrased_sentence == ['graph_minors', 'survey', 'human_interface']
 
-    def testScoringNpmi(self):
+    def test_scoring_npmi(self):
         """Test normalized pointwise mutual information scoring."""
         bigram = Phrases(self.sentences, min_count=1, threshold=.5, scoring='npmi')
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface']]
@@ -278,7 +278,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
             .714  # score for human interface
         }
 
-    def testCustomScorer(self):
+    def test_custom_scorer(self):
         """Test using a custom scoring function."""
         bigram = Phrases(self.sentences, min_count=1, threshold=.001, scoring=dumb_scorer)
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
@@ -287,7 +287,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
         assert all(score == 1 for score in seen_scores)
         assert len(seen_scores) == 3  # 'graph minors' and 'survey human' and 'interface system'
 
-    def testBadParameters(self):
+    def test_bad_parameters(self):
         """Test the phrases module with bad parameters."""
         # should fail with something less or equal than 0
         self.assertRaises(ValueError, Phrases, self.sentences, min_count=0)
@@ -295,16 +295,18 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
         # threshold should be positive
         self.assertRaises(ValueError, Phrases, self.sentences, threshold=-1)
 
-    def testPruning(self):
+    def test_pruning(self):
         """Test that max_vocab_size parameter is respected."""
         bigram = Phrases(self.sentences, max_vocab_size=5)
         self.assertTrue(len(bigram.vocab) <= 5)
+
+
 # endclass TestPhrasesModel
 
 
 class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
 
-    def testSaveLoadCustomScorer(self):
+    def test_save_load_custom_scorer(self):
         """Test saving and loading a Phrases object with a custom scorer."""
         with temporary_file("test.pkl") as fpath:
             bigram = Phrases(self.sentences, min_count=1, threshold=.001, scoring=dumb_scorer)
@@ -316,7 +318,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
             assert all(score == 1 for score in seen_scores)
             assert len(seen_scores) == 3  # 'graph minors' and 'survey human' and 'interface system'
 
-    def testSaveLoad(self):
+    def test_save_load(self):
         """Test saving and loading a Phrases object."""
         with temporary_file("test.pkl") as fpath:
             bigram = Phrases(self.sentences, min_count=1, threshold=1)
@@ -330,7 +332,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
                 3.444  # score for human interface
             ])
 
-    def testSaveLoadStringScoring(self):
+    def test_save_load_string_scoring(self):
         """Test backwards compatibility with a previous version of Phrases with custom scoring."""
         bigram_loaded = Phrases.load(datapath("phrases-scoring-str.pkl"))
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
@@ -341,7 +343,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
             3.444  # score for human interface
         ])
 
-    def testSaveLoadNoScoring(self):
+    def test_save_load_no_scoring(self):
         """Test backwards compatibility with old versions of Phrases with no scoring parameter."""
         bigram_loaded = Phrases.load(datapath("phrases-no-scoring.pkl"))
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
@@ -352,7 +354,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
             3.444  # score for human interface
         ])
 
-    def testSaveLoadNoCommonTerms(self):
+    def test_save_load_no_common_terms(self):
         """Ensure backwards compatibility with old versions of Phrases, before connector_words."""
         bigram_loaded = Phrases.load(datapath("phrases-no-common-terms.pkl"))
         self.assertEqual(bigram_loaded.connector_words, frozenset())
@@ -363,7 +365,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
 
 class TestFrozenPhrasesPersistence(PhrasesData, unittest.TestCase):
 
-    def testSaveLoadCustomScorer(self):
+    def test_save_load_custom_scorer(self):
         """Test saving and loading a FrozenPhrases object with a custom scorer."""
 
         with temporary_file("test.pkl") as fpath:
@@ -373,7 +375,7 @@ class TestFrozenPhrasesPersistence(PhrasesData, unittest.TestCase):
             bigram_loaded = FrozenPhrases.load(fpath)
             self.assertEqual(bigram_loaded.scoring, dumb_scorer)
 
-    def testSaveLoad(self):
+    def test_save_load(self):
         """Test saving and loading a FrozenPhrases object."""
         with temporary_file("test.pkl") as fpath:
             bigram = FrozenPhrases(Phrases(self.sentences, min_count=1, threshold=1))
@@ -383,21 +385,21 @@ class TestFrozenPhrasesPersistence(PhrasesData, unittest.TestCase):
                 bigram_loaded[['graph', 'minors', 'survey', 'human', 'interface', 'system']],
                 ['graph_minors', 'survey', 'human_interface', 'system'])
 
-    def testSaveLoadStringScoring(self):
+    def test_save_load_string_scoring(self):
         """Test saving and loading a FrozenPhrases object with a string scoring parameter.
         This should ensure backwards compatibility with the previous version of FrozenPhrases"""
         bigram_loaded = FrozenPhrases.load(datapath("phraser-scoring-str.pkl"))
         # we do not much with scoring, just verify its the one expected
         self.assertEqual(bigram_loaded.scoring, original_scorer)
 
-    def testSaveLoadNoScoring(self):
+    def test_save_load_no_scoring(self):
         """Test saving and loading a FrozenPhrases object with no scoring parameter.
         This should ensure backwards compatibility with old versions of FrozenPhrases"""
         bigram_loaded = FrozenPhrases.load(datapath("phraser-no-scoring.pkl"))
         # we do not much with scoring, just verify its the one expected
         self.assertEqual(bigram_loaded.scoring, original_scorer)
 
-    def testSaveLoadNoCommonTerms(self):
+    def test_save_load_no_common_terms(self):
         """Ensure backwards compatibility with old versions of FrozenPhrases, before connector_words."""
         bigram_loaded = FrozenPhrases.load(datapath("phraser-no-common-terms.pkl"))
         self.assertEqual(bigram_loaded.connector_words, frozenset())
@@ -447,10 +449,12 @@ class CommonTermsPhrasesData:
 class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
     """Test Phrases models with connector words."""
 
-    def testExportPhrases(self):
+    def test_export_phrases(self):
         """Test Phrases bigram export phrases."""
-        bigram = Phrases(self.sentences, min_count = 1, threshold = 1, delimiter = ' ')
+        bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
+        trigram = Phrases(bigram[self.sentences], min_count=1, threshold=1, delimiter=' ')
         seen_bigrams = set(bigram.export_phrases().keys())
+
         assert seen_bigrams == set([
             'and graph',
             'data and',
@@ -462,7 +466,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             'of trees',
         ])
 
-    def testMultipleBigramsSingleEntry(self):
+    def test_multiple_bigrams_single_entry(self):
         """Test a single entry produces multiple bigrams."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=self.connector_words, delimiter=' ')
         test_sentences = [['data', 'and', 'graph', 'survey', 'for', 'human', 'interface']]
@@ -473,9 +477,9 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             'human interface',
         ])
 
-    def testFindPhrases(self):
-        """Test Phrases bigram find phrases."""
-        bigram = Phrases(self.sentences, min_coun = 1, threshold = 1, connector_words = self.connector_words, delimiter = ' ')
+    def test_find_phrases(self):
+        """Test Phrases bigram export phrases."""
+        bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=self.connector_words, delimiter=' ')
         seen_bigrams = set(bigram.find_phrases(self.sentences).keys())
 
         assert seen_bigrams == set([
@@ -485,7 +489,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             'lack of interest',
         ])
 
-    def testScoringDefault(self):
+    def test_scoring_default(self):
         """ test the default scoring, from the mikolov word2vec paper """
         bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=self.connector_words)
         test_sentences = [['data', 'and', 'graph', 'survey', 'for', 'human', 'interface']]
@@ -507,7 +511,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             round((human_interface - min_count) / human / interface * len_vocab, 3),
         ])
 
-    def testScoringNpmi(self):
+    def test_scoring_npmi(self):
         """Test normalized pointwise mutual information scoring."""
         bigram = Phrases(
             self.sentences, min_count=1, threshold=.5,
@@ -521,7 +525,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             .894  # score for human interface
         ])
 
-    def testCustomScorer(self):
+    def test_custom_scorer(self):
         """Test using a custom scoring function."""
         bigram = Phrases(
             self.sentences, min_count=1, threshold=.001,
@@ -544,7 +548,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
 
 class TestFrozenPhrasesModelCompatibilty(unittest.TestCase):
 
-    def testCompatibilty(self):
+    def test_compatibilty(self):
         phrases = Phrases.load(datapath("phrases-3.6.0.model"))
         phraser = FrozenPhrases.load(datapath("phraser-3.6.0.model"))
         test_sentences = ['trees', 'graph', 'minors']


### PR DESCRIPTION
Fixes #3031: Fix runtime error caused by iterating over iterable view.

Wanted to report a possible bug in phrases.py when trying to use the export_phrases function.  


RuntimeError                              Traceback (most recent call last)
<ipython-input-104-d9bc81fbba62> in <module>
----> 1 trigram.export_phrases()

~\Anaconda3\lib\site-packages\gensim\models\phrases.py in export_phrases(self)
    716         """
    717         result, source_vocab = {}, self.vocab
--> 718         for token in source_vocab:
    719             unigrams = token.split(self.delimiter)
    720             if len(unigrams) < 2:

RuntimeError: dictionary changed size during iteration


**Solution**

Instead of iterating over a dict  , iterate over the copy of the dict. 