### PR TITLE
Fix bug where saved Phrases model did not load its connector_words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes
 
 - LsiModel: Only log top words that actually exist in the dictionary (PR [#3091](https://github.com/RaRe-Technologies/gensim/pull/3091), [@kmurphy4](https://github.com/kmurphy4))
 - [#3115](https://github.com/RaRe-Technologies/gensim/pull/3115): Make LSI dispatcher CLI param for number of jobs optional, by [@robguinness](https://github.com/robguinness))
+- fix bug when loading saved Phrases model (PR [#3116](https://github.com/RaRe-Technologies/gensim/pull/3116), [@aloknayak29](https://github.com/aloknayak29))
 
 ### Documentation
 

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -396,8 +396,7 @@ s        """
                 model.connector_words = model.common_terms
                 del model.common_terms
             else:
-                logger.warning('older version of %s loaded without common_terms attribute, '
-                               'setting connector_words to an empty set', cls.__name__)
+                logger.warning('loaded older version of %s, setting connector_words to an empty set', cls.__name__)
                 model.connector_words = frozenset()
 
         if not hasattr(model, 'corpus_word_count'):

--- a/gensim/models/phrases.py
+++ b/gensim/models/phrases.py
@@ -391,15 +391,14 @@ s        """
                     raise ValueError(f'failed to load {cls.__name__} model, unknown scoring "{model.scoring}"')
 
         # common_terms didn't exist pre-3.?, and was renamed to connector in 4.0.0.
-        if hasattr(model, "common_terms"):
-            model.connector_words = model.common_terms
-            del model.common_terms
-        else:
-            logger.warning(
-                'older version of %s loaded without common_terms attribute, setting connector_words to an empty set',
-                cls.__name__,
-            )
-            model.connector_words = frozenset()
+        if not hasattr(model, "connector_words"):
+            if hasattr(model, "common_terms"):
+                model.connector_words = model.common_terms
+                del model.common_terms
+            else:
+                logger.warning('older version of %s loaded without common_terms attribute, '
+                               'setting connector_words to an empty set', cls.__name__)
+                model.connector_words = frozenset()
 
         if not hasattr(model, 'corpus_word_count'):
             logger.warning('older version of %s loaded without corpus_word_count', cls.__name__)

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -305,41 +305,42 @@ class TestPhrasesModel(PhrasesCommon, unittest.TestCase):
 
 
 class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
-
     def test_save_load_custom_scorer(self):
         """Test saving and loading a Phrases object with a custom scorer."""
+        bigram = Phrases(self.sentences, min_count=1, threshold=.001, scoring=dumb_scorer)
         with temporary_file("test.pkl") as fpath:
-            bigram = Phrases(self.sentences, min_count=1, threshold=.001, scoring=dumb_scorer)
             bigram.save(fpath)
             bigram_loaded = Phrases.load(fpath)
-            test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
-            seen_scores = list(bigram_loaded.find_phrases(test_sentences).values())
 
-            assert all(score == 1 for score in seen_scores)
-            assert len(seen_scores) == 3  # 'graph minors' and 'survey human' and 'interface system'
+        test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
+        seen_scores = list(bigram_loaded.find_phrases(test_sentences).values())
+
+        assert all(score == 1 for score in seen_scores)
+        assert len(seen_scores) == 3  # 'graph minors' and 'survey human' and 'interface system'
 
     def test_save_load(self):
         """Test saving and loading a Phrases object."""
+        bigram = Phrases(self.sentences, min_count=1, threshold=1)
         with temporary_file("test.pkl") as fpath:
-            bigram = Phrases(self.sentences, min_count=1, threshold=1)
             bigram.save(fpath)
             bigram_loaded = Phrases.load(fpath)
-            test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
-            seen_scores = set(round(score, 3) for score in bigram_loaded.find_phrases(test_sentences).values())
 
-            assert seen_scores == set([
-                5.167,  # score for graph minors
-                3.444  # score for human interface
-            ])
+        test_sentences = [['graph', 'minors', 'survey', 'human', 'interface', 'system']]
+        seen_scores = set(round(score, 3) for score in bigram_loaded.find_phrases(test_sentences).values())
+        assert seen_scores == set([
+            5.167,  # score for graph minors
+            3.444  # score for human interface
+        ])
 
     def test_save_load_with_connector_words(self):
         """Test saving and loading a Phrases object."""
         connector_words = frozenset({'of'})
+        bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=connector_words)
         with temporary_file("test.pkl") as fpath:
-            bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=connector_words)
             bigram.save(fpath)
             bigram_loaded = Phrases.load(fpath)
-            self.assertEqual(bigram_loaded.connector_words, connector_words)
+
+        assert bigram_loaded.connector_words == connector_words
 
     def test_save_load_string_scoring(self):
         """Test backwards compatibility with a previous version of Phrases with custom scoring."""

--- a/gensim/test/test_phrases.py
+++ b/gensim/test/test_phrases.py
@@ -332,6 +332,15 @@ class TestPhrasesPersistence(PhrasesData, unittest.TestCase):
                 3.444  # score for human interface
             ])
 
+    def test_save_load_with_connector_words(self):
+        """Test saving and loading a Phrases object."""
+        connector_words = frozenset({'of'})
+        with temporary_file("test.pkl") as fpath:
+            bigram = Phrases(self.sentences, min_count=1, threshold=1, connector_words=connector_words)
+            bigram.save(fpath)
+            bigram_loaded = Phrases.load(fpath)
+            self.assertEqual(bigram_loaded.connector_words, connector_words)
+
     def test_save_load_string_scoring(self):
         """Test backwards compatibility with a previous version of Phrases with custom scoring."""
         bigram_loaded = Phrases.load(datapath("phrases-scoring-str.pkl"))
@@ -384,6 +393,15 @@ class TestFrozenPhrasesPersistence(PhrasesData, unittest.TestCase):
             self.assertEqual(
                 bigram_loaded[['graph', 'minors', 'survey', 'human', 'interface', 'system']],
                 ['graph_minors', 'survey', 'human_interface', 'system'])
+
+    def test_save_load_with_connector_words(self):
+        """Test saving and loading a FrozenPhrases object."""
+        connector_words = frozenset({'of'})
+        with temporary_file("test.pkl") as fpath:
+            bigram = FrozenPhrases(Phrases(self.sentences, min_count=1, threshold=1, connector_words=connector_words))
+            bigram.save(fpath)
+            bigram_loaded = FrozenPhrases.load(fpath)
+            self.assertEqual(bigram_loaded.connector_words, connector_words)
 
     def test_save_load_string_scoring(self):
         """Test saving and loading a FrozenPhrases object with a string scoring parameter.


### PR DESCRIPTION
Bug description: If we have saved the trained phrases model in this version i.e gensim version 4.0.0 or 4.0.1, while giving non empty connector_words. And If we try to load the saved model in this version itself. Then the connector_words of the loaded phrases model will be wrongly assigned empty frozen set. This is a functional bug and will result in some of the words not getting grouped in ngram