### PR TITLE
Correct parameter name in documentation of fasttext.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changes
 * [#3125](https://github.com/RaRe-Technologies/gensim/pull/3125): Improve & unify docs for dirichlet priors, by [@jonaschn](https://github.com/jonaschn)
 * [#3133](https://github.com/RaRe-Technologies/gensim/pull/3133): Update link to Hoffman paper (online VB LDA), by [@jonaschn](https://github.com/jonaschn)
 * [#3141](https://github.com/RaRe-Technologies/gensim/pull/3141): Update link for online LDA paper, by [@dymil](https://github.com/dymil)
+* [#3155](https://github.com/RaRe-Technologies/gensim/pull/3155): Correct parameter name in documentation of fasttext.py, by [@bizzyvinci](https://github.com/bizzyvinci)
 
 ## 4.0.1, 2021-04-01
 

--- a/gensim/models/fasttext.py
+++ b/gensim/models/fasttext.py
@@ -301,7 +301,7 @@ class FastText(Word2Vec):
             uninitialized).
         min_count : int, optional
             The model ignores all words with total frequency lower than this.
-        size : int, optional
+        vector_size : int, optional
             Dimensionality of the word vectors.
         window : int, optional
             The maximum distance between the current and predicted word within a sentence.


### PR DESCRIPTION
Correct parameter name in documentation as mentioned in #3151.

Fix #3151 