### PR TITLE
Skip blinking test `test_translate_gc` on OSX + py3.9

### DIFF
--- a/gensim/test/test_translation_matrix.py
+++ b/gensim/test/test_translation_matrix.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
+import sys
 from collections import namedtuple
 import unittest
 import logging
@@ -60,6 +61,10 @@ class TestTranslationMatrix(unittest.TestCase):
         for idx, item in enumerate(self.test_word_pairs):
             self.assertTrue(item[1] in translated_words[item[0]])
 
+    @unittest.skipIf(
+        (sys.version_info.major == 3) and (sys.version_info.minor == 9) and (sys.platform == 'darwin'),
+        'blinking test, can be related to <https://github.com/RaRe-Technologies/gensim/issues/2977>'
+    )
     def test_translate_gc(self):
         # Test globally corrected neighbour retrieval method
         model = translation_matrix.TranslationMatrix(self.source_word_vec, self.target_word_vec, self.word_pairs)


### PR DESCRIPTION
Can be related to #2977 
I just catch that several times in completely different branches (and none of them touched these part), for example:
- https://github.com/RaRe-Technologies/gensim/runs/3984970447?check_suite_focus=true#step:6:3649
- https://github.com/RaRe-Technologies/gensim/runs/3986968660?check_suite_focus=true#step:6:3588

and so on