### PR TITLE
tighten test_topic_word

### DIFF
--- a/gensim/test/test_ldaseqmodel.py
+++ b/gensim/test/test_ldaseqmodel.py
@@ -214,7 +214,7 @@ class TestLdaSeq(unittest.TestCase):
         topics = self.ldaseq.print_topics(0)
         expected_topic_word = [('skills', 0.035999999999999997)]
         self.assertEqual(topics[0][0][0], expected_topic_word[0][0])
-        self.assertAlmostEqual(topics[0][0][1], expected_topic_word[0][1], places=2)
+        self.assertAlmostEqual(topics[0][0][1], expected_topic_word[0][1], delta=0.0012)
 
     # testing document-topic proportions
     def test_doc_topic(self):


### PR DESCRIPTION
Hi,

The test `test_topic_word` in `test_ldaseqmodel.py` has an assertion bound (`self.assertAlmostEqual(topics[0][0][1], expected_topic_word[0][1], places=2)`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/147298523-2d2f1e4d-eb9c-48a0-88c4-303655aa8e6f.png" width="450">
</p>

Here we see that the bound of `0.005` (same as round to 2 decimal place) is too loose since the original distribution (in orange) is much less than `0.005`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are below the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/147298544-41dbca0c-9780-4d6a-949d-71f1d61f29f7.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `0.005` (red dotted line) has a catch rate of 0.16

To improve this test, I propose to tighten the bound to `0.0012` (the blue dotted line). The new bound has a catch rate of 0.375 (+0.215 increase compare to original) while still has >99 % pass rate (test is not flaky, I ran the updated test 500 times and observed >99 % pass rate). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.7.11
numpy=1.21.4
```

my Gensim Experiment SHA:
`6e362663f23967f3c1931e2cb18d3d25f92aabb5`