### PR TITLE
Update repos before trying to install gdb

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install tox, gdb
         run: |
           pip install tox
+          sudo apt-get update -y
           sudo apt-get install -y gdb
       - name: Enable core dumps
         run: ulimit -c unlimited -S  # enable core dumps


### PR DESCRIPTION
I was able to reproduce the behaviour with the test failing. Updating the repo before trying to install gdb helped.

Build log: https://github.com/janaknat/gensim/actions/runs/523516055