### PR TITLE
added random_seed parameter to make LsiModel reproducible

### DIFF
--- a/gensim/models/lsimodel.py
+++ b/gensim/models/lsimodel.py
@@ -163,7 +163,7 @@ class Projection(utils.SaveLoad):
 
     """
     def __init__(self, m, k, docs=None, use_svdlibc=False, power_iters=P2_EXTRA_ITERS,
-                 extra_dims=P2_EXTRA_DIMS, dtype=np.float64):
+                 extra_dims=P2_EXTRA_DIMS, dtype=np.float64, random_seed=None):
         """Construct the (U, S) projection from a corpus.
 
         Parameters
@@ -183,11 +183,15 @@ class Projection(utils.SaveLoad):
             Extra samples to be used besides the rank `k`. Tune to improve accuracy.
         dtype : numpy.dtype, optional
             Enforces a type for elements of the decomposed matrix.
+        random_seed: {None, int}, optional
+            Random seed used to initialize the pseudo-random number generator,
+            a local instance of numpy.random.RandomState instance.
 
         """
         self.m, self.k = m, k
         self.power_iters = power_iters
         self.extra_dims = extra_dims
+        self.random_seed = random_seed
         if docs is not None:
             # base case decomposition: given a job `docs`, compute its decomposition,
             # *in-core*.
@@ -195,7 +199,7 @@ class Projection(utils.SaveLoad):
                 u, s = stochastic_svd(
                     docs, k, chunksize=sys.maxsize,
                     num_terms=m, power_iters=self.power_iters,
-                    extra_dims=self.extra_dims, dtype=dtype)
+                    extra_dims=self.extra_dims, dtype=dtype, random_seed=self.random_seed)
             else:
                 try:
                     import sparsesvd
@@ -223,7 +227,8 @@ class Projection(utils.SaveLoad):
             An empty copy (without corpus) of the current projection.
 
         """
-        return Projection(self.m, self.k, power_iters=self.power_iters, extra_dims=self.extra_dims)
+        return Projection(self.m, self.k, power_iters=self.power_iters,
+                          extra_dims=self.extra_dims, random_seed=self.random_seed)
 
     def merge(self, other, decay=1.0):
         """Merge current :class:`~gensim.models.lsimodel.Projection` instance with another.
@@ -355,7 +360,7 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
     def __init__(
             self, corpus=None, num_topics=200, id2word=None, chunksize=20000,
             decay=1.0, distributed=False, onepass=True,
-            power_iters=P2_EXTRA_ITERS, extra_samples=P2_EXTRA_DIMS, dtype=np.float64
+            power_iters=P2_EXTRA_ITERS, extra_samples=P2_EXTRA_DIMS, dtype=np.float64, random_seed=None,
         ):
         """Build an LSI model.
 
@@ -383,6 +388,9 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
             Extra samples to be used besides the rank `k`. Can improve accuracy.
         dtype : type, optional
             Enforces a type for elements of the decomposed matrix.
+        random_seed: {None, int}, optional
+            Random seed used to initialize the pseudo-random number generator,
+            a local instance of numpy.random.RandomState instance.
 
         """
         self.id2word = id2word
@@ -396,6 +404,7 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         self.onepass = onepass
         self.extra_samples, self.power_iters = extra_samples, power_iters
         self.dtype = dtype
+        self.random_seed = random_seed
 
         if corpus is None and self.id2word is None:
             raise ValueError(
@@ -411,7 +420,8 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
 
         self.docs_processed = 0
         self.projection = Projection(
-            self.num_terms, self.num_topics, power_iters=self.power_iters, extra_dims=self.extra_samples, dtype=dtype
+            self.num_terms, self.num_topics, power_iters=self.power_iters,
+            extra_dims=self.extra_samples, dtype=dtype, random_seed=self.random_seed
         )
 
         self.numworkers = 1
@@ -478,11 +488,13 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
         if not scipy.sparse.issparse(corpus):
             if not self.onepass:
                 # we are allowed multiple passes over the input => use a faster, randomized two-pass algo
-                update = Projection(self.num_terms, self.num_topics, None, dtype=self.dtype)
+                update = Projection(self.num_terms, self.num_topics, None,
+                                    dtype=self.dtype, random_seed=self.random_seed)
                 update.u, update.s = stochastic_svd(
                     corpus, self.num_topics,
                     num_terms=self.num_terms, chunksize=chunksize,
-                    extra_dims=self.extra_samples, power_iters=self.power_iters, dtype=self.dtype
+                    extra_dims=self.extra_samples, power_iters=self.power_iters, dtype=self.dtype,
+                    random_seed=self.random_seed
                 )
                 self.projection.merge(update, decay=decay)
                 self.docs_processed += len(corpus) if hasattr(corpus, '__len__') else 0
@@ -513,7 +525,7 @@ class LsiModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
                         # serial version, there is only one "worker" (myself) => process the job directly
                         update = Projection(
                             self.num_terms, self.num_topics, job, extra_dims=self.extra_samples,
-                            power_iters=self.power_iters, dtype=self.dtype
+                            power_iters=self.power_iters, dtype=self.dtype, random_seed=self.random_seed
                         )
                         del job
                         self.projection.merge(update, decay=decay)
@@ -865,7 +877,7 @@ def print_debug(id2token, u, s, topics, num_words=10, num_neg=None):
 
 
 def stochastic_svd(corpus, rank, num_terms, chunksize=20000, extra_dims=None,
-                   power_iters=0, dtype=np.float64, eps=1e-6):
+                   power_iters=0, dtype=np.float64, eps=1e-6, random_seed=None):
     """Run truncated Singular Value Decomposition (SVD) on a sparse input.
 
     Parameters
