### PR TITLE
update circleCI image to python:3.8.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7.4
+      - image: cimg/python:3.8.11
 
     working_directory: ~/gensim
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,12 @@ jobs:
             sudo apt-get -yq update
             sudo apt-get -yq remove texlive-binaries --purge
             sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install dvipng texlive-latex-base texlive-latex-extra texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended latexmk
-            sudo apt-get -yq install build-essential python3.7-dev
+            sudo apt-get -yq install build-essential python3.8-dev
 
       - run:
           name: Basic installation (tox)
           command: |
-            python3.7 -m virtualenv venv
+            python3.8 -m virtualenv venv
             source venv/bin/activate
             pip install tox --progress-bar off
 


### PR DESCRIPTION
The older version causes apt updates to fail:

https://app.circleci.com/pipelines/github/RaRe-Technologies/gensim/1154/workflows/1c84ef08-2ea0-4b3e-bb30-ece740068942/jobs/4361

```
Get:1 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:2 http://deb.debian.org/debian buster InRelease [122 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]
Reading package lists...
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'

Exited with code exit status 100


```