### PR TITLE
Tbbharaj/aarch64 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ branches:
   only:
     - /release-.+/
     - travis
-    - tbbharaj/aarch64-wheels
 language: python
 arch: arm64-graviton2
 dist: focal
@@ -48,8 +47,8 @@ after_script:
     - pip install wheelhouse-uploader
     - python -m wheelhouse_uploader upload --local-folder ${TRAVIS_BUILD_DIR}/wheelhouse/ --no-ssl-check gensim-wheels --provider S3 --no-enable-cdn
 
-#notifications:
-  #email:
-  #  - penkov+gensimwheels@pm.me
-  #on_success: always
-  #on_failure: always
+notifications:
+  email:
+    - penkov+gensimwheels@pm.me
+  on_success: always
+  on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
   only:
     - /release-.+/
     - travis
+    - tbbharaj/aarch64-wheels
 language: python
 arch: arm64-graviton2
 dist: focal
@@ -17,12 +18,13 @@ env:
       - MB_ML_VER=2014
       - SKIP_NETWORK_TESTS=1
       - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
-      - BUILD_DEPENDS="numpy==1.19.2 scipy==1.5.3"
+      - BUILD_DEPENDS="numpy==1.19.2 scipy==1.7.0"
       - TEST_DEPENDS="pytest mock cython nmslib pyemd testfixtures Morfessor==2.0.2a4 python-levenshtein==0.12.0 visdom==0.1.8.9 scikit-learn"
 
 matrix:
     - os: linux
       env:
+        - BUILD_DEPENDS="numpy==1.19.2 scipy==1.5.3"
         - MB_PYTHON_VERSION=3.6
     - os: linux
       env:
@@ -46,8 +48,8 @@ after_script:
     - pip install wheelhouse-uploader
     - python -m wheelhouse_uploader upload --local-folder ${TRAVIS_BUILD_DIR}/wheelhouse/ --no-ssl-check gensim-wheels --provider S3 --no-enable-cdn
 
-notifications:
-  email:
-    - penkov+gensimwheels@pm.me
-  on_success: always
-  on_failure: always
+#notifications:
+  #email:
+  #  - penkov+gensimwheels@pm.me
+  #on_success: always
+  #on_failure: always


### PR DESCRIPTION
This PR addresses the issue to build aarch64 wheels.
Travis build for Python 3.9 is [failing](https://travis-ci.com/github/tbbharaj/gensim/jobs/527762124) because it couldn't find matching scipy distribution == 1.5.3. This issue is being addressed in this PR.

If there are any questions/comments - I'd be happy fix things as needed.

Thank you
Tanveen