### PR TITLE
Issue 3064, idf formula of BM25 corrected. 

### DIFF
--- a/gensim/summarization/bm25.py
+++ b/gensim/summarization/bm25.py
@@ -32,7 +32,6 @@ Data:
 -----
 .. data:: PARAM_K1 - Free smoothing parameter for BM25.
 .. data:: PARAM_B - Free smoothing parameter for BM25.
-.. data:: EPSILON - Constant used for negative idf of document in corpus.
 
 """
 
@@ -47,7 +46,6 @@ from ..utils import effective_n_jobs
 
 PARAM_K1 = 1.5
 PARAM_B = 0.75
-EPSILON = 0.25
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +67,7 @@ class BM25(object):
         List of document lengths.
     """
 
-    def __init__(self, corpus, k1=PARAM_K1, b=PARAM_B, epsilon=EPSILON):
+    def __init__(self, corpus, k1=PARAM_K1, b=PARAM_B):
         """
         Parameters
         ----------
@@ -85,19 +83,11 @@ class BM25(object):
             When b is bigger, lengthier documents (compared to average) have more impact on its effect. According to
             [1]_, experiments suggest that 0.5 < b < 0.8 yields reasonably good results, although the optimal value
             depends on factors such as the type of documents or queries.
-        epsilon : float
-            Constant used as floor value for idf of a document in the corpus. When epsilon is positive, it restricts
-            negative idf values. Negative idf implies that adding a very common term to a document penalize the overall
-            score (with 'very common' meaning that it is present in more than half of the documents). That can be
-            undesirable as it means that an identical document would score less than an almost identical one (by
-            removing the referred term). Increasing epsilon above 0 raises the sense of how rare a word has to be (among
-            different documents) to receive an extra score.
 
         """
 
         self.k1 = k1
         self.b = b
-        self.epsilon = epsilon
 
         self.corpus_size = 0
         self.avgdl = 0
@@ -128,29 +118,9 @@ class BM25(object):
                 nd[word] += 1
 
         self.avgdl = float(num_doc) / self.corpus_size
-        # collect idf sum to calculate an average idf for epsilon value
-        idf_sum = 0
-        # collect words with negative idf to set them a special epsilon value.
-        # idf can be negative if word is contained in more than half of documents
-        negative_idfs = []
         for word, freq in iteritems(nd):
-            idf = math.log(self.corpus_size - freq + 0.5) - math.log(freq + 0.5)
+            idf = math.log((self.corpus_size - freq + 0.5) / (freq + 0.5) + 1)
             self.idf[word] = idf
-            idf_sum += idf
-            if idf < 0:
-                negative_idfs.append(word)
-        self.average_idf = float(idf_sum) / len(self.idf)
-
-        if self.average_idf < 0:
-            logger.warning(
-                'Average inverse document frequency is less than zero. Your corpus of {} documents'
-                ' is either too small or it does not originate from natural text. BM25 may produce'
-                ' unintuitive results.'.format(self.corpus_size)
-            )
-
-        eps = self.epsilon * self.average_idf
-        for word in negative_idfs:
-            self.idf[word] = eps
 
     def get_score(self, document, index):
         """Computes BM25 score of given `document` in relation to item of corpus selected by `index`.
@@ -260,7 +230,7 @@ def _get_scores(bm25, document):
     return bm25.get_scores(document)
 
 
-def iter_bm25_bow(corpus, n_jobs=1, k1=PARAM_K1, b=PARAM_B, epsilon=EPSILON):
+def iter_bm25_bow(corpus, n_jobs=1, k1=PARAM_K1, b=PARAM_B):
     """Yield BM25 scores (weights) of documents in corpus.
     Each document has to be weighted with every document in given corpus.
 
@@ -280,13 +250,6 @@ def iter_bm25_bow(corpus, n_jobs=1, k1=PARAM_K1, b=PARAM_B, epsilon=EPSILON):
         When b is bigger, lengthier documents (compared to average) have more impact on its effect. According to
         [1]_, experiments suggest that 0.5 < b < 0.8 yields reasonably good results, although the optimal value
         depends on factors such as the type of documents or queries.
-    epsilon : float
-        Constant used as floor value for idf of a document in the corpus. When epsilon is positive, it restricts
-        negative idf values. Negative idf implies that adding a very common term to a document penalize the overall
-        score (with 'very common' meaning that it is present in more than half of the documents). That can be
-        undesirable as it means that an identical document would score less than an almost identical one (by
-        removing the referred term). Increasing epsilon above 0 raises the sense of how rare a word has to be (among
-        different documents) to receive an extra score.
 
     Yields
     -------
