### PR TITLE
modify comment in LdaModel.inference() to be more explicit

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -687,7 +687,7 @@ class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             expElogthetad = expElogtheta[d, :]
             expElogbetad = self.expElogbeta[:, ids]
 
-            # The optimal phi_{dwk} is proportional to expElogthetad_k * expElogbetad_w.
+            # The optimal phi_{dwk} is proportional to expElogthetad_k * expElogbetad_kw.
             # phinorm is the normalizer.
             # TODO treat zeros explicitly, instead of adding epsilon?
             phinorm = np.dot(expElogthetad, expElogbetad) + epsilon


### PR DESCRIPTION
 One comment  in LdaModel.inference() confused me:
`# The optimal phi_{dwk} is proportional to expElogthetad_k * expElogbetad_w.`
And I think it should modified to this so the comment would be more accurate:
`# The optimal phi_{dwk} is proportional to expElogthetad_k * expElogbetad_kw.`

Reasons:
1.
According to Algorithm 1 on paper:
Online Learning for Latent Dirichlet Allocation, NIPS 2010 <http://www.cs.princeton.edu/~mdhoffma>, 
phi_dwk is proportional to exp(Elogtheta_dk + Elogbeta_kw).
2.
`phi_{dwk}` is a scalar,  `expElogthetad_k ` is a scalar, and `expElogbetad_w `is a vector with K elements,  so  `expElogthetad_k * expElogbetad_w` will return a vector with K elements, which does not match the type of `phi_{dwk}`. If we use `expElogthetad_k * expElogbetad_kw` instead, in which `expElogbetad_kw `is a scalar, it matches.
