### PR TITLE
Fixing flaky test

### DIFF
--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -428,7 +428,7 @@ class TestFastTextModel(unittest.TestCase):
         self.assertGreaterEqual(
             overlap_count, 2,
             "only %i overlap in expected %s & actual %s" % (overlap_count, expected_sims_words, sims_gensim_words))
-    
+
     @flaky
     def test_cbow_hs_training_fromfile(self):
         with temporary_file(get_tmpfile('gensim_fasttext.tst')) as corpus_file:

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import struct
 import sys
-
+from flaky import flaky
 import numpy as np
 
 from gensim import utils

--- a/gensim/test/test_fasttext.py
+++ b/gensim/test/test_fasttext.py
@@ -428,7 +428,8 @@ class TestFastTextModel(unittest.TestCase):
         self.assertGreaterEqual(
             overlap_count, 2,
             "only %i overlap in expected %s & actual %s" % (overlap_count, expected_sims_words, sims_gensim_words))
-
+    
+    @flaky
     def test_cbow_hs_training_fromfile(self):
         with temporary_file(get_tmpfile('gensim_fasttext.tst')) as corpus_file:
             model_gensim = FT_gensim(

--- a/setup.py
+++ b/setup.py
@@ -267,6 +267,7 @@ visdom_req = ['visdom >= 0.1.8, != 0.1.8.7']
 # packages included for build-testing everywhere
 core_testenv = [
     'pytest',
+    'flaky',
 #    'pytest-rerunfailures',  # disabled 2020-08-28 for <https://github.com/pytest-dev/pytest-rerunfailures/issues/128>
     'mock',
     'cython',


### PR DESCRIPTION
The test `test_cbow_hs_training_fromfile` is flaky. It failed 21 out of 250 times that I ran. This PR addresses this issue.

In some cases, the assertion fails when `overlap_count` is less than 2 (it can be 1 or 0). To reduce the flakiness of this test, I suggest marking it as flaky, so that it can be re-run once on failure. Running twice will reduce the failure rate to less than 1% instead of over 8% currently. 

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions. Also, here I assume there are no bugs in the code under test.
