### PR TITLE
Fix URL for ldamodel.py

### DIFF
--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2011 Radim Rehurek <radimrehurek@seznam.cz>
 # Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
 
-"""Optimized `Latent Dirichlet Allocation (LDA) <https://en.wikipedia.org/wiki/Latent_Dirichlet_allocation>` in Python.
+"""Optimized `Latent Dirichlet Allocation (LDA) <https://en.wikipedia.org/wiki/Latent_Dirichlet_allocation>`_ in Python.
 
 For a faster implementation of LDA (parallelized for multicore machines), see also :mod:`gensim.models.ldamulticore`.
 


### PR DESCRIPTION
The [API docs](https://radimrehurek.com/gensim/models/ldamodel.html) were not displayed correctly.
![image](https://user-images.githubusercontent.com/9538230/114900761-76869c80-9e14-11eb-8c8c-171ea5364a18.png)