@@ -306,7 +269,7 @@ def iter_bm25_bow(corpus, n_jobs=1, k1=PARAM_K1, b=PARAM_B, epsilon=EPSILON):
         >>> result = iter_bm25_weights(corpus, n_jobs=-1)
 
     """
-    bm25 = BM25(corpus, k1, b, epsilon)
+    bm25 = BM25(corpus, k1, b)
 
     n_processes = effective_n_jobs(n_jobs)
     if n_processes == 1:
@@ -323,7 +286,7 @@ def iter_bm25_bow(corpus, n_jobs=1, k1=PARAM_K1, b=PARAM_B, epsilon=EPSILON):
     pool.join()
 
 
-def get_bm25_weights(corpus, n_jobs=1, k1=PARAM_K1, b=PARAM_B, epsilon=EPSILON):
+def get_bm25_weights(corpus, n_jobs=1, k1=PARAM_K1, b=PARAM_B):
     """Returns BM25 scores (weights) of documents in corpus.
     Each document has to be weighted with every document in given corpus.
 
@@ -343,13 +306,6 @@ def get_bm25_weights(corpus, n_jobs=1, k1=PARAM_K1, b=PARAM_B, epsilon=EPSILON):
         When b is bigger, lengthier documents (compared to average) have more impact on its effect. According to
         [1]_, experiments suggest that 0.5 < b < 0.8 yields reasonably good results, although the optimal value
         depends on factors such as the type of documents or queries.
-    epsilon : float
-        Constant used as floor value for idf of a document in the corpus. When epsilon is positive, it restricts
-        negative idf values. Negative idf implies that adding a very common term to a document penalize the overall
-        score (with 'very common' meaning that it is present in more than half of the documents). That can be
-        undesirable as it means that an identical document would score less than an almost identical one (by
-        removing the referred term). Increasing epsilon above 0 raises the sense of how rare a word has to be (among
-        different documents) to receive an extra score.
 
     Returns
     -------
@@ -369,7 +325,7 @@ def get_bm25_weights(corpus, n_jobs=1, k1=PARAM_K1, b=PARAM_B, epsilon=EPSILON):
         >>> result = get_bm25_weights(corpus, n_jobs=-1)
 
     """
-    bm25 = BM25(corpus, k1, b, epsilon)
+    bm25 = BM25(corpus, k1, b)
 
     n_processes = effective_n_jobs(n_jobs)
     if n_processes == 1:

--- a/gensim/test/test_BM25.py
+++ b/gensim/test/test_BM25.py
@@ -114,42 +114,6 @@ class TestBM25(unittest.TestCase):
         second_score = second_weights[index]
         self.assertLess(first_score, second_score)
 
-    def test_epsilon(self):
-        """ Changing the b parameter should give consistent results """
-        corpus = [['cat', 'dog', 'mouse'], ['cat', 'lion'], ['cat', 'lion']]
-        first_epsilon = 1.0
-        second_epsilon = 2.0
-        bm25 = BM25(corpus)
-        words_with_negative_idfs = set([
-            word
-            for word, idf in bm25.idf.items()
-            if idf < 0
-        ])
-        index, doc = [
-            (index, document)
-            for index, document
-            in enumerate(corpus)
-            if words_with_negative_idfs & set(document)
-        ][0]
-
-        first_bm25 = BM25(corpus, epsilon=first_epsilon)
-        second_bm25 = BM25(corpus, epsilon=second_epsilon)
-        first_score = first_bm25.get_score(doc, index)
-        second_score = second_bm25.get_score(doc, index)
-        self.assertGreater(first_score, second_score)
-
-        first_iter = iter_bm25_bow(corpus, epsilon=first_epsilon)
-        second_iter = iter_bm25_bow(corpus, epsilon=second_epsilon)
-        first_score = dict(next(iter(first_iter)))[index]
-        second_score = dict(next(iter(second_iter)))[index]
-        self.assertGreater(first_score, second_score)
-
-        first_weights = get_bm25_weights(corpus, epsilon=first_epsilon)
-        second_weights = get_bm25_weights(corpus, epsilon=second_epsilon)
-        first_score = first_weights[index]
-        second_score = second_weights[index]
-        self.assertGreater(first_score, second_score)
-
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -12,3 +12,5 @@ testfixtures==6.10.0
 statsmodels==0.10.1
 pyemd==0.5.1
 pandas==0.25.2
+mock==4.0.3
+Levenshtein==0.12.0


### PR DESCRIPTION
Fixes #3064.

The idf computation of BM25 model has been corrected (according to <https://en.wikipedia.org/wiki/Okapi_BM25>). With this modification, a word can't have a negative idf value. So no more counter intuitive scores for documents that have too many frequent words.

Since we can't have negative idf values anymore, there's no need for the epsilon parameter. Hence, it has been removed from BM25.

2 missing dependencies have also been added to `requirements_docs.txt`.