### PR TITLE
transformed camelCase to snake_case test names

### DIFF
--- a/gensim/test/test_aggregation.py
+++ b/gensim/test/test_aggregation.py
@@ -18,7 +18,7 @@ class TestAggregation(unittest.TestCase):
     def setUp(self):
         self.confirmed_measures = [1.1, 2.2, 3.3, 4.4]
 
-    def testArithmeticMean(self):
+    def test_arithmetic_mean(self):
         """Test arithmetic_mean()"""
         obtained = aggregation.arithmetic_mean(self.confirmed_measures)
         expected = 2.75

--- a/gensim/test/test_atmodel.py
+++ b/gensim/test/test_atmodel.py
@@ -70,7 +70,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         self.class_ = atmodel.AuthorTopicModel
         self.model = self.class_(corpus, id2word=dictionary, author2doc=author2doc, num_topics=2, passes=100)
 
-    def testTransform(self):
+    def test_transform(self):
         passed = False
         # sometimes, training gets stuck at a local minimum
         # in that case try re-training the model from scratch, hoping for a
@@ -99,7 +99,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
             )
         self.assertTrue(passed)
 
-    def testBasic(self):
+    def test_basic(self):
         # Check that training the model produces a positive topic vector for some author
         # Otherwise, many of the other tests are invalid.
 
@@ -109,7 +109,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         jill_topics = matutils.sparse2full(jill_topics, model.num_topics)
         self.assertTrue(all(jill_topics > 0))
 
-    def testEmptyDocument(self):
+    def test_empty_document(self):
         local_texts = common_texts + [['only_occurs_once_in_corpus_and_alone_in_doc']]
         dictionary = Dictionary(local_texts)
         dictionary.filter_extremes(no_below=2)
@@ -119,7 +119,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
 
         self.class_(corpus, author2doc=a2d, id2word=dictionary, num_topics=2)
 