@@ -888,6 +900,10 @@ def stochastic_svd(corpus, rank, num_terms, chunksize=20000, extra_dims=None,
         Enforces a type for elements of the decomposed matrix.
     eps: float, optional
         Percentage of the spectrum's energy to be discarded.
+    random_seed: {None, int}, optional
+        Random seed used to initialize the pseudo-random number generator,
+         a local instance of numpy.random.RandomState instance.
+
 
     Notes
     -----
@@ -924,11 +940,12 @@ def stochastic_svd(corpus, rank, num_terms, chunksize=20000, extra_dims=None,
     # and more memory friendly than processing all documents at once)
     y = np.zeros(dtype=dtype, shape=(num_terms, samples))
     logger.info("1st phase: constructing %s action matrix", str(y.shape))
+    random_state = np.random.RandomState(random_seed)
 
     if scipy.sparse.issparse(corpus):
         m, n = corpus.shape
         assert num_terms == m, "mismatch in number of features: %i in sparse matrix vs. %i parameter" % (m, num_terms)
-        o = np.random.normal(0.0, 1.0, (n, samples)).astype(y.dtype)  # draw a random gaussian matrix
+        o = random_state.normal(0.0, 1.0, (n, samples)).astype(y.dtype)  # draw a random gaussian matrix
         sparsetools.csc_matvecs(m, n, samples, corpus.indptr, corpus.indices,
                                 corpus.data, o.ravel(), y.ravel())  # y = corpus * o
         del o
@@ -960,7 +977,7 @@ def stochastic_svd(corpus, rank, num_terms, chunksize=20000, extra_dims=None,
             assert n <= chunksize  # the very last chunk of A is allowed to be smaller in size
             num_docs += n
             logger.debug("multiplying chunk * gauss")
-            o = np.random.normal(0.0, 1.0, (n, samples)).astype(dtype)  # draw a random gaussian matrix
+            o = random_state.normal(0.0, 1.0, (n, samples), ).astype(dtype)  # draw a random gaussian matrix
             sparsetools.csc_matvecs(
                 m, n, samples, chunk.indptr, chunk.indices,  # y = y + chunk * o
                 chunk.data, o.ravel(), y.ravel()


### PR DESCRIPTION
The results from multiple runs of LsiModel on same input data produces different results.
This is primarily due to the random gaussian matrix creation step in `stochastic_svd` function.
Hence, it is hard to setup a reproducible pipeline without resorting to changing global randomness controlling methods.

What was done in this PR :
- A local random state (`numpy.random.RandomState`) was created in the `stochastic_svd` function. This random state can be seeded by a user provided parameter (`random_seed`). The gaussian matrices are drawn using this random state.
- The `random_seed` parameter was exposed in calls to `stochastic_svd` from `LsiModel.add_documents` and `Projection.__init__`
- 'random_seed' parameter was added to '__init__' of both `LsiModel` and `Projection` classes.
- Calls to `Projection` from `LsiModel` methods (`__init__` and `add_documents`) now expose the `random_seed` parameter
- The default value of `random_seed`  in `Projection`, `LsiModel` and `stochastic_svd` was set to None. This means the current behavior is persevered by default.

Overall, the above changes allows relaying a 'random_seed' from LsiModel class to downstream calls. The changes suggested in this PR are highly localized and are not expected to have any global impact.


```
from gensim.test.utils import common_dictionary, common_corpus
from gensim.models import LsiModel
import numpy as np

model1 = LsiModel(common_corpus, id2word=common_dictionary)
model2 = LsiModel(common_corpus, id2word=common_dictionary)

print (np.all(model1.get_topics() - model2.get_topics() < 1e-10))
# Prints 'False' for both the current version and this PR.
```

With `random_seed` parameter introduced in this PR:
```
model1 = LsiModel(common_corpus, id2word=common_dictionary, random_seed=1)
model2 = LsiModel(common_corpus, id2word=common_dictionary, random_seed=1)

print (np.all(model1.get_topics() - model2.get_topics() < 1e-10))
# Prints 'True'
```
