### PR TITLE
Change build NumPy versions for MacOS according to oldest-supported-numpy

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -79,13 +79,13 @@ jobs:
           travis-os-name: osx
           manylinux-version: 1
           python-version: 3.8
-          build-depends: numpy==1.21.0
+          build-depends: numpy==1.17.3
 
         - os: macos-latest
           travis-os-name: osx
           manylinux-version: 1
           python-version: 3.9
-          build-depends: numpy==1.21.0
+          build-depends: numpy==1.19.3
 
         - os: windows-latest
           manylinux-version: 2010


### PR DESCRIPTION
Made according to the conversation in: https://github.com/RaRe-Technologies/gensim/issues/3226#issuecomment-920854099

It fixes wrongly set NumPY build versions which prevent Gensim to work on macOS with Numpy <1.20

I tried to build wheels with those versions and it seems it works correclty.