### PR TITLE
Fix some of the warnings/ deprecated functions 

### DIFF
--- a/gensim/matutils.py
+++ b/gensim/matutils.py
@@ -724,7 +724,7 @@ def unitvec(vec, norm='l2', return_norm=False):
             veclen = vec.nnz
         if veclen > 0.0:
             if np.issubdtype(vec.dtype, np.integer):
-                vec = vec.astype(np.float)
+                vec = vec.astype(float)
             vec /= veclen
             if return_norm:
                 return vec, veclen
@@ -748,7 +748,7 @@ def unitvec(vec, norm='l2', return_norm=False):
             veclen = np.count_nonzero(vec)
         if veclen > 0.0:
             if np.issubdtype(vec.dtype, np.integer):
-                vec = vec.astype(np.float)
+                vec = vec.astype(float)
             if return_norm:
                 return blas_scal(1.0 / veclen, vec).astype(vec.dtype), veclen
             else:

--- a/gensim/models/atmodel.py
+++ b/gensim/models/atmodel.py
@@ -463,11 +463,11 @@ class AuthorTopicModel(LdaModel):
                 ids = [int(idx) for idx, _ in doc]
             else:
                 ids = [idx for idx, _ in doc]
-            ids = np.array(ids, dtype=np.int)
-            cts = np.fromiter((cnt for _, cnt in doc), dtype=np.int, count=len(doc))
+            ids = np.array(ids, dtype=int)
+            cts = np.fromiter((cnt for _, cnt in doc), dtype=int, count=len(doc))
 
             # Get all authors in current document, and convert the author names to integer IDs.
-            authors_d = np.fromiter((self.author2id[a] for a in self.doc2author[doc_no]), dtype=np.int)
+            authors_d = np.fromiter((self.author2id[a] for a in self.doc2author[doc_no]), dtype=int)
 
             gammad = self.state.gamma[authors_d, :]  # gamma of document d before update.
             tilde_gamma = gammad.copy()  # gamma that will be updated.
@@ -975,9 +975,9 @@ class AuthorTopicModel(LdaModel):
             else:
                 doc_no = d
             # Get all authors in current document, and convert the author names to integer IDs.
-            authors_d = np.fromiter((self.author2id[a] for a in self.doc2author[doc_no]), dtype=np.int)
-            ids = np.fromiter((id for id, _ in doc), dtype=np.int, count=len(doc))  # Word IDs in doc.
-            cts = np.fromiter((cnt for _, cnt in doc), dtype=np.int, count=len(doc))  # Word counts.
+            authors_d = np.fromiter((self.author2id[a] for a in self.doc2author[doc_no]), dtype=int)
+            ids = np.fromiter((id for id, _ in doc), dtype=int, count=len(doc))  # Word IDs in doc.
+            cts = np.fromiter((cnt for _, cnt in doc), dtype=int, count=len(doc))  # Word counts.
 
             if d % self.chunksize == 0:
                 logger.debug("bound: at document #%i in chunk", d)

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -501,7 +501,7 @@ class KeyedVectors(utils.SaveLoad):
         # initially allocate extras, check type compatibility
         self.allocate_vecattrs(extras.keys(), [extras[k].dtype for k in extras.keys()])
 
-        in_vocab_mask = np.zeros(len(keys), dtype=np.bool)
+        in_vocab_mask = np.zeros(len(keys), dtype=bool)
         for idx, key in enumerate(keys):
             if key in self:
                 in_vocab_mask[idx] = True

--- a/gensim/models/nmf.py
+++ b/gensim/models/nmf.py
@@ -93,7 +93,8 @@ The NMF should be used whenever one needs extremely fast and memory optimized to
 
 """
 
-import collections
+
+import collections.abc as collections
 import logging
 
 import numpy as np

--- a/gensim/test/test_matutils.py
+++ b/gensim/test/test_matutils.py
@@ -144,7 +144,7 @@ class TestLdaModelInner(unittest.TestCase):
 
 def manual_unitvec(vec):
     # manual unit vector calculation for UnitvecTestCase
-    vec = vec.astype(np.float)
+    vec = vec.astype(float)
     if sparse.issparse(vec):
         vec_sum_of_squares = vec.multiply(vec)
         unit = 1. / np.sqrt(vec_sum_of_squares.sum())

--- a/gensim/utils.py
+++ b/gensim/utils.py
@@ -8,7 +8,7 @@
 
 from __future__ import with_statement
 from contextlib import contextmanager
-import collections
+import collections.abc as collections
 import logging
 import warnings
 import numbers


### PR DESCRIPTION

Closes https://github.com/RaRe-Technologies/gensim/issues/3066
Addresses https://github.com/RaRe-Technologies/gensim/issues/3014

Remaining (removed windows specific warnings): 

```
.tox\py39-win\lib\site-packages\scipy\sparse\sparsetools.py:21
  c:\users\dell\documents\github\gensim\.tox\py39-win\lib\site-packages\scipy\sparse\sparsetools.py:21: DeprecationWarning: `parse.sparsetools` is deprecated!
  scipy.sparse.sparsetools is a private module for scipy.sparse, and should not be used.
    _deprecated()

gensim/test/test_api.py::TestApi::test_load_dataset
gensim/test/test_api.py::TestApi::test_multipart_load
  c:\users\dell\documents\github\gensim\.tox\py39-win\lib\site-packages\smart_open\smart_open_lib.py:479: DeprecationWarning:unction is deprecated.  See https://github.com/RaRe-Technologies/smart_open/blob/develop/MIGRATING_FROM_OLDER_VERSIONS.rst fo
information
    warnings.warn(message, category=DeprecationWarning)

gensim/test/test_ldaseqmodel.py::TestLdaSeq::test_doc_topic
gensim/test/test_ldaseqmodel.py::TestLdaSeq::test_dtype_backward_compatibility
gensim/test/test_ldaseqmodel.py::TestLdaSeq::test_topic_word
  C:\Users\Dell\Documents\GitHub\gensim\gensim\models\ldaseqmodel.py:297: RuntimeWarning: divide by zero encountered in doublrs
    convergence = np.fabs((bound - old_bound) / old_bound)

gensim/test/test_lsimodel.py::TestLsiModel::test_online_transform
gensim/test/test_lsimodel.py::TestLsiModel::test_online_transform
gensim/test/test_lsimodel.py::TestLsiModel::test_online_transform
  c:\users\dell\documents\github\gensim\.tox\py39-win\lib\site-packages\numpy\matrixlib\defmatrix.py:1109: PendingDeprecation: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.orumpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
    return matrix(concatenate(arr_rows, axis=0))

gensim/test/test_miislita.py: 1 warning
gensim/test/test_sharded_corpus.py: 15 warnings
  C:\Users\Dell\Documents\GitHub\gensim\gensim\interfaces.py:92: UserWarning: corpus.save() stores only the (tiny) iteration 
in memory; to serialize the actual corpus content, use e.g. MmCorpus.serialize(corpus)
    warnings.warn(

```