### PR TITLE
Remove commented out pytest-rerunfailures test dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -267,7 +267,6 @@ visdom_req = ['visdom >= 0.1.8, != 0.1.8.7']
 core_testenv = [
     'pytest',
     'pytest-cov',
-#    'pytest-rerunfailures',  # disabled 2020-08-28 for <https://github.com/pytest-dev/pytest-rerunfailures/issues/128>
     'mock',
     'cython',
     'testfixtures',


### PR DESCRIPTION
pytest-rerunfailures is now compatible with pytest 6.1.0 and later.

Reverts: commit 8687e7f68afb9f9251e69039e04280b6ae1e7bdc.
Reported-in: https://github.com/pytest-dev/pytest-rerunfailures/issues/128
Fixed-by: https://github.com/pytest-dev/pytest-rerunfailures/pull/129