### PR TITLE
Fix documentation links: Travis to Github Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ scientific computing. You must have them installed prior to installing
 gensim.
 
 It is also recommended you install a fast BLAS library before installing
-NumPy. This is optional, but using an optimized BLAS such as [ATLAS] or
+NumPy. This is optional, but using an optimized BLAS such as MKL, [ATLAS] or
 [OpenBLAS] is known to improve performance by as much as an order of
-magnitude. On OS X, NumPy picks up the BLAS that comes with it
-automatically, so you don’t need to do anything special.
+magnitude. On OSX, NumPy picks up its vecLib BLAS automatically,
+so you don’t need to do anything special.
 
 Install the latest version of gensim:
 
@@ -77,7 +77,8 @@ package:
 
 For alternative modes of installation, see the [documentation].
 
-Gensim is being [continuously tested](https://travis-ci.org/RaRe-Technologies/gensim) under Python 3.6, 3.7 and 3.8.
+Gensim is being [continuously tested](http://radimrehurek.com/gensim/#testing) under all
+[supported Python versions](https://github.com/RaRe-Technologies/gensim/wiki/Gensim-And-Compatibility).
 Support for Python 2.7 was dropped in gensim 4.0.0 – install gensim 3.8.3 if you must use Python 2.7.
 
 How come gensim is so fast and memory efficient? Isn’t it pure Python, and isn’t Python slow and greedy?
@@ -162,14 +163,11 @@ BibTeX entry:
 
   [citing gensim in academic papers and theses]: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=9vG_kV0AAAAJ&citation_for_view=9vG_kV0AAAAJ:NaGl4SEjCO4C
 
-  [Travis CI for automated testing]: https://travis-ci.org/RaRe-Technologies/gensim
   [design goals]: http://radimrehurek.com/gensim/about.html
   [RaRe Technologies]: http://rare-technologies.com/wp-content/uploads/2016/02/rare_image_only.png%20=10x20
   [rare\_tech]: //rare-technologies.com
   [Talentpair]: https://avatars3.githubusercontent.com/u/8418395?v=3&s=100
   [citing gensim in academic papers and theses]: https://scholar.google.cz/citations?view_op=view_citation&hl=en&user=9vG_kV0AAAAJ&citation_for_view=9vG_kV0AAAAJ:u-x6o8ySG0sC
-
-
 
   [documentation and Jupyter Notebook tutorials]: https://github.com/RaRe-Technologies/gensim/#documentation
   [Vector Space Model]: http://en.wikipedia.org/wiki/Vector_space_model

--- a/docs/src/_templates/indexcontent.html
+++ b/docs/src/_templates/indexcontent.html
@@ -108,7 +108,7 @@
                 <div class="mcb-wrap-inner">
                   <div class="column mcb-column mcb-item-jypwdj8nx three-fifth column_column">
                     <div class="column_attr clearfix" style>
-                      <h2>Installation</h2>
+                      <h2 id="install">Installation</h2>
                     </div>
                   </div>
                   <div class="column mcb-column mcb-item-jg4w6j6zg one column_divider">
@@ -161,7 +161,7 @@
                     </div>
                   </div>
                   <div class="column mcb-column mcb-item-jg4w6j6zg one">
-                    <h3>Testing Gensim</h3>
+                    <h3 id="testing">Testing Gensim</h3>
                   </div>
                   <div class="column mcb-column mcb-item-pm31t65yi one">
                     <div class="column_attr clearfix" style>
@@ -174,10 +174,10 @@
                           <th>Build status</th>
                         </tr>
                         <tr>
-                          <td>Travis</td>
-                          <td>Run tests on Linux and check code-style</td>
-                          <td><a href="https://travis-ci.org/RaRe-Technologies/gensim"><img alt="Travis"
-                                                                                            src="https://travis-ci.org/RaRe-Technologies/gensim.svg?branch=develop"></a>
+                          <td>Github Actions</td>
+                          <td>Run tests on Linux and Mac, plus check code-style</td>
+                          <td><a href="https://github.com/RaRe-Technologies/gensim/actions"><img alt="Github Action"
+                                                                                            src="https://github.com/RaRe-Technologies/gensim/actions/workflows/tests.yml/badge.svg?branch=develop"></a>
                           </td>
                         </tr>
                         <tr>

--- a/setup.py
+++ b/setup.py
@@ -155,13 +155,13 @@ LONG_DESCRIPTION = u"""
 gensim -- Topic Modelling in Python
 ==============================================
 
-|Travis|_
+|GA|_
 |Wheel|_
 
-.. |Travis| image:: https://img.shields.io/travis/RaRe-Technologies/gensim/develop.svg
+.. |GA| image:: https://github.com/RaRe-Technologies/gensim/actions/workflows/tests.yml/badge.svg?branch=develop
 .. |Wheel| image:: https://img.shields.io/pypi/wheel/gensim.svg
 
-.. _Travis: https://travis-ci.org/RaRe-Technologies/gensim
+.. _GA: https://github.com/RaRe-Technologies/gensim/actions
 .. _Downloads: https://pypi.python.org/pypi/gensim
 .. _License: http://radimrehurek.com/gensim/about.html
 .. _Wheel: https://pypi.python.org/pypi/gensim
@@ -194,7 +194,7 @@ Installation
 This software depends on `NumPy and Scipy <http://www.scipy.org/Download>`_, two Python packages for scientific computing.
 You must have them installed prior to installing `gensim`.
 
-It is also recommended you install a fast BLAS library before installing NumPy. This is optional, but using an optimized BLAS such as `ATLAS <http://math-atlas.sourceforge.net/>`_ or `OpenBLAS <http://xianyi.github.io/OpenBLAS/>`_ is known to improve performance by as much as an order of magnitude. On OS X, NumPy picks up the BLAS that comes with it automatically, so you don't need to do anything special.
+It is also recommended you install a fast BLAS library before installing NumPy. This is optional, but using an optimized BLAS such as MKL, `ATLAS <http://math-atlas.sourceforge.net/>`_ or `OpenBLAS <http://xianyi.github.io/OpenBLAS/>`_ is known to improve performance by as much as an order of magnitude. On OSX, NumPy picks up its vecLib BLAS automatically, so you don't need to do anything special.
 
 Install the latest version of gensim::
 
@@ -205,9 +205,9 @@ Or, if you have instead downloaded and unzipped the `source tar.gz <http://pypi.
     python setup.py install
 
 
-For alternative modes of installation, see the `documentation <http://radimrehurek.com/gensim/install.html>`_.
+For alternative modes of installation, see the `documentation <http://radimrehurek.com/gensim/#install>`_.
 
-Gensim is being `continuously tested <https://travis-ci.org/RaRe-Technologies/gensim>`_ under Python 3.6, 3.7 and 3.8.
+Gensim is being `continuously tested <http://radimrehurek.com/gensim/#testing>`_ under all `supported Python versions <https://github.com/RaRe-Technologies/gensim/wiki/Gensim-And-Compatibility>`_.
 Support for Python 2.7 was dropped in gensim 4.0.0 – install gensim 3.8.3 if you must use Python 2.7.
 
 


### PR DESCRIPTION
Following up on https://github.com/RaRe-Technologies/gensim/commit/ee3d6fd1e33fe39fc7aa31ebd56bd63b1a2a2ed6, updating the CI links consistently everywhere.