### PR TITLE
Tighten test_parallel bound

### DIFF
--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -834,7 +834,7 @@ class TestWord2VecModel(unittest.TestCase):
             # the exact vectors and therefore similarities may differ, due to different thread collisions/randomization
             # so let's test only for top10
             neighbor_rank = [word for word, sim in sims].index(expected_neighbor)
-            self.assertLess(neighbor_rank, 20)
+            self.assertLess(neighbor_rank, 2)
 
     def test_r_n_g(self):
         """Test word2vec results identical with identical RNG seed."""


### PR DESCRIPTION
Hi,

The test `test_parallel` in `test_word2vec.py` has an assertion bound (`self.assertLess(neighbor_rank, 20)`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/145623983-3d498683-685e-4b0c-80b2-aee5b30730f2.png" width="450">
</p>

Here we see that the bound of `20` is too loose since the original distribution (in orange) is much less than `20`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are below the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/145637817-d827a762-7684-437d-94cc-0cf02332f1a4.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `20` (red dotted line) has a catch rate of 0.5.

To improve this test, I propose to tighten the bound to `2` (the blue dotted line). The new bound has a catch rate of 0.8 (+0.3 increase compare to original) while still has 100 % pass rate (test is not flaky, I ran the updated test 500 times and had no failures). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.7.11
numpy=1.21.4
```

my Gensim Experiment SHA:
`6e362663f23967f3c1931e2cb18d3d25f92aabb5`