### PR TITLE
Update Numpy minimum version to 1.17.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -315,7 +315,7 @@ docs_testenv = core_testenv + distributed_env + visdom_req + [
     'pandas',
 ]
 
-NUMPY_STR = 'numpy >= 1.11.3'
+NUMPY_STR = 'numpy >= 1.17.0'
 #
 # We pin the Cython version for reproducibility.  We expect our extensions
 # to build with any sane version of Cython, so we should update this pin


### PR DESCRIPTION
Based on the discussion in https://github.com/RaRe-Technologies/gensim/issues/3137 I am updating the minimum NumPy version to 1.17.0. It is required since otherwise users who install Gensim in the environment with an older NumPy version get `AttributeError: module 'numpy.random' has no attribute 'default_rng'` error.