### PR TITLE
Optimize word mover distance (WMD) computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changes
 * [#3115](https://github.com/RaRe-Technologies/gensim/pull/3115): Make LSI dispatcher CLI param for number of jobs optional, by [@robguinness](https://github.com/robguinness)
 * [#3128](https://github.com/RaRe-Technologies/gensim/pull/3128): Materialize and copy the corpus passed to SoftCosineSimilarity, by [@Witiko](https://github.com/Witiko)
 * [#3131](https://github.com/RaRe-Technologies/gensim/pull/3131): Added import to Nmf docs, and to models/__init__.py, by [@properGrammar](https://github.com/properGrammar)
+* [#3163](https://github.com/RaRe-Technologies/gensim/pull/3163): Optimize word mover distance (WMD) computation, by [@flowlight0](https://github.com/flowlight0)
 
 ### :books: Documentation
 

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -178,6 +178,7 @@ from numpy import (
 )
 import numpy as np
 from scipy import stats
+from scipy.spatial.distance import cdist
 
 from gensim import utils, matutils  # utility fnc for pickling, common scipy operations etc
 from gensim.corpora.dictionary import Dictionary
@@ -901,23 +902,16 @@ class KeyedVectors(utils.SaveLoad):
             # Both documents are composed of a single unique token => zero distance.
             return 0.0
 
-        # Sets for faster look-up.
-        docset1 = set(document1)
-        docset2 = set(document2)
+        doclist1 = list(set(document1))
+        doclist2 = list(set(document2))
+        v1 = np.array([self.get_vector(token, norm=norm) for token in doclist1])
+        v2 = np.array([self.get_vector(token, norm=norm) for token in doclist2])
+        doc1_indices = dictionary.doc2idx(doclist1)
+        doc2_indices = dictionary.doc2idx(doclist2)
 
         # Compute distance matrix.
         distance_matrix = zeros((vocab_len, vocab_len), dtype=double)
-        for i, t1 in dictionary.items():
-            if t1 not in docset1:
-                continue
-
-            for j, t2 in dictionary.items():
-                if t2 not in docset2 or distance_matrix[i, j] != 0.0:
-                    continue
-
-                # Compute Euclidean distance between (potentially unit-normed) word vectors.
-                distance_matrix[i, j] = distance_matrix[j, i] = np.sqrt(
-                    np_sum((self.get_vector(t1, norm=norm) - self.get_vector(t2, norm=norm))**2))
+        distance_matrix[np.ix_(doc1_indices, doc2_indices)] = cdist(v1, v2)
 
         if abs(np_sum(distance_matrix)) < 1e-8:
             # `emd` gets stuck if the distance matrix contains only zeros.


### PR DESCRIPTION
This change makes WMD computation faster by replacing a heavy nested loop for distance matrix construction with scipy's faster implementation. 

I verified its performance improvement with the following micro-benchmark. It generated the next two different set of text pairs by sampling texts from 20newsgroups and measured WMD computation speed of both versions. 
- Long: 500 pairs of full texts from 20newsgroups. The average number of tokens in this dataset is 256.69. 
- Short: 50,000 pairs of truncated texts. I truncated texts from 20newsgroups such that whose maximum number of tokens become less than or equal to 30. 

**Benchmark**
```python
import random
import time
from pathlib import Path
from typing import List, Tuple

import joblib
import numpy as np
from nltk import word_tokenize
from nltk.corpus import stopwords
from sklearn.datasets import fetch_20newsgroups
from tqdm import tqdm

from gensim.models import KeyedVectors

stopwords = stopwords.words("english")


def tokenize(model: KeyedVectors, text: str):
    return [token for token in word_tokenize(text.strip()) if token.lower() not in stopwords and token in model]


def average_text_length(text_pairs):
    lengths = []
    for (a, b) in text_pairs:
        lengths.append((len(a)))
        lengths.append((len(b)))
    return np.mean(lengths)


def load_text_pairs(model: KeyedVectors, num_pairs=500, num_texts=1000, max_length=None, seed=0):
    newsgroups_train = fetch_20newsgroups(subset='train')
    tokenized_texts = [tokenize(model=model, text=text) for text in newsgroups_train["data"][:num_texts]]
    if max_length is not None:
        tokenized_texts = [tokenized_text[:max_length] for tokenized_text in tokenized_texts]
    random.seed(seed)
    return [(random.choice(tokenized_texts), random.choice(tokenized_texts)) for _ in range(num_pairs)]


def run(model: KeyedVectors, text_pairs: List[Tuple[str, str]]):
    start_time = time.time()
    values = []
    for (a, b) in tqdm(text_pairs, "Computing WMD", total=len(text_pairs)):
        values.append(model.wmdistance(a, b))
    print(f"Elapsed time: {time.time() - start_time:.4f} [s]")
    return values


def main():
    out_dir = Path("./output")
    out_dir.mkdir(exist_ok=True, parents=True)
    for d in [50, 100, 200]:
        print(f"The dimensionality of word vectors: {d}")
        model = KeyedVectors.load_word2vec_format(f"./glove.6B.{d}d.txt", no_header=True)
        long_pairs = load_text_pairs(model=model, num_pairs=500)
        print(f"The average number of tokens in long texts: {average_text_length(long_pairs):.4f}")
        values = run(model, long_pairs)
        joblib.dump(values, out_dir / f"long.{d}.bin")

        short_pairs = load_text_pairs(model=model, num_pairs=50000, max_length=25)
        print(f"The average number of tokens in short texts: {average_text_length(short_pairs):.4f}")
        values = run(model, short_pairs)
        joblib.dump(values, out_dir / f"short.{d}.bin")
        print("")


if __name__ == '__main__':
    main()

```

**Result**
The next two tables show how WMD computation performance changed. The computation speed becomes consistently faster (7x speedup for short text paris and 2x speedup for long text pairs). 

Before
| vector size | time (short text) [s] | time (long text) [s]
| ---: | ---: | ---: |
| 50 | 287.76 | 179.40
| 100 | 290.24 | 180.13
| 200 | 321.66 | 187.87


After
| vector size | time (short text) [s] | time (long text) [s]
| ---: | ---: | ---: |
| 50 | 41.89 | 82.12
| 100 | 43.29 | 87.39
| 200 | 46.95 | 86.37

Of course, I checked this change doesn't break the current behavior by checking outputs from two versions as follows: 
```python
In [10]: import joblib
In [11]: import numpy
In [12]: a = joblib.load("./new_output/long.50.bin")
In [13]: b = joblib.load("./old_output/long.50.bin")
In [14]: numpy.allclose(a, b)
Out[14]: True

```

- [x] `tox -e flake8` succeeded
- [x]  `tox -e py36-linux` succeeded

(Update 2021-06-07: fixed explanation about the experimental results based on @gojomo 's comment) 