-    def testAuthor2docMissing(self):
+    def test_author2doc_missing(self):
         # Check that the results are the same if author2doc is constructed automatically from doc2author.
         model = self.class_(
             corpus, author2doc=author2doc, doc2author=doc2author,
@@ -137,7 +137,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         jill_topics2 = matutils.sparse2full(jill_topics2, model.num_topics)
         self.assertTrue(np.allclose(jill_topics, jill_topics2))
 
-    def testDoc2authorMissing(self):
+    def test_doc2author_missing(self):
         # Check that the results are the same if doc2author is constructed automatically from author2doc.
         model = self.class_(
             corpus, author2doc=author2doc, doc2author=doc2author,
@@ -155,7 +155,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         jill_topics2 = matutils.sparse2full(jill_topics2, model.num_topics)
         self.assertTrue(np.allclose(jill_topics, jill_topics2))
 
-    def testUpdate(self):
+    def test_update(self):
         # Check that calling update after the model already has been trained works.
         model = self.class_(corpus, author2doc=author2doc, id2word=dictionary, num_topics=2)
 
@@ -169,7 +169,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # Did we learn something?
         self.assertFalse(all(np.equal(jill_topics, jill_topics2)))
 
-    def testUpdateNewDataOldAuthor(self):
+    def test_update_new_data_old_author(self):
         # Check that calling update with new documents and/or authors after the model already has
         # been trained works.
         # Test an author that already existed in the old dataset.
@@ -185,7 +185,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # Did we learn more about Jill?
         self.assertFalse(all(np.equal(jill_topics, jill_topics2)))
 
-    def testUpdateNewDataNewAuthor(self):
+    def test_update_new_data_new_author(self):
         # Check that calling update with new documents and/or authors after the model already has
         # been trained works.
         # Test a new author, that didn't exist in the old dataset.
@@ -198,7 +198,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         sally_topics = matutils.sparse2full(sally_topics, model.num_topics)
         self.assertTrue(all(sally_topics > 0))
 
-    def testSerialized(self):
+    def test_serialized(self):
         # Test the model using serialized corpora. Basic tests, plus test of update functionality.
 
         model = self.class_(
@@ -227,7 +227,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # Delete the MmCorpus used for serialization inside the author-topic model.
         remove(datapath('testcorpus_serialization.mm'))
 
-    def testTransformSerialized(self):
+    def test_transform_serialized(self):
         # Same as testTransform, using serialized corpora.
         passed = False
         # sometimes, training gets stuck at a local minimum
@@ -263,7 +263,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
             )
         self.assertTrue(passed)
 
-    def testAlphaAuto(self):
+    def test_alpha_auto(self):
         model1 = self.class_(
             corpus, author2doc=author2doc, id2word=dictionary,
             alpha='symmetric', passes=10, num_topics=2
@@ -276,7 +276,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # did we learn something?
         self.assertFalse(all(np.equal(model1.alpha, modelauto.alpha)))
 
-    def testAlpha(self):
+    def test_alpha(self):
         kwargs = dict(
             author2doc=author2doc,
             id2word=dictionary,
@@ -331,7 +331,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         kwargs['alpha'] = "gensim is cool"
         self.assertRaises(ValueError, self.class_, **kwargs)
 
-    def testEtaAuto(self):
+    def test_eta_auto(self):
         model1 = self.class_(
             corpus, author2doc=author2doc, id2word=dictionary,
             eta='symmetric', passes=10, num_topics=2
@@ -344,7 +344,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # did we learn something?
         self.assertFalse(all(np.equal(model1.eta, modelauto.eta)))
 
-    def testEta(self):
+    def test_eta(self):
         kwargs = dict(
             author2doc=author2doc,
             id2word=dictionary,
@@ -405,7 +405,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         kwargs['eta'] = "asymmetric"
         self.assertRaises(ValueError, self.class_, **kwargs)
 
-    def testTopTopics(self):
+    def test_top_topics(self):
         top_topics = self.model.top_topics(corpus)
 
         for topic, score in top_topics:
@@ -416,14 +416,14 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
                 self.assertTrue(isinstance(k, str))
                 self.assertTrue(isinstance(v, float))
 
-    def testGetTopicTerms(self):
+    def test_get_topic_terms(self):
         topic_terms = self.model.get_topic_terms(1)
 
         for k, v in topic_terms:
             self.assertTrue(isinstance(k, numbers.Integral))
             self.assertTrue(isinstance(v, float))
 
-    def testGetAuthorTopics(self):
+    def test_get_author_topics(self):
 
         model = self.class_(
             corpus, author2doc=author2doc, id2word=dictionary, num_topics=2,
@@ -440,7 +440,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
                 self.assertTrue(isinstance(k, int))
                 self.assertTrue(isinstance(v, float))
 
-    def testTermTopics(self):
+    def test_term_topics(self):
 
         model = self.class_(
             corpus, author2doc=author2doc, id2word=dictionary, num_topics=2,
@@ -459,7 +459,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
             self.assertTrue(isinstance(topic_no, int))
             self.assertTrue(isinstance(probability, float))
 
-    def testNewAuthorTopics(self):
+    def test_new_author_topics(self):
 
         model = self.class_(
             corpus, author2doc=author2doc, id2word=dictionary, num_topics=2,
@@ -498,7 +498,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         self.assertEqual(id2author_len, len(model.id2author))
         self.assertEqual(doc2author_len, len(model.doc2author))
 
-    def testPasses(self):
+    def test_passes(self):
         # long message includes the original error message with a custom one
         self.longMessage = True
         # construct what we expect when passes aren't involved
@@ -526,7 +526,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
             self.assertEqual(model.state.numdocs, len(corpus) * len(test_rhots))
             self.assertEqual(model.num_updates, len(corpus) * len(test_rhots))
 
-    def testPersistence(self):
+    def test_persistence(self):
         fname = get_tmpfile('gensim_models_atmodel.tst')
         model = self.model
         model.save(fname)
@@ -535,7 +535,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         self.assertTrue(np.allclose(model.expElogbeta, model2.expElogbeta))
         self.assertTrue(np.allclose(model.state.gamma, model2.state.gamma))
 
-    def testPersistenceIgnore(self):
+    def test_persistence_ignore(self):
         fname = get_tmpfile('gensim_models_atmodel_testPersistenceIgnore.tst')
         model = atmodel.AuthorTopicModel(corpus, author2doc=author2doc, num_topics=2)
         model.save(fname, ignore='id2word')
@@ -546,7 +546,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         model2 = atmodel.AuthorTopicModel.load(fname)
         self.assertTrue(model2.id2word is None)
 
-    def testPersistenceCompressed(self):
+    def test_persistence_compressed(self):
         fname = get_tmpfile('gensim_models_atmodel.tst.gz')
         model = self.model
         model.save(fname)
@@ -561,7 +561,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         jill_topics2 = matutils.sparse2full(jill_topics2, model.num_topics)
         self.assertTrue(np.allclose(jill_topics, jill_topics2))
 
-    def testLargeMmap(self):
+    def test_large_mmap(self):
         fname = get_tmpfile('gensim_models_atmodel.tst')
         model = self.model
 
@@ -581,7 +581,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         jill_topics2 = matutils.sparse2full(jill_topics2, model.num_topics)
         self.assertTrue(np.allclose(jill_topics, jill_topics2))
 
-    def testLargeMmapCompressed(self):
+    def test_large_mmap_compressed(self):
         fname = get_tmpfile('gensim_models_atmodel.tst.gz')
         model = self.model
 
@@ -591,7 +591,7 @@ class TestAuthorTopicModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # test loading the large model arrays with mmap
         self.assertRaises(IOError, self.class_.load, fname, mmap='r')
 
-    def testDtypeBackwardCompatibility(self):
+    def test_dtype_backward_compatibility(self):
         atmodel_3_0_1_fname = datapath('atmodel_3_0_1_model')
         expected_topics = [(0, 0.068200842977296727), (1, 0.93179915702270333)]
 

--- a/gensim/test/test_big.py
+++ b/gensim/test/test_big.py
@@ -43,7 +43,7 @@ if os.environ.get('GENSIM_BIG', False):
     class TestLargeData(unittest.TestCase):
         """Try common operations, using large models. You'll need ~8GB RAM to run these tests"""
 
-        def testWord2Vec(self):
+        def test_word2vec(self):
             corpus = BigCorpus(words_only=True, num_docs=100000, num_terms=3000000, doc_len=200)
             tmpf = get_tmpfile('gensim_big.tst')
             model = gensim.models.Word2Vec(corpus, vector_size=300, workers=4)
@@ -51,7 +51,7 @@ if os.environ.get('GENSIM_BIG', False):
             del model
             gensim.models.Word2Vec.load(tmpf)
 
-        def testLsiModel(self):
+        def test_lsi_model(self):
             corpus = BigCorpus(num_docs=50000)
             tmpf = get_tmpfile('gensim_big.tst')
             model = gensim.models.LsiModel(corpus, num_topics=500, id2word=corpus.dictionary)
@@ -59,7 +59,7 @@ if os.environ.get('GENSIM_BIG', False):
             del model
             gensim.models.LsiModel.load(tmpf)
 
-        def testLdaModel(self):
+        def test_lda_model(self):
             corpus = BigCorpus(num_docs=5000)
             tmpf = get_tmpfile('gensim_big.tst')
             model = gensim.models.LdaModel(corpus, num_topics=500, id2word=corpus.dictionary)

--- a/gensim/test/test_corpora_dictionary.py
+++ b/gensim/test/test_corpora_dictionary.py
@@ -26,13 +26,13 @@ class TestDictionary(unittest.TestCase):
     def setUp(self):
         self.texts = common_texts
 
-    def testDocFreqOneDoc(self):
+    def test_doc_freq_one_doc(self):
         texts = [['human', 'interface', 'computer']]
         d = Dictionary(texts)
         expected = {0: 1, 1: 1, 2: 1}
         self.assertEqual(d.dfs, expected)
 
-    def testDocFreqAndToken2IdForSeveralDocsWithOneWord(self):
+    def test_doc_freq_and_token2id_for_several_docs_with_one_word(self):
         # two docs
         texts = [['human'], ['human']]
         d = Dictionary(texts)
@@ -60,7 +60,7 @@ class TestDictionary(unittest.TestCase):
         expected = {'human': 0}
         self.assertEqual(d.token2id, expected)
 
-    def testDocFreqForOneDocWithSeveralWord(self):
+    def test_doc_freq_for_one_doc_with_several_word(self):
         # two words
         texts = [['human', 'cat']]
         d = Dictionary(texts)
@@ -73,7 +73,7 @@ class TestDictionary(unittest.TestCase):
         expected = {0: 1, 1: 1, 2: 1}
         self.assertEqual(d.dfs, expected)
 
-    def testDocFreqAndCollectionFreq(self):
+    def test_doc_freq_and_collection_freq(self):
         # one doc
         texts = [['human', 'human', 'human']]
         d = Dictionary(texts)
@@ -92,7 +92,7 @@ class TestDictionary(unittest.TestCase):
         self.assertEqual(d.cfs, {0: 3})
         self.assertEqual(d.dfs, {0: 3})
 
-    def testBuild(self):
+    def test_build(self):
         d = Dictionary(self.texts)
 
         # Since we don't specify the order in which dictionaries are built,
@@ -110,7 +110,7 @@ class TestDictionary(unittest.TestCase):
         self.assertEqual(sorted(d.token2id.keys()), expected_keys)
         self.assertEqual(sorted(d.token2id.values()), expected_values)
 
-    def testMerge(self):
+    def test_merge(self):
         d = Dictionary(self.texts)
         f = Dictionary(self.texts[:3])
         g = Dictionary(self.texts[3:])
@@ -118,7 +118,7 @@ class TestDictionary(unittest.TestCase):
         f.merge_with(g)
         self.assertEqual(sorted(d.token2id.keys()), sorted(f.token2id.keys()))
 
-    def testFilter(self):
+    def test_filter(self):
         d = Dictionary(self.texts)
         d.filter_extremes(no_below=2, no_above=1.0, keep_n=4)
         dfs_expected = {0: 3, 1: 3, 2: 3, 3: 3}
@@ -161,13 +161,13 @@ class TestDictionary(unittest.TestCase):
         expected = {'graph', 'trees', 'system', 'user', 'worda'}
         self.assertEqual(set(d.token2id.keys()), expected)
 
-    def testFilterMostFrequent(self):
+    def test_filter_most_frequent(self):
         d = Dictionary(self.texts)
         d.filter_n_most_frequent(4)
         expected = {0: 2, 1: 2, 2: 2, 3: 2, 4: 2, 5: 2, 6: 2, 7: 2}
         self.assertEqual(d.dfs, expected)
 
-    def testFilterTokens(self):
+    def test_filter_tokens(self):
         self.maxDiff = 10000
         d = Dictionary(self.texts)
 

--- a/gensim/test/test_corpora_hashdictionary.py
+++ b/gensim/test/test_corpora_hashdictionary.py
@@ -21,13 +21,13 @@ class TestHashDictionary(unittest.TestCase):
     def setUp(self):
         self.texts = common_texts
 
-    def testDocFreqOneDoc(self):
+    def test_doc_freq_one_doc(self):
         texts = [['human', 'interface', 'computer']]
         d = HashDictionary(texts, myhash=zlib.adler32)
         expected = {10608: 1, 12466: 1, 31002: 1}
         self.assertEqual(d.dfs, expected)
 
-    def testDocFreqAndToken2IdForSeveralDocsWithOneWord(self):
+    def test_doc_freq_and_token2id_for_several_docs_with_one_word(self):
         # two docs
         texts = [['human'], ['human']]
         d = HashDictionary(texts, myhash=zlib.adler32)
@@ -58,7 +58,7 @@ class TestHashDictionary(unittest.TestCase):
         self.assertEqual(d.token2id['human'], expected['human'])
         self.assertEqual(d.token2id.keys(), expected.keys())
 
-    def testDocFreqForOneDocWithSeveralWord(self):
+    def test_doc_freq_for_one_doc_with_several_word(self):
         # two words
         texts = [['human', 'cat']]
         d = HashDictionary(texts, myhash=zlib.adler32)
@@ -71,7 +71,7 @@ class TestHashDictionary(unittest.TestCase):
         expected = {9273: 1, 15001: 1, 31002: 1}
         self.assertEqual(d.dfs, expected)
 
-    def testDebugMode(self):
+    def test_debug_mode(self):
         # two words
         texts = [['human', 'cat']]
         d = HashDictionary(texts, debug=True, myhash=zlib.adler32)
@@ -84,7 +84,7 @@ class TestHashDictionary(unittest.TestCase):
         expected = {}
         self.assertEqual(d.id2token, expected)
 
-    def testRange(self):
+    def test_range(self):
         # all words map to the same id
         d = HashDictionary(self.texts, id_range=1, debug=True)
         dfs = {0: 9}
@@ -118,7 +118,7 @@ class TestHashDictionary(unittest.TestCase):
         self.assertEqual(d.id2token, id2token)
         self.assertEqual(d.token2id, token2id)
 
-    def testBuild(self):
+    def test_build(self):
         d = HashDictionary(self.texts, myhash=zlib.adler32)
         expected = {
             5232: 2, 5798: 3, 10608: 2, 12466: 2, 12736: 3, 15001: 2,
@@ -135,7 +135,7 @@ class TestHashDictionary(unittest.TestCase):
         for ex in expected:
             self.assertEqual(d.token2id[ex], expected[ex])
 
-    def testFilter(self):
+    def test_filter(self):
         d = HashDictionary(self.texts, myhash=zlib.adler32)
         d.filter_extremes()
         expected = {}

--- a/gensim/test/test_direct_confirmation.py
+++ b/gensim/test/test_direct_confirmation.py
@@ -31,7 +31,7 @@ class TestDirectConfirmationMeasure(unittest.TestCase):
         self.accumulator._inverted_index = {0: {2, 3, 4}, 1: {3, 5}}
         self.accumulator._num_docs = self.num_docs
 
-    def testLogConditionalProbability(self):
+    def test_log_conditional_probability(self):
         """Test log_conditional_probability()"""
         obtained = direct_confirmation_measure.log_conditional_probability(
             self.segmentation, self.accumulator)[0]
@@ -44,7 +44,7 @@ class TestDirectConfirmationMeasure(unittest.TestCase):
         self.assertAlmostEqual(expected, mean)
         self.assertEqual(0.0, std)
 
-    def testLogRatioMeasure(self):
+    def test_log_ratio_measure(self):
         """Test log_ratio_measure()"""
         obtained = direct_confirmation_measure.log_ratio_measure(
             self.segmentation, self.accumulator)[0]
@@ -57,7 +57,7 @@ class TestDirectConfirmationMeasure(unittest.TestCase):
         self.assertAlmostEqual(expected, mean)
         self.assertEqual(0.0, std)
 
-    def testNormalizedLogRatioMeasure(self):
+    def test_normalized_log_ratio_measure(self):
         """Test normalized_log_ratio_measure()"""
         obtained = direct_confirmation_measure.log_ratio_measure(
             self.segmentation, self.accumulator, normalize=True)[0]

--- a/gensim/test/test_doc2vec.py
+++ b/gensim/test/test_doc2vec.py
@@ -78,7 +78,7 @@ class TestDoc2VecModel(unittest.TestCase):
             model.save(tmpf)
             self.models_equal(model, doc2vec.Doc2Vec.load(tmpf))
 
-    def testPersistenceWord2VecFormat(self):
+    def test_persistence_word2vec_format(self):
         """Test storing the entire model in word2vec format."""
         model = doc2vec.Doc2Vec(DocsLeeCorpus(), min_count=1)
         # test saving both document and word embedding
@@ -201,7 +201,7 @@ class TestDoc2VecModel(unittest.TestCase):
         sims_to_infer = loaded_model.dv.most_similar([doc0_inferred], topn=len(loaded_model.dv))
         self.assertTrue(sims_to_infer)
 
-    def testDoc2vecTrainParameters(self):
+    def test_doc2vec_train_parameters(self):
 
         model = doc2vec.Doc2Vec(vector_size=50)
         model.build_vocab(corpus_iterable=list_corpus)
@@ -653,7 +653,7 @@ class TestDoc2VecModel(unittest.TestCase):
             vector *= 0
 
     @log_capture()
-    def testBuildVocabWarning(self, loglines):
+    def test_build_vocab_warning(self, loglines):
         """Test if logger warning is raised on non-ideal input to a doc2vec model"""
         raw_sentences = ['human', 'machine']
         sentences = [doc2vec.TaggedDocument(words, [i]) for i, words in enumerate(raw_sentences)]
@@ -663,7 +663,7 @@ class TestDoc2VecModel(unittest.TestCase):
         self.assertTrue(warning in str(loglines))
 
     @log_capture()
-    def testTrainWarning(self, loglines):
+    def test_train_warning(self, loglines):
         """Test if warning is raised if alpha rises during subsequent calls to train()"""
         raw_sentences = [['human'],
                          ['graph', 'trees']]
@@ -679,7 +679,7 @@ class TestDoc2VecModel(unittest.TestCase):
         warning = "Effective 'alpha' higher than previous training cycles"
         self.assertTrue(warning in str(loglines))
 
-    def testLoadOnClassError(self):
+    def test_load_on_class_error(self):
         """Test if exception is raised when loading doc2vec model on instance"""
         self.assertRaises(AttributeError, load_on_instance)
 # endclass TestDoc2VecModel

--- a/gensim/test/test_dtm.py
+++ b/gensim/test/test_dtm.py
@@ -26,7 +26,7 @@ class TestDtmModel(unittest.TestCase):
         if not self.dtm_path:
             self.skipTest("$DTM_PATH is not properly set up.")
 
-    def testDtm(self):
+    def test_dtm(self):
         if self.dtm_path is not None:
             model = gensim.models.wrappers.DtmModel(
                 self.dtm_path, self.corpus, self.time_slices, num_topics=2,
@@ -40,7 +40,7 @@ class TestDtmModel(unittest.TestCase):
             self.assertEqual(len(one_topic), 10)
             self.assertEqual(one_topic[0][1], u'idexx')
 
-    def testDim(self):
+    def test_dim(self):
         if self.dtm_path is not None:
             model = gensim.models.wrappers.DtmModel(
                 self.dtm_path, self.corpus, self.time_slices, num_topics=2,
@@ -55,7 +55,7 @@ class TestDtmModel(unittest.TestCase):
             self.assertEqual(one_topic[0][1], u'skills')
 
     # In stderr expect "Error opening file /tmp/a65419_train_out/initial-lda-ss.dat. Failing."
-    def testCalledProcessError(self):
+    def test_called_process_error(self):
         if self.dtm_path is not None:
             with self.assertRaises(CalledProcessError):
                 gensim.models.wrappers.DtmModel(

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -94,7 +94,7 @@ class TestFastTextModel(unittest.TestCase):
         oov_vec = model.wv['minor']  # oov word
         self.assertEqual(len(oov_vec), 12)
 
-    def testFastTextTrainParameters(self):
+    def test_fast_text_train_parameters(self):
 
         model = FT_gensim(vector_size=12, min_count=1, hs=1, negative=0, seed=42, workers=1, bucket=BUCKET)
         model.build_vocab(corpus_iterable=sentences)

--- a/gensim/test/test_glove2word2vec.py
+++ b/gensim/test/test_glove2word2vec.py
@@ -23,7 +23,7 @@ class TestGlove2Word2Vec(unittest.TestCase):
         self.datapath = datapath('test_glove.txt')
         self.output_file = get_tmpfile('glove2word2vec.test')
 
-    def testConversion(self):
+    def test_conversion(self):
         check_output(args=[
             sys.executable, '-m', 'gensim.scripts.glove2word2vec',
             '--input', self.datapath, '--output', self.output_file

--- a/gensim/test/test_hdpmodel.py
+++ b/gensim/test/test_hdpmodel.py
@@ -29,7 +29,7 @@ class TestHdpModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         self.class_ = hdpmodel.HdpModel
         self.model = self.class_(corpus, id2word=dictionary, random_state=np.random.seed(0))
 
-    def testTopicValues(self):
+    def test_topic_values(self):
         """
         Check show topics method
         """
@@ -42,7 +42,7 @@ class TestHdpModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
 
         return
 
-    def testLDAmodel(self):
+    def test_ldamodel(self):
         """
         Create ldamodel object, and check if the corresponding alphas are equal.
         """

--- a/gensim/test/test_indirect_confirmation.py
+++ b/gensim/test/test_indirect_confirmation.py
@@ -31,7 +31,7 @@ class TestIndirectConfirmation(unittest.TestCase):
         self.dictionary = Dictionary()
         self.dictionary.id2token = {1: 'fake', 2: 'tokens'}
 
-    def testCosineSimilarity(self):
+    def test_cosine_similarity(self):
         """Test cosine_similarity()"""
         accumulator = text_analysis.InvertedIndexAccumulator({1, 2}, self.dictionary)
         accumulator._inverted_index = {0: {2, 3, 4}, 1: {3, 5}}
@@ -55,7 +55,7 @@ class TestIndirectConfirmation(unittest.TestCase):
         self.assertAlmostEqual(expected, mean, 4)
         self.assertAlmostEqual(0.0, std, 1)
 
-    def testWord2VecSimilarity(self):
+    def test_word2vec_similarity(self):
         """Sanity check word2vec_similarity."""
         accumulator = text_analysis.WordVectorsAccumulator({1, 2}, self.dictionary)
         accumulator.accumulate([

--- a/gensim/test/test_lda_callback.py
+++ b/gensim/test/test_lda_callback.py
@@ -35,7 +35,7 @@ class TestLdaCallback(unittest.TestCase):
         self.host = "http://localhost"
         self.port = 8097
 
-    def testCallbackUpdateGraph(self):
+    def test_callback_update_graph(self):
         with subprocess.Popen(['python', '-m', 'visdom.server', '-port', str(self.port)]) as proc:
             # wait for visdom server startup (any better way?)
             viz = Visdom(server=self.host, port=self.port)

--- a/gensim/test/test_ldamodel.py
+++ b/gensim/test/test_ldamodel.py
@@ -29,7 +29,7 @@ dictionary = Dictionary(common_texts)
 corpus = [dictionary.doc2bow(text) for text in common_texts]
 
 
-def testRandomState():
+def test_random_state():
     testcases = [np.random.seed(0), None, np.random.RandomState(0), 0]
     for testcase in testcases:
         assert(isinstance(utils.get_random_state(testcase), np.random.RandomState))
@@ -41,7 +41,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         self.class_ = ldamodel.LdaModel
         self.model = self.class_(corpus, id2word=dictionary, num_topics=2, passes=100)
 
-    def testTransform(self):
+    def test_transform(self):
         passed = False
         # sometimes, LDA training gets stuck at a local minimum
         # in that case try re-training the model from scratch, hoping for a
@@ -66,14 +66,14 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
             )
         self.assertTrue(passed)
 
-    def testAlphaAuto(self):
+    def test_alpha_auto(self):
         model1 = self.class_(corpus, id2word=dictionary, alpha='symmetric', passes=10)
         modelauto = self.class_(corpus, id2word=dictionary, alpha='auto', passes=10)
 
         # did we learn something?
         self.assertFalse(all(np.equal(model1.alpha, modelauto.alpha)))
 
-    def testAlpha(self):
+    def test_alpha(self):
         kwargs = dict(
             id2word=dictionary,
             num_topics=2,
@@ -127,14 +127,14 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         kwargs['alpha'] = "gensim is cool"
         self.assertRaises(ValueError, self.class_, **kwargs)
 
-    def testEtaAuto(self):
+    def test_eta_auto(self):
         model1 = self.class_(corpus, id2word=dictionary, eta='symmetric', passes=10)
         modelauto = self.class_(corpus, id2word=dictionary, eta='auto', passes=10)
 
         # did we learn something?
         self.assertFalse(np.allclose(model1.eta, modelauto.eta))
 
-    def testEta(self):
+    def test_eta(self):
         kwargs = dict(
             id2word=dictionary,
             num_topics=2,
@@ -194,7 +194,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         kwargs['eta'] = "asymmetric"
         self.assertRaises(ValueError, self.class_, **kwargs)
 
-    def testTopTopics(self):
+    def test_top_topics(self):
         top_topics = self.model.top_topics(self.corpus)
 
         for topic, score in top_topics:
@@ -205,7 +205,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
                 self.assertTrue(isinstance(k, str))
                 self.assertTrue(np.issubdtype(v, np.floating))
 
-    def testGetTopicTerms(self):
+    def test_get_topic_terms(self):
         topic_terms = self.model.get_topic_terms(1)
 
         for k, v in topic_terms:
@@ -213,7 +213,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
             self.assertTrue(np.issubdtype(v, np.floating))
 
     @unittest.skipIf(AZURE, 'see <https://github.com/RaRe-Technologies/gensim/pull/2836>')
-    def testGetDocumentTopics(self):
+    def test_get_document_topics(self):
 
         model = self.class_(
             self.corpus, id2word=dictionary, num_topics=2, passes=100, random_state=np.random.seed(0)
@@ -299,7 +299,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # self.assertEqual(word_topics[0][0], expected_word)
         # self.assertTrue(0 in word_topics[0][1])
 
-    def testTermTopics(self):
+    def test_term_topics(self):
 
         model = self.class_(
             self.corpus, id2word=dictionary, num_topics=2, passes=100, random_state=np.random.seed(0)
@@ -325,7 +325,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # FIXME: Fails on osx and win
         # self.assertTrue(1 in result[0])
 
-    def testPasses(self):
+    def test_passes(self):
         # long message includes the original error message with a custom one
         self.longMessage = True
         # construct what we expect when passes aren't involved
@@ -353,7 +353,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
             self.assertEqual(model.state.numdocs, len(corpus) * len(test_rhots))
             self.assertEqual(model.num_updates, len(corpus) * len(test_rhots))
 
-    # def testTopicSeeding(self):
+    # def test_topic_seeding(self):
     #     for topic in range(2):
     #         passed = False
     #         for i in range(5):  # restart at most this many times, to mitigate LDA randomness
@@ -386,7 +386,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
     #             logging.warning("LDA failed to converge on attempt %i (got %s)", i, topics)
     #         self.assertTrue(passed)
 
-    def testPersistence(self):
+    def test_persistence(self):
         fname = get_tmpfile('gensim_models_lda.tst')
         model = self.model
         model.save(fname)
@@ -396,7 +396,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         tstvec = []
         self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
-    def testModelCompatibilityWithPythonVersions(self):
+    def test_model_compatibility_with_python_versions(self):
         fname_model_2_7 = datapath('ldamodel_python_2_7')
         model_2_7 = self.class_.load(fname_model_2_7)
         fname_model_3_5 = datapath('ldamodel_python_3_5')
@@ -409,7 +409,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         id2word_3_5 = dict(model_3_5.id2word.iteritems())
         self.assertEqual(set(id2word_2_7.keys()), set(id2word_3_5.keys()))
 
-    def testPersistenceIgnore(self):
+    def test_persistence_ignore(self):
         fname = get_tmpfile('gensim_models_lda_testPersistenceIgnore.tst')
         model = ldamodel.LdaModel(self.corpus, num_topics=2)
         model.save(fname, ignore='id2word')
@@ -420,7 +420,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         model2 = ldamodel.LdaModel.load(fname)
         self.assertTrue(model2.id2word is None)
 
-    def testPersistenceCompressed(self):
+    def test_persistence_compressed(self):
         fname = get_tmpfile('gensim_models_lda.tst.gz')
         model = self.model
         model.save(fname)
@@ -430,7 +430,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         tstvec = []
         self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
-    def testLargeMmap(self):
+    def test_large_mmap(self):
         fname = get_tmpfile('gensim_models_lda.tst')
         model = self.model
 
@@ -445,7 +445,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         tstvec = []
         self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
-    def testLargeMmapCompressed(self):
+    def test_large_mmap_compressed(self):
         fname = get_tmpfile('gensim_models_lda.tst.gz')
         model = self.model
 
@@ -455,7 +455,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # test loading the large model arrays with mmap
         self.assertRaises(IOError, self.class_.load, fname, mmap='r')
 
-    def testRandomStateBackwardCompatibility(self):
+    def test_random_state_backward_compatibility(self):
         # load a model saved using a pre-0.13.2 version of Gensim
         pre_0_13_2_fname = datapath('pre_0_13_2_model')
         model_pre_0_13_2 = self.class_.load(pre_0_13_2_fname)
@@ -479,7 +479,7 @@ class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
             self.assertTrue(isinstance(i[0], int))
             self.assertTrue(isinstance(i[1], str))
 
-    def testDtypeBackwardCompatibility(self):
+    def test_dtype_backward_compatibility(self):
         lda_3_0_1_fname = datapath('lda_3_0_1_model')
         test_doc = [(0, 1), (1, 1), (2, 1)]
         expected_topics = [(0, 0.87005886977475178), (1, 0.12994113022524822)]
@@ -504,7 +504,7 @@ class TestLdaMulticore(TestLdaModel):
         self.model = self.class_(corpus, id2word=dictionary, num_topics=2, passes=100)
 
     # override LdaModel because multicore does not allow alpha=auto
-    def testAlphaAuto(self):
+    def test_alpha_auto(self):
         self.assertRaises(RuntimeError, self.class_, alpha='auto')
 
 

--- a/gensim/test/test_ldaseqmodel.py
+++ b/gensim/test/test_ldaseqmodel.py
@@ -209,7 +209,7 @@ class TestLdaSeq(unittest.TestCase):
         )
 
     # testing topic word proportions
-    def testTopicWord(self):
+    def test_topic_word(self):
 
         topics = self.ldaseq.print_topics(0)
         expected_topic_word = [('skills', 0.035999999999999997)]
@@ -217,12 +217,12 @@ class TestLdaSeq(unittest.TestCase):
         self.assertAlmostEqual(topics[0][0][1], expected_topic_word[0][1], places=2)
 
     # testing document-topic proportions
-    def testDocTopic(self):
+    def test_doc_topic(self):
         doc_topic = self.ldaseq.doc_topics(0)
         expected_doc_topic = 0.00066577896138482028
         self.assertAlmostEqual(doc_topic[0], expected_doc_topic, places=2)
 
-    def testDtypeBackwardCompatibility(self):
+    def test_dtype_backward_compatibility(self):
         ldaseq_3_0_1_fname = datapath('DTM/ldaseq_3_0_1_model')
         test_doc = [(547, 1), (549, 1), (552, 1), (555, 1)]
         expected_topics = [0.99751244, 0.00248756]

--- a/gensim/test/test_logentropy_model.py
+++ b/gensim/test/test_logentropy_model.py
@@ -37,7 +37,7 @@ class TestLogEntropyModel(unittest.TestCase):
         """Test creating a model using an empty input; should fail."""
         self.assertRaises(ValueError, logentropy_model.LogEntropyModel, corpus=self.corpus_empty)
 
-    def testTransform(self):
+    def test_transform(self):
         # create the transformation model
         model = logentropy_model.LogEntropyModel(self.corpus_ok, normalize=False)
 
@@ -52,7 +52,7 @@ class TestLogEntropyModel(unittest.TestCase):
         ]
         self.assertTrue(np.allclose(transformed, expected))
 
-    def testPersistence(self):
+    def test_persistence(self):
         fname = get_tmpfile('gensim_models_logentry.tst')
         model = logentropy_model.LogEntropyModel(self.corpus_ok, normalize=True)
         model.save(fname)
@@ -61,7 +61,7 @@ class TestLogEntropyModel(unittest.TestCase):
         tstvec = []
         self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))
 
-    def testPersistenceCompressed(self):
+    def test_persistence_compressed(self):
         fname = get_tmpfile('gensim_models_logentry.tst.gz')
         model = logentropy_model.LogEntropyModel(self.corpus_ok, normalize=True)
         model.save(fname)

--- a/gensim/test/test_lsimodel.py
+++ b/gensim/test/test_lsimodel.py
@@ -27,7 +27,7 @@ class TestLsiModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         self.corpus = MmCorpus(datapath('testcorpus.mm'))
         self.model = lsimodel.LsiModel(self.corpus, num_topics=2)
 
-    def testTransform(self):
+    def test_transform(self):
         """Test lsi[vector] transformation."""
         # create the transformation model
         model = self.model
@@ -44,7 +44,7 @@ class TestLsiModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # expected = np.array([-0.1973928, 0.05591352])  # non-scaled LSI version
         self.assertTrue(np.allclose(abs(vec), abs(expected)))  # transformed entries must be equal up to sign
 
-    def testTransformFloat32(self):
+    def test_transform_float32(self):
         """Test lsi[vector] transformation."""
         # create the transformation model
         model = lsimodel.LsiModel(self.corpus, num_topics=2, dtype=np.float32)
@@ -63,7 +63,7 @@ class TestLsiModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # transformed entries must be equal up to sign
         self.assertTrue(np.allclose(abs(vec), abs(expected), atol=1.e-5))
 
-    def testCorpusTransform(self):
+    def test_corpus_transform(self):
         """Test lsi[corpus] transformation."""
         model = self.model
         got = np.vstack([matutils.sparse2full(doc, 2) for doc in model[self.corpus]])
@@ -80,7 +80,7 @@ class TestLsiModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         ])
         self.assertTrue(np.allclose(abs(got), abs(expected)))  # must equal up to sign
 
-    def testOnlineTransform(self):
+    def test_online_transform(self):
         corpus = list(self.corpus)
         doc = corpus[0]  # use the corpus' first document for testing
 
@@ -116,7 +116,7 @@ class TestLsiModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # the two LSI representations must equal up to sign
         self.assertTrue(np.allclose(abs(vec1), abs(vec2), atol=1e-5))
 
-    def testPersistence(self):
+    def test_persistence(self):
         fname = get_tmpfile('gensim_models_lsi.tst')
         model = self.model
         model.save(fname)
@@ -127,7 +127,7 @@ class TestLsiModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         tstvec = []
         self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
-    def testPersistenceCompressed(self):
+    def test_persistence_compressed(self):
         fname = get_tmpfile('gensim_models_lsi.tst.gz')
         model = self.model
         model.save(fname)
@@ -138,7 +138,7 @@ class TestLsiModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         tstvec = []
         self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
-    def testLargeMmap(self):
+    def test_large_mmap(self):
         fname = get_tmpfile('gensim_models_lsi.tst')
         model = self.model
 
@@ -155,7 +155,7 @@ class TestLsiModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         tstvec = []
         self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
-    def testLargeMmapCompressed(self):
+    def test_large_mmap_compressed(self):
         fname = get_tmpfile('gensim_models_lsi.tst.gz')
         model = self.model
 
@@ -169,7 +169,7 @@ class TestLsiModel(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # to be mmaped!
         self.assertRaises(IOError, lsimodel.LsiModel.load, fname, mmap='r')
 
-    def testDocsProcessed(self):
+    def test_docs_processed(self):
         self.assertEqual(self.model.docs_processed, 9)
         self.assertEqual(self.model.docs_processed, self.corpus.num_docs)
 

--- a/gensim/test/test_matutils.py
+++ b/gensim/test/test_matutils.py
@@ -90,7 +90,7 @@ class TestLdaModelInner(unittest.TestCase):
         self.num_runs = 100  # test functions with *num_runs* random inputs
         self.num_topics = 100
 
-    def testLogSumExp(self):
+    def test_log_sum_exp(self):
         # test logsumexp
         rs = self.random_state
 
@@ -104,7 +104,7 @@ class TestLdaModelInner(unittest.TestCase):
                 msg = "logsumexp failed for dtype={}".format(dtype)
                 self.assertTrue(np.allclose(known_good, test_values), msg)
 
-    def testMeanAbsoluteDifference(self):
+    def test_mean_absolute_difference(self):
         # test mean_absolute_difference
         rs = self.random_state
 
@@ -119,7 +119,7 @@ class TestLdaModelInner(unittest.TestCase):
                 msg = "mean_absolute_difference failed for dtype={}".format(dtype)
                 self.assertTrue(np.allclose(known_good, test_values), msg)
 
-    def testDirichletExpectation(self):
+    def test_dirichlet_expectation(self):
         # test dirichlet_expectation
         rs = self.random_state
 

--- a/gensim/test/test_nmf.py
+++ b/gensim/test/test_nmf.py
@@ -32,7 +32,7 @@ class TestNmf(unittest.TestCase, basetmtests.TestBaseTopicModel):
             random_state=42,
         )
 
-    def testGenerator(self):
+    def test_generator(self):
         model_1 = nmf.Nmf(
             iter(common_corpus * 100),
             id2word=common_dictionary,
@@ -53,13 +53,13 @@ class TestNmf(unittest.TestCase, basetmtests.TestBaseTopicModel):
 
         self.assertTrue(np.allclose(model_1.get_topics(), model_2.get_topics()))
 
-    def testUpdate(self):
+    def test_update(self):
         model = copy.deepcopy(self.model)
         model.update(common_corpus)
 
         self.assertFalse(np.allclose(self.model.get_topics(), model.get_topics()))
 
-    def testRandomState(self):
+    def test_random_state(self):
         model_1 = nmf.Nmf(
             common_corpus,
             id2word=common_dictionary,
@@ -80,7 +80,7 @@ class TestNmf(unittest.TestCase, basetmtests.TestBaseTopicModel):
         self.assertTrue(np.allclose(self.model.get_topics(), model_1.get_topics()))
         self.assertFalse(np.allclose(self.model.get_topics(), model_2.get_topics()))
 
-    def testTransform(self):
+    def test_transform(self):
         # transform one document
         doc = list(common_corpus)[0]
         transformed = self.model[doc]
@@ -99,7 +99,7 @@ class TestNmf(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # must contain the same values, up to re-ordering
         self.assertTrue(np.allclose(sorted(vec), sorted(expected), rtol=1e-3))
 
-    def testTopTopics(self):
+    def test_top_topics(self):
         top_topics = self.model.top_topics(common_corpus)
 
         for topic, score in top_topics:
@@ -110,14 +110,14 @@ class TestNmf(unittest.TestCase, basetmtests.TestBaseTopicModel):
                 self.assertTrue(isinstance(k, str))
                 self.assertTrue(np.issubdtype(v, float))
 
-    def testGetTopicTerms(self):
+    def test_get_topic_terms(self):
         topic_terms = self.model.get_topic_terms(1)
 
         for k, v in topic_terms:
             self.assertTrue(isinstance(k, numbers.Integral))
             self.assertTrue(np.issubdtype(v, float))
 
-    def testGetDocumentTopics(self):
+    def test_get_document_topics(self):
         doc_topics = self.model.get_document_topics(common_corpus)
 
         for topic in doc_topics:
@@ -137,7 +137,7 @@ class TestNmf(unittest.TestCase, basetmtests.TestBaseTopicModel):
                 self.assertTrue(isinstance(k, numbers.Integral))
                 self.assertTrue(np.issubdtype(v, float))
 
-    def testTermTopics(self):
+    def test_term_topics(self):
         # check with word_type
         result = self.model.get_term_topics(2)
         for topic_no, probability in result:
@@ -150,7 +150,7 @@ class TestNmf(unittest.TestCase, basetmtests.TestBaseTopicModel):
             self.assertTrue(isinstance(topic_no, int))
             self.assertTrue(np.issubdtype(probability, float))
 
-    def testPersistence(self):
+    def test_persistence(self):
         fname = get_tmpfile('gensim_models_nmf.tst')
 
         self.model.save(fname)
@@ -158,7 +158,7 @@ class TestNmf(unittest.TestCase, basetmtests.TestBaseTopicModel):
         tstvec = []
         self.assertTrue(np.allclose(self.model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
-    def testLargeMmap(self):
+    def test_large_mmap(self):
         fname = get_tmpfile('gensim_models_nmf.tst')
 
         # simulate storing large arrays separately
@@ -170,7 +170,7 @@ class TestNmf(unittest.TestCase, basetmtests.TestBaseTopicModel):
         tstvec = []
         self.assertTrue(np.allclose(self.model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
-    def testLargeMmapCompressed(self):
+    def test_large_mmap_compressed(self):
         fname = get_tmpfile('gensim_models_nmf.tst.gz')
 
         # simulate storing large arrays separately
@@ -179,7 +179,7 @@ class TestNmf(unittest.TestCase, basetmtests.TestBaseTopicModel):
         # test loading the large model arrays with mmap
         self.assertRaises(IOError, nmf.Nmf.load, fname, mmap='r')
 
-    def testDtypeBackwardCompatibility(self):
+    def test_dtype_backward_compatibility(self):
         nmf_fname = datapath('nmf_model')
         test_doc = [(0, 1), (1, 1), (2, 1)]
         expected_topics = [(1, 1.0)]

--- a/gensim/test/test_normmodel.py
+++ b/gensim/test/test_normmodel.py
@@ -125,11 +125,11 @@ class TestNormModel(unittest.TestCase):
         # Test if error is raised on unsupported input type
         self.assertRaises(ValueError, lambda model, doc: model.normalize(doc), self.model_l2, [1, 2, 3])
 
-    def testInit(self):
+    def test_init(self):
         """Test if error messages raised on unsupported norm"""
         self.assertRaises(ValueError, normmodel.NormModel, self.corpus, 'l0')
 
-    def testPersistence(self):
+    def test_persistence(self):
         fname = get_tmpfile('gensim_models.tst')
         model = normmodel.NormModel(self.corpus)
         model.save(fname)
@@ -139,7 +139,7 @@ class TestNormModel(unittest.TestCase):
         # try projecting an empty vector
         self.assertTrue(np.allclose(model.normalize(tstvec), model2.normalize(tstvec)))
 
-    def testPersistenceCompressed(self):
+    def test_persistence_compressed(self):
         fname = get_tmpfile('gensim_models.tst.gz')
         model = normmodel.NormModel(self.corpus)
         model.save(fname)

--- a/gensim/test/test_parsing.py
+++ b/gensim/test/test_parsing.py
@@ -45,29 +45,29 @@ classes = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
 
 class TestPreprocessing(unittest.TestCase):
 
-    def testStripNumeric(self):
+    def test_strip_numeric(self):
         self.assertEqual(strip_numeric("salut les amis du 59"), "salut les amis du ")
 
-    def testStripShort(self):
+    def test_strip_short(self):
         self.assertEqual(strip_short("salut les amis du 59", 3), "salut les amis")
 
-    def testStripTags(self):
+    def test_strip_tags(self):
         self.assertEqual(strip_tags("<i>Hello</i> <b>World</b>!"), "Hello World!")
 
-    def testStripMultipleWhitespaces(self):
+    def test_strip_multiple_whitespaces(self):
         self.assertEqual(strip_multiple_whitespaces("salut  les\r\nloulous!"), "salut les loulous!")
 
-    def testStripNonAlphanum(self):
+    def test_strip_non_alphanum(self):
         self.assertEqual(strip_non_alphanum("toto nf-kappa titi"), "toto nf kappa titi")
 
-    def testSplitAlphanum(self):
+    def test_split_alphanum(self):
         self.assertEqual(split_alphanum("toto diet1 titi"), "toto diet 1 titi")
         self.assertEqual(split_alphanum("toto 1diet titi"), "toto 1 diet titi")
 
-    def testStripStopwords(self):
+    def test_strip_stopwords(self):
         self.assertEqual(remove_stopwords("the world is square"), "world square")
 
-    def testStemText(self):
+    def test_stem_text(self):
         target = \
             "while it is quit us to be abl to search a larg " + \
             "collect of document almost instantli for a joint occurr " + \

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -112,7 +112,7 @@ class PhrasesCommon(PhrasesData):
         self.bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=self.connector_words)
         self.bigram_default = Phrases(self.sentences, connector_words=self.connector_words)
 
-    def testEmptyPhrasifiedSentencesIterator(self):
+    def test_empty_phrasified_sentences_iterator(self):
         bigram_phrases = Phrases(self.sentences)
         bigram_phraser = FrozenPhrases(bigram_phrases)
         trigram_phrases = Phrases(bigram_phraser[self.sentences])
@@ -122,7 +122,7 @@ class PhrasesCommon(PhrasesData):
         self.assertEqual(fst, snd)
         self.assertNotEqual(snd, [])
 
-    def testEmptyInputsOnBigramConstruction(self):
+    def test_empty_inputs_on_bigram_construction(self):
         """Test that empty inputs don't throw errors and return the expected result."""
         # Empty list -> empty list
         self.assertEqual(list(self.bigram_default[[]]), [])
@@ -135,7 +135,7 @@ class PhrasesCommon(PhrasesData):
         # Iterator of empty iterator -> list of empty list
         self.assertEqual(list(self.bigram_default[(iter(()) for i in range(2))]), [[], []])
 
-    def testSentenceGeneration(self):
+    def test_sentence_generation(self):
         """Test basic bigram using a dummy corpus."""
         # test that we generate the same amount of sentences as the input
         self.assertEqual(
@@ -143,14 +143,14 @@ class PhrasesCommon(PhrasesData):
             len(list(self.bigram_default[self.sentences])),
         )
 
-    def testSentenceGenerationWithGenerator(self):
+    def test_sentence_generation_with_generator(self):
         """Test basic bigram production when corpus is a generator."""
         self.assertEqual(
             len(list(self.gen_sentences())),
             len(list(self.bigram_default[self.gen_sentences()])),
         )
 
-    def testBigramConstruction(self):
+    def test_bigram_construction(self):
         """Test Phrases bigram construction."""
         # with this setting we should get response_time and graph_minors
         bigram1_seen = False
@@ -173,7 +173,7 @@ class PhrasesCommon(PhrasesData):
         self.assertTrue(self.bigram2 in self.bigram[self.sentences[-1]])
         self.assertTrue(self.bigram3 in self.bigram[self.sentences[-1]])
 
-    def testBigramConstructionFromGenerator(self):
+    def test_bigram_construction_from_generator(self):
         """Test Phrases bigram construction building when corpus is a generator."""
         bigram1_seen = False
         bigram2_seen = False
@@ -187,7 +187,7 @@ class PhrasesCommon(PhrasesData):
                 break
         self.assertTrue(bigram1_seen and bigram2_seen)
 
-    def testBigramConstructionFromArray(self):
+    def test_bigram_construction_from_array(self):
         """Test Phrases bigram construction building when corpus is a numpy array."""
         bigram1_seen = False
         bigram2_seen = False
@@ -212,7 +212,7 @@ def dumb_scorer(worda_count, wordb_count, bigram_count, len_vocab, min_count, co
 
 class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
 
-    def testExportPhrases(self):
+    def test_export_phrases(self):
         """Test Phrases bigram export phrases."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
         seen_bigrams = set(bigram.find_phrases(self.sentences).keys())
@@ -223,7 +223,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
             'human interface',
         }
 
-    def testMultipleBigramsSingleEntry(self):
+    def test_multiple_bigrams_single_entry(self):
         """Test a single entry produces multiple bigrams."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface']]
@@ -231,7 +231,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
 
         assert seen_bigrams == {'graph minors', 'human interface'}
 
-    def testScoringDefault(self):
+    def test_scoring_default(self):
         """Test the default scoring, from the mikolov word2vec paper."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, delimiter=' ')
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface']]
@@ -250,7 +250,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
 
         assert phrased_sentence == ['graph_minors', 'survey', 'human_interface']
 
-    def testScoringNpmi(self):
+    def test_scoring_npmi(self):
         """Test normalized pointwise mutual information scoring."""
         bigram = Phrases(self.sentences, min_count=1, threshold=.5, scoring='npmi')
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface']]
@@ -261,7 +261,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
             .714  # score for human interface
         }
 
-    def testCustomScorer(self):
+    def test_custom_scorer(self):
         """Test using a custom scoring function."""
         bigram = Phrases(self.sentences, min_count=1, threshold=.001, scoring=dumb_scorer)
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
@@ -270,7 +270,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
         assert all(score == 1 for score in seen_scores)
         assert len(seen_scores) == 3  # 'graph minors' and 'survey human' and 'interface system'
 
-    def testBadParameters(self):
+    def test_bad_parameters(self):
         """Test the phrases module with bad parameters."""
         # should fail with something less or equal than 0
         self.assertRaises(ValueError, Phrases, self.sentences, min_count=0)
@@ -278,7 +278,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
         # threshold should be positive
         self.assertRaises(ValueError, Phrases, self.sentences, threshold=-1)
 
-    def testPruning(self):
+    def test_pruning(self):
         """Test that max_vocab_size parameter is respected."""
         bigram = Phrases(self.sentences, max_vocab_size=5)
         self.assertTrue(len(bigram.vocab) <= 5)
@@ -287,7 +287,7 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
 
 class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
 
-    def testSaveLoadCustomScorer(self):
+    def test_save_load_custom_scorer(self):
         """Test saving and loading a Phrases object with a custom scorer."""
         with temporary_file("test.pkl") as fpath:
             bigram = Phrases(self.sentences, min_count=1, threshold=.001, scoring=dumb_scorer)
@@ -299,7 +299,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
             assert all(score == 1 for score in seen_scores)
             assert len(seen_scores) == 3  # 'graph minors' and 'survey human' and 'interface system'
 
-    def testSaveLoad(self):
+    def test_save_load(self):
         """Test saving and loading a Phrases object."""
         with temporary_file("test.pkl") as fpath:
             bigram = Phrases(self.sentences, min_count=1, threshold=1)
@@ -313,7 +313,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
                 3.444  # score for human interface
             ])
 
-    def testSaveLoadStringScoring(self):
+    def test_save_load_string_scoring(self):
         """Test backwards compatibility with a previous version of Phrases with custom scoring."""
         bigram_loaded = Phrases.load(datapath("phrases-scoring-str.pkl"))
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
@@ -324,7 +324,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
             3.444  # score for human interface
         ])
 
-    def testSaveLoadNoScoring(self):
+    def test_save_load_no_scoring(self):
         """Test backwards compatibility with old versions of Phrases with no scoring parameter."""
         bigram_loaded = Phrases.load(datapath("phrases-no-scoring.pkl"))
         test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
@@ -335,7 +335,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
             3.444  # score for human interface
         ])
 
-    def testSaveLoadNoCommonTerms(self):
+    def test_save_load_no_common_terms(self):
         """Ensure backwards compatibility with old versions of Phrases, before connector_words."""
         bigram_loaded = Phrases.load(datapath("phrases-no-common-terms.pkl"))
         self.assertEqual(bigram_loaded.connector_words, frozenset())
@@ -346,7 +346,7 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
 
 class TestFrozenPhrasesPersistence(PhrasesData, unittest.TestCase):
 
-    def testSaveLoadCustomScorer(self):
+    def test_save_load_custom_scorer(self):
         """Test saving and loading a FrozenPhrases object with a custom scorer."""
 
         with temporary_file("test.pkl") as fpath:
@@ -356,7 +356,7 @@ class TestFrozenPhrasesPersistence(PhrasesData, unittest.TestCase):
             bigram_loaded = FrozenPhrases.load(fpath)
             self.assertEqual(bigram_loaded.scoring, dumb_scorer)
 
-    def testSaveLoad(self):
+    def test_save_load(self):
         """Test saving and loading a FrozenPhrases object."""
         with temporary_file("test.pkl") as fpath:
             bigram = FrozenPhrases(Phrases(self.sentences, min_count=1, threshold=1))
@@ -366,21 +366,21 @@ class TestFrozenPhrasesPersistence(PhrasesData, unittest.TestCase):
                 bigram_loaded[['graph', 'minors', 'survey', 'human', 'interface', 'system']],
                 ['graph_minors', 'survey', 'human_interface', 'system'])
 
-    def testSaveLoadStringScoring(self):
+    def test_save_load_string_scoring(self):
         """Test saving and loading a FrozenPhrases object with a string scoring parameter.
         This should ensure backwards compatibility with the previous version of FrozenPhrases"""
         bigram_loaded = FrozenPhrases.load(datapath("phraser-scoring-str.pkl"))
         # we do not much with scoring, just verify its the one expected
         self.assertEqual(bigram_loaded.scoring, original_scorer)
 
-    def testSaveLoadNoScoring(self):
+    def test_save_load_no_scoring(self):
         """Test saving and loading a FrozenPhrases object with no scoring parameter.
         This should ensure backwards compatibility with old versions of FrozenPhrases"""
         bigram_loaded = FrozenPhrases.load(datapath("phraser-no-scoring.pkl"))
         # we do not much with scoring, just verify its the one expected
         self.assertEqual(bigram_loaded.scoring, original_scorer)
 
-    def testSaveLoadNoCommonTerms(self):
+    def test_save_load_no_common_terms(self):
         """Ensure backwards compatibility with old versions of FrozenPhrases, before connector_words."""
         bigram_loaded = FrozenPhrases.load(datapath("phraser-no-common-terms.pkl"))
         self.assertEqual(bigram_loaded.connector_words, frozenset())
@@ -430,7 +430,7 @@ class CommonTermsPhrasesData:
 class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
     """Test Phrases models with connector words."""
 
-    def testMultipleBigramsSingleEntry(self):
+    def test_multiple_bigrams_single_entry(self):
         """Test a single entry produces multiple bigrams."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=self.connector_words, delimiter=' ')
         test_sentences = [['data', 'and', 'graph', 'survey', 'for', 'human', 'interface']]
@@ -441,7 +441,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             'human interface',
         ])
 
-    def testExportPhrases(self):
+    def test_export_phrases(self):
         """Test Phrases bigram export phrases."""
         bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=self.connector_words, delimiter=' ')
         seen_bigrams = set(bigram.find_phrases(self.sentences).keys())
@@ -453,7 +453,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             'lack of interest',
         ])
 
-    def testScoringDefault(self):
+    def test_scoring_default(self):
         """ test the default scoring, from the mikolov word2vec paper """
         bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=self.connector_words)
         test_sentences = [['data', 'and', 'graph', 'survey', 'for', 'human', 'interface']]
@@ -475,7 +475,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             round((human_interface - min_count) / human / interface * len_vocab, 3),
         ])
 
-    def testScoringNpmi(self):
+    def test_scoring_npmi(self):
         """Test normalized pointwise mutual information scoring."""
         bigram = Phrases(
             self.sentences, min_count=1, threshold=.5,
@@ -489,7 +489,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
             .894  # score for human interface
         ])
 
-    def testCustomScorer(self):
+    def test_custom_scorer(self):
         """Test using a custom scoring function."""
         bigram = Phrases(
             self.sentences, min_count=1, threshold=.001,
@@ -512,7 +512,7 @@ class TestPhrasesModelCommonTerms(CommonTermsPhrasesData, TestPhrasesModel):
 
 class TestFrozenPhrasesModelCompatibilty(unittest.TestCase):
 
-    def testCompatibilty(self):
+    def test_compatibilty(self):
         phrases = Phrases.load(datapath("phrases-3.6.0.model"))
         phraser = FrozenPhrases.load(datapath("phraser-3.6.0.model"))
         test_sentences = ['trees', 'graph', 'minors']

--- a/gensim/test/test_probability_estimation.py
+++ b/gensim/test/test_probability_estimation.py
@@ -61,7 +61,7 @@ class BaseTestCases:
             self.corpus = [self.dictionary.doc2bow(text) for text in self.texts]
             self.build_segmented_topics()
 
-        def testPBooleanDocument(self):
+        def test_p_boolean_document(self):
             """Test p_boolean_document()"""
             accumulator = probability_estimation.p_boolean_document(
                 self.corpus, self.segmented_topics)
@@ -74,7 +74,7 @@ class BaseTestCases:
             }
             self.assertEqual(expected, obtained)
 
-        def testPBooleanSlidingWindow(self):
+        def test_p_boolean_sliding_window(self):
             """Test p_boolean_sliding_window()"""
             # Test with window size as 2. window_id is zero indexed.
             accumulator = probability_estimation.p_boolean_sliding_window(

--- a/gensim/test/test_rpmodel.py
+++ b/gensim/test/test_rpmodel.py
@@ -24,7 +24,7 @@ class TestRpModel(unittest.TestCase):
     def setUp(self):
         self.corpus = MmCorpus(datapath('testcorpus.mm'))
 
-    def testTransform(self):
+    def test_transform(self):
         # create the transformation model
         # HACK; set fixed seed so that we always get the same random matrix (and can compare against expected results)
         np.random.seed(13)
@@ -38,7 +38,7 @@ class TestRpModel(unittest.TestCase):
         expected = np.array([-0.70710677, 0.70710677])
         self.assertTrue(np.allclose(vec, expected))  # transformed entries must be equal up to sign
 
-    def testPersistence(self):
+    def test_persistence(self):
         fname = get_tmpfile('gensim_models.tst')
         model = rpmodel.RpModel(self.corpus, num_topics=2)
         model.save(fname)
@@ -48,7 +48,7 @@ class TestRpModel(unittest.TestCase):
         tstvec = []
         self.assertTrue(np.allclose(model[tstvec], model2[tstvec]))  # try projecting an empty vector
 
-    def testPersistenceCompressed(self):
+    def test_persistence_compressed(self):
         fname = get_tmpfile('gensim_models.tst.gz')
         model = rpmodel.RpModel(self.corpus, num_topics=2)
         model.save(fname)

--- a/gensim/test/test_scripts.py
+++ b/gensim/test/test_scripts.py
@@ -121,7 +121,7 @@ class TestWord2Vec2Tensor(unittest.TestCase):
         self.tensor_file = self.output_folder + '_tensor.tsv'
         self.vector_file = self.output_folder + '_vector.tsv'
 
-    def testConversion(self):
+    def test_conversion(self):
         word2vec2tensor(word2vec_model_path=self.datapath, tensor_filename=self.output_folder)
 
         with utils.open(self.metadata_file, 'rb') as f:

--- a/gensim/test/test_segmentation.py
+++ b/gensim/test/test_segmentation.py
@@ -26,7 +26,7 @@ class TestSegmentation(unittest.TestCase):
             array([5, 2, 7])
         ]
 
-    def testSOnePre(self):
+    def test_s_one_pre(self):
         """Test s_one_pre segmentation."""
         actual = segmentation.s_one_pre(self.topics)
         expected = [
@@ -36,7 +36,7 @@ class TestSegmentation(unittest.TestCase):
         ]
         self.assertTrue(np.allclose(actual, expected))
 
-    def testSOneOne(self):
+    def test_s_one_one(self):
         """Test s_one_one segmentation."""
         actual = segmentation.s_one_one(self.topics)
         expected = [
@@ -46,7 +46,7 @@ class TestSegmentation(unittest.TestCase):
         ]
         self.assertTrue(np.allclose(actual, expected))
 
-    def testSOneSet(self):
+    def test_s_one_set(self):
         """Test s_one_set segmentation."""
         actual = segmentation.s_one_set(self.topics)
         expected = [

--- a/gensim/test/test_similarities.py
+++ b/gensim/test/test_similarities.py
@@ -54,7 +54,7 @@ class _TestSimilarityABC(unittest.TestCase):
         """Creates a SimilarityABC instance."""
         return self.cls(CORPUS, num_features=len(DICTIONARY))
 
-    def testFull(self, num_best=None, shardsize=100):
+    def test_full(self, num_best=None, shardsize=100):
         if self.cls == similarities.Similarity:
             index = self.cls(None, CORPUS, num_features=len(DICTIONARY), shardsize=shardsize)
         else:
@@ -87,7 +87,7 @@ class _TestSimilarityABC(unittest.TestCase):
         if self.cls == similarities.Similarity:
             index.destroy()
 
-    def testNumBest(self):
+    def test_num_best(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
             self.skipTest("pyemd not installed")
 
@@ -117,7 +117,7 @@ class _TestSimilarityABC(unittest.TestCase):
         self.assertTrue(scipy.sparse.issparse(matrix_scipy_clipped))
         self.assertTrue([matutils.scipy2sparse(x) for x in matrix_scipy_clipped], [expected] * 3)
 
-    def testEmptyQuery(self):
+    def test_empty_query(self):
         index = self.factoryMethod()
         if isinstance(index, similarities.WmdSimilarity) and not PYEMD_EXT:
             self.skipTest("pyemd not installed")
@@ -129,7 +129,7 @@ class _TestSimilarityABC(unittest.TestCase):
         except IndexError:
             self.assertTrue(False)
 
-    def testChunking(self):
+    def test_chunking(self):
         if self.cls == similarities.Similarity:
             index = self.cls(None, CORPUS, num_features=len(DICTIONARY), shardsize=5)
         else:
@@ -155,7 +155,7 @@ class _TestSimilarityABC(unittest.TestCase):
         if self.cls == similarities.Similarity:
             index.destroy()
 
-    def testIter(self):
+    def test_iter(self):
         if self.cls == similarities.Similarity:
             index = self.cls(None, CORPUS, num_features=len(DICTIONARY), shardsize=5)
         else:
@@ -176,7 +176,7 @@ class _TestSimilarityABC(unittest.TestCase):
         if self.cls == similarities.Similarity:
             index.destroy()
 
-    def testPersistency(self):
+    def test_persistency(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
             self.skipTest("pyemd not installed")
 
@@ -196,7 +196,7 @@ class _TestSimilarityABC(unittest.TestCase):
             self.assertTrue(numpy.allclose(index.index, index2.index))
             self.assertEqual(index.num_best, index2.num_best)
 
-    def testPersistencyCompressed(self):
+    def test_persistency_compressed(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
             self.skipTest("pyemd not installed")
 
@@ -216,7 +216,7 @@ class _TestSimilarityABC(unittest.TestCase):
             self.assertTrue(numpy.allclose(index.index, index2.index))
             self.assertEqual(index.num_best, index2.num_best)
 
-    def testLarge(self):
+    def test_large(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
             self.skipTest("pyemd not installed")
 
@@ -238,7 +238,7 @@ class _TestSimilarityABC(unittest.TestCase):
             self.assertTrue(numpy.allclose(index.index, index2.index))
             self.assertEqual(index.num_best, index2.num_best)
 
-    def testLargeCompressed(self):
+    def test_large_compressed(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
             self.skipTest("pyemd not installed")
 
@@ -260,7 +260,7 @@ class _TestSimilarityABC(unittest.TestCase):
             self.assertTrue(numpy.allclose(index.index, index2.index))
             self.assertEqual(index.num_best, index2.num_best)
 
-    def testMmap(self):
+    def test_mmap(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
             self.skipTest("pyemd not installed")
 
@@ -283,7 +283,7 @@ class _TestSimilarityABC(unittest.TestCase):
             self.assertTrue(numpy.allclose(index.index, index2.index))
             self.assertEqual(index.num_best, index2.num_best)
 
-    def testMmapCompressed(self):
+    def test_mmap_compressed(self):
         if self.cls == similarities.WmdSimilarity and not PYEMD_EXT:
             self.skipTest("pyemd not installed")
 
@@ -311,7 +311,7 @@ class TestWmdSimilarity(_TestSimilarityABC):
         return self.cls(TEXTS, self.w2v_model)
 
     @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
-    def testFull(self, num_best=None):
+    def test_full(self, num_best=None):
         # Override testFull.
 
         index = self.cls(TEXTS, self.w2v_model)
@@ -330,7 +330,7 @@ class TestWmdSimilarity(_TestSimilarityABC):
             self.assertTrue(numpy.alltrue(sims[1:] < 1.0))
 
     @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
-    def testNonIncreasing(self):
+    def test_non_increasing(self):
         ''' Check that similarities are non-increasing when `num_best` is not
         `None`.'''
         # NOTE: this could be implemented for other similarities as well (i.e.
@@ -346,7 +346,7 @@ class TestWmdSimilarity(_TestSimilarityABC):
         self.assertTrue(cond)
 
     @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
-    def testChunking(self):
+    def test_chunking(self):
         # Override testChunking.
 
         index = self.cls(TEXTS, self.w2v_model)
@@ -365,7 +365,7 @@ class TestWmdSimilarity(_TestSimilarityABC):
                 self.assertTrue(numpy.alltrue(sim <= 1.0))
 
     @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
-    def testIter(self):
+    def test_iter(self):
         # Override testIter.
 
         index = self.cls(TEXTS, self.w2v_model)
@@ -386,7 +386,7 @@ class TestSoftCosineSimilarity(_TestSimilarityABC):
     def factoryMethod(self):
         return self.cls(CORPUS, self.similarity_matrix)
 
-    def testFull(self, num_best=None):
+    def test_full(self, num_best=None):
         # Single query
         index = self.cls(CORPUS, self.similarity_matrix, num_best=num_best)
         query = DICTIONARY.doc2bow(TEXTS[0])
@@ -421,7 +421,7 @@ class TestSoftCosineSimilarity(_TestSimilarityABC):
                     self.assertTrue(numpy.alltrue(result[i + 1:] >= 0.0))
                     self.assertTrue(numpy.alltrue(result[i + 1:] < 1.0))
 
-    def testNonIncreasing(self):
+    def test_non_increasing(self):
         """ Check that similarities are non-increasing when `num_best` is not `None`."""
         # NOTE: this could be implemented for other similarities as well (i.e. in _TestSimilarityABC).
 
@@ -434,7 +434,7 @@ class TestSoftCosineSimilarity(_TestSimilarityABC):
         cond = sum(numpy.diff(sims2) <= 0) == len(sims2) - 1
         self.assertTrue(cond)
 
-    def testChunking(self):
+    def test_chunking(self):
         index = self.cls(CORPUS, self.similarity_matrix)
         query = [DICTIONARY.doc2bow(document) for document in TEXTS[:3]]
         sims = index[query]
@@ -451,7 +451,7 @@ class TestSoftCosineSimilarity(_TestSimilarityABC):
             expected = 1.0
             self.assertAlmostEqual(expected, chunk[0][1], places=2)
 
-    def testIter(self):
+    def test_iter(self):
         index = self.cls(CORPUS, self.similarity_matrix)
         for sims in index:
             self.assertTrue(numpy.alltrue(sims >= 0.0))
@@ -462,7 +462,7 @@ class TestSparseMatrixSimilarity(_TestSimilarityABC):
     def setUp(self):
         self.cls = similarities.SparseMatrixSimilarity
 
-    def testMaintainSparsity(self):
+    def test_maintain_sparsity(self):
         """Sparsity is correctly maintained when maintain_sparsity=True"""
         num_features = len(DICTIONARY)
 
@@ -476,7 +476,7 @@ class TestSparseMatrixSimilarity(_TestSimilarityABC):
         self.assertTrue(scipy.sparse.issparse(sparse_sims))
         numpy.testing.assert_array_equal(dense_sims, sparse_sims.todense())
 
-    def testMaintainSparsityWithNumBest(self):
+    def test_maintain_sparsity_with_num_best(self):
         """Tests that sparsity is correctly maintained when maintain_sparsity=True and num_best is not None"""
         num_features = len(DICTIONARY)
 
@@ -499,12 +499,12 @@ class TestSimilarity(_TestSimilarityABC):
         # Override factoryMethod.
         return self.cls(None, CORPUS, num_features=len(DICTIONARY), shardsize=5)
 
-    def testSharding(self):
+    def test_sharding(self):
         for num_best in [None, 0, 1, 9, 1000]:
             for shardsize in [1, 2, 9, 1000]:
                 self.testFull(num_best=num_best, shardsize=shardsize)
 
-    def testReopen(self):
+    def test_reopen(self):
         """test re-opening partially full shards"""
         index = similarities.Similarity(None, CORPUS[:5], num_features=len(DICTIONARY), shardsize=9)
         _ = index[CORPUS[0]]  # noqa:F841 forces shard close
@@ -516,12 +516,12 @@ class TestSimilarity(_TestSimilarityABC):
         self.assertTrue(numpy.allclose(expected, sims))
         index.destroy()
 
-    def testMmapCompressed(self):
+    def test_mmap_compressed(self):
         pass
         # turns out this test doesn't exercise this because there are no arrays
         # to be mmaped!
 
-    def testChunksize(self):
+    def test_chunksize(self):
         index = self.cls(None, CORPUS, num_features=len(DICTIONARY), shardsize=5)
         expected = [sim for sim in index]
         index.chunksize = len(index) - 1
@@ -529,7 +529,7 @@ class TestSimilarity(_TestSimilarityABC):
         self.assertTrue(numpy.allclose(expected, sims))
         index.destroy()
 
-    def testNlargest(self):
+    def test_nlargest(self):
         sims = ([(0, 0.8), (1, 0.2), (2, 0.0), (3, 0.0), (4, -0.1), (5, -0.15)],)
         expected = [(0, 0.8), (1, 0.2), (5, -0.15)]
         self.assertTrue(_nlargest(3, sims), expected)
@@ -546,7 +546,7 @@ class TestWord2VecAnnoyIndexer(unittest.TestCase):
         from gensim.similarities.annoy import AnnoyIndexer
         self.indexer = AnnoyIndexer
 
-    def testWord2Vec(self):
+    def test_word2vec(self):
         model = word2vec.Word2Vec(TEXTS, min_count=1)
         index = self.indexer(model, 10)
 
@@ -555,7 +555,7 @@ class TestWord2VecAnnoyIndexer(unittest.TestCase):
         self.assertIndexSaved(index)
         self.assertLoadedIndexEqual(index, model)
 
-    def testFastText(self):
+    def test_fast_text(self):
         class LeeReader:
             def __init__(self, fn):
                 self.fn = fn
@@ -573,7 +573,7 @@ class TestWord2VecAnnoyIndexer(unittest.TestCase):
         self.assertIndexSaved(index)
         self.assertLoadedIndexEqual(index, model)
 
-    def testAnnoyIndexingOfKeyedVectors(self):
+    def test_annoy_indexing_of_keyed_vectors(self):
         from gensim.similarities.annoy import AnnoyIndexer
         keyVectors_file = datapath('lee_fasttext.vec')
         model = KeyedVectors.load_word2vec_format(keyVectors_file)
@@ -583,7 +583,7 @@ class TestWord2VecAnnoyIndexer(unittest.TestCase):
         self.assertVectorIsSimilarToItself(model, index)
         self.assertApproxNeighborsMatchExact(model, model, index)
 
-    def testLoadMissingRaisesError(self):
+    def test_load_missing_raises_error(self):
         from gensim.similarities.annoy import AnnoyIndexer
         test_index = AnnoyIndexer()
 
@@ -651,14 +651,14 @@ class TestDoc2VecAnnoyIndexer(unittest.TestCase):
         self.index = AnnoyIndexer(self.model, 300)
         self.vector = self.model.dv.get_normed_vectors()[0]
 
-    def testDocumentIsSimilarToItself(self):
+    def test_document_is_similar_to_itself(self):
         approx_neighbors = self.index.most_similar(self.vector, 1)
         doc, similarity = approx_neighbors[0]
 
         self.assertEqual(doc, 0)
         self.assertAlmostEqual(similarity, 1.0, places=2)
 
-    def testApproxNeighborsMatchExact(self):
+    def test_approx_neighbors_match_exact(self):
         approx_neighbors = self.model.dv.most_similar([self.vector], topn=5, indexer=self.index)
         exact_neighbors = self.model.dv.most_similar([self.vector], topn=5)
 
@@ -667,19 +667,19 @@ class TestDoc2VecAnnoyIndexer(unittest.TestCase):
 
         self.assertEqual(approx_words, exact_words)
 
-    def testSave(self):
+    def test_save(self):
         fname = get_tmpfile('gensim_similarities.tst.pkl')
         self.index.save(fname)
         self.assertTrue(os.path.exists(fname))
         self.assertTrue(os.path.exists(fname + '.d'))
 
-    def testLoadNotExist(self):
+    def test_load_not_exist(self):
         from gensim.similarities.annoy import AnnoyIndexer
         self.test_index = AnnoyIndexer()
 
         self.assertRaises(IOError, self.test_index.load, fname='test-index')
 
-    def testSaveLoad(self):
+    def test_save_load(self):
         from gensim.similarities.annoy import AnnoyIndexer
 
         fname = get_tmpfile('gensim_similarities.tst.pkl')

--- a/gensim/test/test_tmdiff.py
+++ b/gensim/test/test_tmdiff.py
@@ -20,7 +20,7 @@ class TestLdaDiff(unittest.TestCase):
         self.n_ann_terms = 10
         self.model = LdaModel(corpus=self.corpus, id2word=self.dictionary, num_topics=self.num_topics, passes=10)
 
-    def testBasic(self):
+    def test_basic(self):
         # test for matrix case
         mdiff, annotation = self.model.diff(self.model, n_ann_terms=self.n_ann_terms)
 
@@ -34,7 +34,7 @@ class TestLdaDiff(unittest.TestCase):
         self.assertEqual(mdiff.shape, (self.num_topics,))
         self.assertEqual(len(annotation), self.num_topics)
 
-    def testIdentity(self):
+    def test_identity(self):
         for dist_name in ["hellinger", "kullback_leibler", "jaccard"]:
             # test for matrix case
             mdiff, annotation = self.model.diff(self.model, n_ann_terms=self.n_ann_terms, distance=dist_name)
@@ -62,7 +62,7 @@ class TestLdaDiff(unittest.TestCase):
             if dist_name == "jaccard":
                 self.assertTrue(np.allclose(mdiff, np.zeros(mdiff.shape, dtype=mdiff.dtype)))
 
-    def testInput(self):
+    def test_input(self):
         self.assertRaises(ValueError, self.model.diff, self.model, n_ann_terms=self.n_ann_terms, distance='something')
         self.assertRaises(ValueError, self.model.diff, [], n_ann_terms=self.n_ann_terms, distance='something')
 

--- a/gensim/test/test_translation_matrix.py
+++ b/gensim/test/test_translation_matrix.py
@@ -36,7 +36,7 @@ class TestTranslationMatrix(unittest.TestCase):
         model.train(self.word_pairs)
         self.assertEqual(model.translation_matrix.shape, (300, 300))
 
-    def testPersistence(self):
+    def test_persistence(self):
         """Test storing/loading the entire model."""
         tmpf = get_tmpfile('transmat-en-it.pkl')
 

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -59,7 +59,7 @@ def load_on_instance():
 
 
 class TestWord2VecModel(unittest.TestCase):
-    def testBuildVocabFromFreq(self):
+    def test_build_vocab_from_freq(self):
         """Test that the algorithm is able to build vocabulary from given
         frequency table"""
         freq_dict = {
@@ -89,7 +89,7 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertEqual(len(model_hs.wv), 14)
         self.assertEqual(len(model_neg.wv), 14)
 
-    def testPruneVocab(self):
+    def test_prune_vocab(self):
         """Test Prune vocab while scanning sentences"""
         sentences = [
             ["graph", "system"],
@@ -115,12 +115,12 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertEqual(model.wv.get_vecattr('minors', 'count'), 3)
         self.assertEqual(model.wv.get_vecattr('system', 'count'), 4)
 
-    def testTotalWordCount(self):
+    def test_total_word_count(self):
         model = word2vec.Word2Vec(vector_size=10, min_count=0, seed=42)
         total_words = model.scan_vocab(sentences)[0]
         self.assertEqual(total_words, 29)
 
-    def testMaxFinalVocab(self):
+    def test_max_final_vocab(self):
         # Test for less restricting effect of max_final_vocab
         # max_final_vocab is specified but has no effect
         model = word2vec.Word2Vec(vector_size=10, max_final_vocab=4, min_count=4, sample=0)
@@ -141,7 +141,7 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertEqual(reported_values['num_retained_words'], 4)
         self.assertEqual(model.effective_min_count, 3)
 
-    def testOnlineLearning(self):
+    def test_online_learning(self):
         """Test that the algorithm is able to add new words to the
         vocabulary and to a trained model when using a sorted vocabulary"""
         model_hs = word2vec.Word2Vec(sentences, vector_size=10, min_count=0, seed=42, hs=1, negative=0)
@@ -155,7 +155,7 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertEqual(len(model_hs.wv), 14)
         self.assertEqual(len(model_neg.wv), 14)
 
-    def testOnlineLearningAfterSave(self):
+    def test_online_learning_after_save(self):
         """Test that the algorithm is able to add new words to the
         vocabulary and to a trained model when using a sorted vocabulary"""
         tmpf = get_tmpfile('gensim_word2vec.tst')
@@ -167,7 +167,7 @@ class TestWord2VecModel(unittest.TestCase):
         model_neg.train(new_sentences, total_examples=model_neg.corpus_count, epochs=model_neg.epochs)
         self.assertEqual(len(model_neg.wv), 14)
 
-    def testOnlineLearningFromFile(self):
+    def test_online_learning_from_file(self):
         """Test that the algorithm is able to add new words to the
         vocabulary and to a trained model when using a sorted vocabulary"""
         with temporary_file(get_tmpfile('gensim_word2vec1.tst')) as corpus_file,\
@@ -192,7 +192,7 @@ class TestWord2VecModel(unittest.TestCase):
             self.assertEqual(len(model_hs.wv), 14)
             self.assertEqual(len(model_neg.wv), 14)
 
-    def testOnlineLearningAfterSaveFromFile(self):
+    def test_online_learning_after_save_from_file(self):
         """Test that the algorithm is able to add new words to the
         vocabulary and to a trained model when using a sorted vocabulary"""
         with temporary_file(get_tmpfile('gensim_word2vec1.tst')) as corpus_file,\
@@ -259,7 +259,7 @@ class TestWord2VecModel(unittest.TestCase):
         )
         self.onlineSanity(model)
 
-    def testPersistence(self):
+    def test_persistence(self):
         """Test storing/loading the entire model."""
         tmpf = get_tmpfile('gensim_word2vec.tst')
         model = word2vec.Word2Vec(sentences, min_count=1)
@@ -272,7 +272,7 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertTrue(np.allclose(wv.vectors, loaded_wv.vectors))
         self.assertEqual(len(wv), len(loaded_wv))
 
-    def testPersistenceFromFile(self):
+    def test_persistence_from_file(self):
         """Test storing/loading the entire model trained with corpus_file argument."""
         with temporary_file(get_tmpfile('gensim_word2vec.tst')) as corpus_file:
             utils.save_as_line_sentence(sentences, corpus_file)
@@ -288,27 +288,27 @@ class TestWord2VecModel(unittest.TestCase):
             self.assertTrue(np.allclose(wv.vectors, loaded_wv.vectors))
             self.assertEqual(len(wv), len(loaded_wv))
 
-    def testPersistenceWithConstructorRule(self):
+    def test_persistence_with_constructor_rule(self):
         """Test storing/loading the entire model with a vocab trimming rule passed in the constructor."""
         tmpf = get_tmpfile('gensim_word2vec.tst')
         model = word2vec.Word2Vec(sentences, min_count=1, trim_rule=_rule)
         model.save(tmpf)
         self.models_equal(model, word2vec.Word2Vec.load(tmpf))
 
-    def testRuleWithMinCount(self):
+    def test_rule_with_min_count(self):
         """Test that returning RULE_DEFAULT from trim_rule triggers min_count."""
         model = word2vec.Word2Vec(sentences + [["occurs_only_once"]], min_count=2, trim_rule=_rule)
         self.assertTrue("human" not in model.wv)
         self.assertTrue("occurs_only_once" not in model.wv)
         self.assertTrue("interface" in model.wv)
 
-    def testRule(self):
+    def test_rule(self):
         """Test applying vocab trim_rule to build_vocab instead of constructor."""
         model = word2vec.Word2Vec(min_count=1)
         model.build_vocab(sentences, trim_rule=_rule)
         self.assertTrue("human" not in model.wv)
 
-    def testLambdaRule(self):
+    def test_lambda_rule(self):
         """Test that lambda trim_rule works."""
         def rule(word, count, min_count):
             return utils.RULE_DISCARD if word == "human" else utils.RULE_DEFAULT
@@ -338,12 +338,12 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertTrue(model.wv.vectors.shape == (len(model.wv), model.vector_size))
         self.assertTrue(model.syn1neg.shape == (len(model.wv), model.vector_size))
 
-    def testLoadPreKeyedVectorModelCFormat(self):
+    def test_load_pre_keyed_vector_model_c_format(self):
         """Test loading pre-KeyedVectors word2vec model saved in word2vec format"""
         model = keyedvectors.KeyedVectors.load_word2vec_format(datapath('word2vec_pre_kv_c'))
         self.assertTrue(model.vectors.shape[0] == len(model))
 
-    def testPersistenceWord2VecFormat(self):
+    def test_persistence_word2vec_format(self):
         """Test storing/loading the entire model in word2vec format."""
         tmpf = get_tmpfile('gensim_word2vec.tst')
         model = word2vec.Word2Vec(sentences, min_count=1)
@@ -361,7 +361,7 @@ class TestWord2VecModel(unittest.TestCase):
         )
         self.assertEqual(binary_model_kv.vectors.nbytes, half_precision_model_kv.vectors.nbytes * 2)
 
-    def testNoTrainingCFormat(self):
+    def test_no_training_c_format(self):
         tmpf = get_tmpfile('gensim_word2vec.tst')
         model = word2vec.Word2Vec(sentences, min_count=1)
         model.wv.save_word2vec_format(tmpf, binary=True)
@@ -370,7 +370,7 @@ class TestWord2VecModel(unittest.TestCase):
         binary_model.wv = kv
         self.assertRaises(ValueError, binary_model.train, sentences)
 
-    def testTooShortBinaryWord2VecFormat(self):
+    def test_too_short_binary_word2vec_format(self):
         tfile = get_tmpfile('gensim_word2vec.tst')
         model = word2vec.Word2Vec(sentences, min_count=1)
         model.wv.save_word2vec_format(tfile, binary=True)
@@ -379,7 +379,7 @@ class TestWord2VecModel(unittest.TestCase):
         f.close()
         self.assertRaises(EOFError, keyedvectors.KeyedVectors.load_word2vec_format, tfile, binary=True)
 
-    def testTooShortTextWord2VecFormat(self):
+    def test_too_short_text_word2vec_format(self):
         tfile = get_tmpfile('gensim_word2vec.tst')
         model = word2vec.Word2Vec(sentences, min_count=1)
         model.wv.save_word2vec_format(tfile, binary=False)
@@ -388,7 +388,7 @@ class TestWord2VecModel(unittest.TestCase):
         f.close()
         self.assertRaises(EOFError, keyedvectors.KeyedVectors.load_word2vec_format, tfile, binary=False)
 
-    def testPersistenceWord2VecFormatNonBinary(self):
+    def test_persistence_word2vec_format_non_binary(self):
         """Test storing/loading the entire model in word2vec non-binary format."""
         tmpf = get_tmpfile('gensim_word2vec.tst')
         model = word2vec.Word2Vec(sentences, min_count=1)
@@ -402,7 +402,7 @@ class TestWord2VecModel(unittest.TestCase):
             model.wv.get_vector('human', norm=True), norm_only_model['human'], atol=1e-4
         ))
 
-    def testPersistenceWord2VecFormatWithVocab(self):
+    def test_persistence_word2vec_format_with_vocab(self):
         """Test storing/loading the entire model and vocabulary in word2vec format."""
         tmpf = get_tmpfile('gensim_word2vec.tst')
         model = word2vec.Word2Vec(sentences, min_count=1)
@@ -414,7 +414,7 @@ class TestWord2VecModel(unittest.TestCase):
             binary_model_with_vocab_kv.get_vecattr('human', 'count'),
         )
 
-    def testPersistenceKeyedVectorsFormatWithVocab(self):
+    def test_persistence_keyed_vectors_format_with_vocab(self):
         """Test storing/loading the entire model and vocabulary in word2vec format."""
         tmpf = get_tmpfile('gensim_word2vec.tst')
         model = word2vec.Word2Vec(sentences, min_count=1)
@@ -426,7 +426,7 @@ class TestWord2VecModel(unittest.TestCase):
             kv_binary_model_with_vocab.get_vecattr('human', 'count'),
         )
 
-    def testPersistenceWord2VecFormatCombinationWithStandardPersistence(self):
+    def test_persistence_word2vec_format_combination_with_standard_persistence(self):
         """Test storing/loading the entire model and vocabulary in word2vec format chained with
          saving and loading via `save` and `load` methods`.
          It was possible prior to 1.0.0 release, now raises Exception"""
@@ -438,7 +438,7 @@ class TestWord2VecModel(unittest.TestCase):
         binary_model_with_vocab_kv.save(tmpf)
         self.assertRaises(AttributeError, word2vec.Word2Vec.load, tmpf)
 
-    def testLargeMmap(self):
+    def test_large_mmap(self):
         """Test storing/loading the entire model."""
         tmpf = get_tmpfile('gensim_word2vec.tst')
         model = word2vec.Word2Vec(sentences, min_count=1)
@@ -450,7 +450,7 @@ class TestWord2VecModel(unittest.TestCase):
         # make sure mmaping the arrays back works, too
         self.models_equal(model, word2vec.Word2Vec.load(tmpf, mmap='r'))
 
-    def testVocab(self):
+    def test_vocab(self):
         """Test word2vec vocabulary building."""
         corpus = LeeCorpus()
         total_words = sum(len(sentence) for sentence in corpus)
@@ -477,7 +477,7 @@ class TestWord2VecModel(unittest.TestCase):
         # input not empty, but rather completely filtered out
         self.assertRaises(RuntimeError, word2vec.Word2Vec, corpus, min_count=total_words + 1)
 
-    def testTraining(self):
+    def test_training(self):
         """Test word2vec training."""
         # build vocabulary, don't train yet
         model = word2vec.Word2Vec(vector_size=2, min_count=1, hs=1, negative=0)
@@ -500,7 +500,7 @@ class TestWord2VecModel(unittest.TestCase):
         model2 = word2vec.Word2Vec(sentences, vector_size=2, min_count=1, hs=1, negative=0)
         self.models_equal(model, model2)
 
-    def testTrainingFromFile(self):
+    def test_training_from_file(self):
         """Test word2vec training with corpus_file argument."""
         # build vocabulary, don't train yet
         with temporary_file(get_tmpfile('gensim_word2vec.tst')) as tf:
@@ -522,7 +522,7 @@ class TestWord2VecModel(unittest.TestCase):
             sims2 = [(w, sim) for w, sim in sims2 if w != 'graph']  # ignore 'graph' itself
             self.assertEqual(sims, sims2)
 
-    def testScoring(self):
+    def test_scoring(self):
         """Test word2vec scoring."""
         model = word2vec.Word2Vec(sentences, vector_size=2, min_count=1, hs=1, negative=0)
 
@@ -530,7 +530,7 @@ class TestWord2VecModel(unittest.TestCase):
         scores = model.score(sentences, len(sentences))
         self.assertEqual(len(scores), len(sentences))
 
-    def testLocking(self):
+    def test_locking(self):
         """Test word2vec training doesn't change locked vectors."""
         corpus = LeeCorpus()
         # build vocabulary, don't train yet
@@ -550,7 +550,7 @@ class TestWord2VecModel(unittest.TestCase):
             self.assertFalse((unlocked1 == model.wv.vectors[1]).all())  # unlocked vector should vary
             self.assertTrue((locked0 == model.wv.vectors[0]).all())  # locked vector should not vary
 
-    def testEvaluateWordAnalogies(self):
+    def test_evaluate_word_analogies(self):
         """Test that evaluating analogies on KeyedVectors give sane results"""
         model = word2vec.Word2Vec(LeeCorpus())
         score, sections = model.wv.evaluate_word_analogies(datapath('questions-words.txt'))
@@ -563,7 +563,7 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertIn('correct', first_section)
         self.assertIn('incorrect', first_section)
 
-    def testEvaluateWordPairs(self):
+    def test_evaluate_word_pairs(self):
         """Test Spearman and Pearson correlation coefficients give sane results on similarity datasets"""
         corpus = word2vec.LineSentence(datapath('head500.noblanks.cor.bz2'))
         model = word2vec.Word2Vec(corpus, min_count=3, epochs=20)
@@ -575,7 +575,7 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertTrue(0.1 < spearman < 1.0, "spearman {spearman} not between 0.1 and 1.0")
         self.assertTrue(0.0 <= oov < 90.0, "OOV {oov} not between 0.0 and 90.0")
 
-    def testEvaluateWordPairsFromFile(self):
+    def test_evaluate_word_pairs_from_file(self):
         """Test Spearman and Pearson correlation coefficients give sane results on similarity datasets"""
         with temporary_file(get_tmpfile('gensim_word2vec.tst')) as tf:
             utils.save_as_line_sentence(word2vec.LineSentence(datapath('head500.noblanks.cor.bz2')), tf)
@@ -697,7 +697,7 @@ class TestWord2VecModel(unittest.TestCase):
         sims2 = [(w, sim) for w, sim in sims2 if w != 'graph']  # ignore 'graph' itself
         self.assertEqual(sims, sims2)
 
-    def testTrainingCbow(self):
+    def test_training_cbow(self):
         """Test CBOW word2vec training."""
         # to test training, make the corpus larger by repeating its sentences over and over
         # build vocabulary, don't train yet
@@ -720,7 +720,7 @@ class TestWord2VecModel(unittest.TestCase):
         model2 = word2vec.Word2Vec(sentences, vector_size=2, min_count=1, sg=0, hs=1, negative=0)
         self.models_equal(model, model2)
 
-    def testTrainingSgNegative(self):
+    def test_training_sg_negative(self):
         """Test skip-gram (negative sampling) word2vec training."""
         # to test training, make the corpus larger by repeating its sentences over and over
         # build vocabulary, don't train yet
@@ -743,7 +743,7 @@ class TestWord2VecModel(unittest.TestCase):
         model2 = word2vec.Word2Vec(sentences, vector_size=2, min_count=1, sg=1, hs=0, negative=2)
         self.models_equal(model, model2)
 
-    def testTrainingCbowNegative(self):
+    def test_training_cbow_negative(self):
         """Test CBOW (negative sampling) word2vec training."""
         # to test training, make the corpus larger by repeating its sentences over and over
         # build vocabulary, don't train yet
@@ -766,7 +766,7 @@ class TestWord2VecModel(unittest.TestCase):
         model2 = word2vec.Word2Vec(sentences, vector_size=2, min_count=1, sg=0, hs=0, negative=2)
         self.models_equal(model, model2)
 
-    def testSimilarities(self):
+    def test_similarities(self):
         """Test similarity and n_similarity methods."""
         # The model is trained using CBOW
         model = word2vec.Word2Vec(vector_size=2, min_count=1, sg=0, hs=0, negative=2)
@@ -779,7 +779,7 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertRaises(ZeroDivisionError, model.wv.n_similarity, [], ['graph', 'trees'])
         self.assertRaises(ZeroDivisionError, model.wv.n_similarity, [], [])
 
-    def testSimilarBy(self):
+    def test_similar_by(self):
         """Test word2vec similar_by_word and similar_by_vector."""
         model = word2vec.Word2Vec(sentences, vector_size=2, min_count=1, hs=1, negative=0)
         wordsims = model.wv.similar_by_word('graph', topn=10)
@@ -789,7 +789,7 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertEqual(wordsims, wordsims2)
         self.assertEqual(vectorsims, vectorsims2)
 
-    def testParallel(self):
+    def test_parallel(self):
         """Test word2vec parallel training."""
         corpus = utils.RepeatCorpus(LeeCorpus(), 10000)  # repeats about 33 times
 
@@ -803,7 +803,7 @@ class TestWord2VecModel(unittest.TestCase):
             neighbor_rank = [word for word, sim in sims].index(expected_neighbor)
             self.assertLess(neighbor_rank, 20)
 
-    def testRNG(self):
+    def test_r_n_g(self):
         """Test word2vec results identical with identical RNG seed."""
         model = word2vec.Word2Vec(sentences, min_count=2, seed=42, workers=1)
         model2 = word2vec.Word2Vec(sentences, min_count=2, seed=42, workers=1)
@@ -820,7 +820,7 @@ class TestWord2VecModel(unittest.TestCase):
         most_common_word = model.wv.index_to_key[most_common_word_index]
         self.assertTrue(np.allclose(model.wv[most_common_word], model2.wv[most_common_word]))
 
-    def testPredictOutputWord(self):
+    def test_predict_output_word(self):
         '''Test word2vec predict_output_word method handling for negative sampling scheme'''
         # under normal circumstances
         model_with_neg = word2vec.Word2Vec(sentences, min_count=1)
@@ -843,7 +843,7 @@ class TestWord2VecModel(unittest.TestCase):
         model_without_neg = word2vec.Word2Vec(sentences, min_count=1, negative=0)
         self.assertRaises(RuntimeError, model_without_neg.predict_output_word, ['system', 'human'])
 
-    def testLoadOldModel(self):
+    def test_load_old_model(self):
         """Test loading an old word2vec model of indeterminate version"""
 
         model_file = 'word2vec_old'  # which version?!?
@@ -857,7 +857,7 @@ class TestWord2VecModel(unittest.TestCase):
 
         self.onlineSanity(model, trained_model=True)
 
-    def testLoadOldModelSeparates(self):
+    def test_load_old_model_separates(self):
         """Test loading an old word2vec model of indeterminate version"""
 
         # Model stored in multiple files
@@ -949,7 +949,7 @@ class TestWord2VecModel(unittest.TestCase):
         loaded_model.train(lee_corpus_list, total_examples=model.corpus_count, epochs=model.epochs)
 
     @log_capture()
-    def testBuildVocabWarning(self, loglines):
+    def test_build_vocab_warning(self, loglines):
         """Test if warning is raised on non-ideal input to a word2vec model"""
         sentences = ['human', 'machine']
         model = word2vec.Word2Vec()
@@ -958,7 +958,7 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertTrue(warning in str(loglines))
 
     @log_capture()
-    def testTrainWarning(self, loglines):
+    def test_train_warning(self, loglines):
         """Test if warning is raised if alpha rises during subsequent calls to train()"""
         sentences = [
             ['human'],
@@ -994,7 +994,7 @@ class TestWord2VecModel(unittest.TestCase):
         gen = (s for s in sentences)
         self.assertRaises(TypeError, word2vec.Word2Vec, (gen,))
 
-    def testLoadOnClassError(self):
+    def test_load_on_class_error(self):
         """Test if exception is raised when loading word2vec model on instance"""
         self.assertRaises(AttributeError, load_on_instance)
 
@@ -1018,7 +1018,7 @@ class TestWord2VecModel(unittest.TestCase):
 class TestWMD(unittest.TestCase):
 
     @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
-    def testNonzero(self):
+    def test_nonzero(self):
         '''Test basic functionality with a test sentence.'''
 
         model = word2vec.Word2Vec(sentences, min_count=2, seed=42, workers=1)
@@ -1030,7 +1030,7 @@ class TestWMD(unittest.TestCase):
         self.assertFalse(distance == 0.0)
 
     @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
-    def testSymmetry(self):
+    def test_symmetry(self):
         '''Check that distance is symmetric.'''
 
         model = word2vec.Word2Vec(sentences, min_count=2, seed=42, workers=1)
@@ -1041,7 +1041,7 @@ class TestWMD(unittest.TestCase):
         self.assertTrue(np.allclose(distance1, distance2))
 
     @unittest.skipIf(PYEMD_EXT is False, "pyemd not installed")
-    def testIdenticalSentences(self):
+    def test_identical_sentences(self):
         '''Check that the distance from a sentence to itself is zero.'''
 
         model = word2vec.Word2Vec(sentences, min_count=1)
@@ -1051,14 +1051,14 @@ class TestWMD(unittest.TestCase):
 
 
 class TestWord2VecSentenceIterators(unittest.TestCase):
-    def testLineSentenceWorksWithFilename(self):
+    def test_line_sentence_works_with_filename(self):
         """Does LineSentence work with a filename argument?"""
         with utils.open(datapath('lee_background.cor'), 'rb') as orig:
             sentences = word2vec.LineSentence(datapath('lee_background.cor'))
             for words in sentences:
                 self.assertEqual(words, utils.to_unicode(orig.readline()).split())
 
-    def testCythonLineSentenceWorksWithFilename(self):
+    def test_cython_line_sentence_works_with_filename(self):
         """Does CythonLineSentence work with a filename argument?"""
         from gensim.models import word2vec_corpusfile
         with utils.open(datapath('lee_background.cor'), 'rb') as orig:
@@ -1066,14 +1066,14 @@ class TestWord2VecSentenceIterators(unittest.TestCase):
             for words in sentences:
                 self.assertEqual(words, orig.readline().split())
 
-    def testLineSentenceWorksWithCompressedFile(self):
+    def test_line_sentence_works_with_compressed_file(self):
         """Does LineSentence work with a compressed file object argument?"""
         with utils.open(datapath('head500.noblanks.cor'), 'rb') as orig:
             sentences = word2vec.LineSentence(bz2.BZ2File(datapath('head500.noblanks.cor.bz2')))
             for words in sentences:
                 self.assertEqual(words, utils.to_unicode(orig.readline()).split())
 
-    def testLineSentenceWorksWithNormalFile(self):
+    def test_line_sentence_works_with_normal_file(self):
         """Does LineSentence work with a file object argument, rather than filename?"""
         with utils.open(datapath('head500.noblanks.cor'), 'rb') as orig:
             with utils.open(datapath('head500.noblanks.cor'), 'rb') as fin:
@@ -1081,7 +1081,7 @@ class TestWord2VecSentenceIterators(unittest.TestCase):
                 for words in sentences:
                     self.assertEqual(words, utils.to_unicode(orig.readline()).split())
 
-    def testPathLineSentences(self):
+    def test_path_line_sentences(self):
         """Does PathLineSentences work with a path argument?"""
         with utils.open(os.path.join(datapath('PathLineSentences'), '1.txt'), 'rb') as orig1:
             with utils.open(os.path.join(datapath('PathLineSentences'), '2.txt.bz2'), 'rb') as orig2:
@@ -1092,7 +1092,7 @@ class TestWord2VecSentenceIterators(unittest.TestCase):
                     self.assertEqual(words, utils.to_unicode(orig[orig_counter]).split())
                     orig_counter += 1
 
-    def testPathLineSentencesOneFile(self):
+    def test_path_line_sentences_one_file(self):
         """Does PathLineSentences work with a single file argument?"""
         test_file = os.path.join(datapath('PathLineSentences'), '1.txt')
         with utils.open(test_file, 'rb') as orig:
@@ -1105,7 +1105,7 @@ class TestWord2VecSentenceIterators(unittest.TestCase):
 
 # TODO: get correct path to Python binary
 # class TestWord2VecScripts(unittest.TestCase):
-#     def testWord2VecStandAloneScript(self):
+#     def test_word2vec_stand_alone_script(self):
 #         """Does Word2Vec script launch standalone?"""
 #         cmd = 'python -m gensim.scripts.word2vec_standalone -train ' + datapath('testcorpus.txt') + \
 #               ' -output vec.txt -size 200 -sample 1e-4 -binary 0 -iter 3 -min_count 1'


### PR DESCRIPTION
I have written this script to convert all camelCase function names in tests to snake_case: https://gist.github.com/sezanzeb/ca1f4ebc36f6f65915b5bbb6385db24e

~wip until ci confirms that the same number of tests is still executed and that the replacement didn't cause long lines~