### PR TITLE
Fix error message when Doc2Vec does not receive corpus_file or corpus iterable

### DIFF
--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -487,7 +487,7 @@ class Doc2Vec(Word2Vec):
 
         """
         if corpus_file is None and corpus_iterable is None:
-            raise TypeError("Either one of corpus_file or documents value must be provided")
+            raise TypeError("Either one of corpus_file or corpus_iterable value must be provided")
 
         if corpus_file is not None and corpus_iterable is not None:
             raise TypeError("Both corpus_file and corpus_iterable must not be provided at the same time")


### PR DESCRIPTION
The error message thrown when you do not include `corpus_file` or `corpus_iterable` to the doc2vec model is incorrect, stating that you can set the `documents` value.  This change simply makes the error message more accurate so others going through a gensim 3.x to 4.0 migration don't run into issues if they were previously using `documents`.