### PR TITLE
Update link for online LDA paper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changes
 * [#3123](https://github.com/RaRe-Technologies/gensim/pull/3123): Fix hyperlink for doc2vec tutorial, by [@AdityaSoni19031997](https://github.com/AdityaSoni19031997)
 * [#3125](https://github.com/RaRe-Technologies/gensim/pull/3125): Improve & unify docs for dirichlet priors, by [@jonaschn](https://github.com/jonaschn)
 * [#3133](https://github.com/RaRe-Technologies/gensim/pull/3133): Update link to Hoffman paper (online VB LDA), by [@jonaschn](https://github.com/jonaschn)
+* [#3141](https://github.com/RaRe-Technologies/gensim/pull/3141): Update link for online LDA paper, by [@dymil](https://github.com/dymil)
 
 ## 4.0.1, 2021-04-01
 

--- a/docs/src/wiki.rst
+++ b/docs/src/wiki.rst
@@ -236,5 +236,5 @@ into LDA topic distributions:
   By the way, improvements to the Wiki markup parsing code are welcome :-)
 
 .. [3] Hoffman, Blei, Bach. 2010. Online learning for Latent Dirichlet Allocation
-   [`pdf <http://www.cs.princeton.edu/~blei/papers/HoffmanBleiBach2010b.pdf>`_] [`code <http://www.cs.princeton.edu/~mdhoffma/>`_]
+   [`pdf <http://www.cs.columbia.edu/~blei/papers/HoffmanBleiBach2010b.pdf>`_] [`code <http://www.cs.princeton.edu/~mdhoffma/>`_]
 


### PR DESCRIPTION
The old link was broken, as Blei moved from Princeton to Columbia. The code link is also broken, but, alas, I don't know anywhere it's still alive.