### PR TITLE
Migrate setup.py from distutils to setuptools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes
 * [#3247](https://github.com/RaRe-Technologies/gensim/pull/3247): Sparse2Corpus: update __getitem__ to work on slices, lists and ellipsis, by [@PrimozGodec](https://github.com/PrimozGodec)
 * [#3250](https://github.com/RaRe-Technologies/gensim/pull/3250): Make negative ns_exponent work correctly, by [@menshikh-iv](https://github.com/menshikh-iv)
 * [#3258](https://github.com/RaRe-Technologies/gensim/pull/3258): Adding another check to _check_corpus_sanity for compressed files, adding test, by [@dchaplinsky](https://github.com/dchaplinsky)
+* [#3274](https://github.com/RaRe-Technologies/gensim/pull/3274): Migrate setup.py from distutils to setuptools, by [@geojacobm6](https://github.com/geojacobm6)
 
 ## 4.1.2, 2021-09-17
 

--- a/gensim/corpora/dictionary.py
+++ b/gensim/corpora/dictionary.py
@@ -331,7 +331,7 @@ class Dictionary(utils.SaveLoad, Mapping):
         After the pruning, resulting gaps in word ids are shrunk.
         Due to this gap shrinking, **the same word may have a different word id before and after the call
         to this function!** See :class:`gensim.models.VocabTransform` and the
-        `dedicated FAQ entry <https://github.com/RaRe-Technologies/gensim/wiki/Recipes-&-FAQ#q8-how-can-i-filter-a-saved-corpus-and-its-corresponding-dictionary>`_ on how
+        `dedicated FAQ entry <https://github.com/RaRe-Technologies/gensim/wiki/Recipes-&-FAQ#q8-how-can-i-filter-a-saved-corpus-and-its-corresponding-dictionary>`_ on how  # noqa
         to transform a corpus built with a dictionary before pruning.
 
         Examples

--- a/setup.py
+++ b/setup.py
@@ -10,15 +10,13 @@ Run with::
     python ./setup.py install
 """
 
-import distutils.cmd
-import distutils.log
 import itertools
 import os
 import platform
 import shutil
 import sys
 
-from setuptools import Extension, find_packages, setup
+from setuptools import Extension, find_packages, setup, distutils
 from setuptools.command.build_ext import build_ext
 
 c_extensions = {


### PR DESCRIPTION
Fixes #3272 

Migrate setup.py from distutils to setuptools

distutils is going away in a future version of Python

https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated