### PR TITLE
Fix broken pdf link in docs

### DIFF
--- a/docs/src/auto_examples/core/run_topics_and_transformations.rst
+++ b/docs/src/auto_examples/core/run_topics_and_transformations.rst
@@ -370,7 +370,7 @@ Gensim implements several popular Vector Space Model algorithms:
   See also :ref:`wiki` for further speed-ups by distributing the computation across
   a cluster of computers.
 
-* `Random Projections, RP <http://www.cis.hut.fi/ella/publications/randproj_kdd.pdf>`_ aim to
+* `Random Projections, RP <http://www.inf.fu-berlin.de/lehre/WS08/ME/randproj_kdd.pdf>`_ aim to
   reduce vector space dimensionality. This is a very efficient (both memory- and
   CPU-friendly) approach to approximating TfIdf distances between documents, by throwing in a little randomness.
   Recommended target dimensionality is again in the hundreds/thousands, depending on your dataset.


### PR DESCRIPTION
The existing link: `http://users.ics.tkk.fi/ella/publications/randproj_kdd.pdf` is not working for some reason. 
Searched for the paper and founded it hosted here: `http://www.inf.fu-berlin.de/lehre/WS08/ME/randproj_kdd.pdf`