### PR TITLE
Materialize and copy the corpus passed to SoftCosineSimilarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes
 ## Unreleased
 
 - LsiModel: Only log top words that actually exist in the dictionary (PR [#3091](https://github.com/RaRe-Technologies/gensim/pull/3091), [@kmurphy4](https://github.com/kmurphy4))
+- Materialize and copy the corpus passed to SoftCosineSimilarity (PR [#3128](https://github.com/RaRe-Technologies/gensim/pull/3128), [@Witiko](https://github.com/Witiko))
 - [#3115](https://github.com/RaRe-Technologies/gensim/pull/3115): Make LSI dispatcher CLI param for number of jobs optional, by [@robguinness](https://github.com/robguinness))
 
 ### Documentation

--- a/gensim/similarities/docsim.py
+++ b/gensim/similarities/docsim.py
@@ -937,7 +937,7 @@ class SoftCosineSimilarity(interfaces.SimilarityABC):
         """
         self.similarity_matrix = similarity_matrix
 
-        self.corpus = corpus
+        self.corpus = list(corpus)
         self.num_best = num_best
         self.chunksize = chunksize
         self.normalized = normalized


### PR DESCRIPTION
SoftCosineSimilarity currently does not perform any indexing and keeps a reference to the corpus passed to the constructor. This [can cause confusion](https://groups.google.com/g/gensim/c/3ksqzgCTWxI) if a corpus is lazy and requests for documents are only resolved when reading the corpus. In general, subclasses of the SimilarityABC interface are expected to materialize and copy (i.e. index) the corpus rather than just reference it.

Some classes, such as WmdSimilarity, do not conform to this expectation. However, these classes also don't work with traditional BoW corpora and should be considered novelties/outliers. SoftCosineSimilarity, on the other hand, is very similar to the core SparseMatrixSimilarity class, and should satisfy the same invariants even if they are generally unspoken.

This pull request makes SoftCosineSimilarity materialize and copy the corpus passed to the constructor using the `list()` built-in. This is a minimal change with no change of interface and little chance of regressions. A more thorough solution would be to index the corpus to a sparse CSC matrix. However, this would likely [break the interface](https://groups.google.com/g/gensim/c/3ksqzgCTWxI/m/QZZEv0r5AgAJ), which may be undesirable so soon after 4.0.0.