### PR TITLE
Fixes 'not enough arguments for format string' error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Linux, python: 3.6, os: ubuntu-20.04, tox: 'flake8,flake8-docs'}
-          - {name: Linux, python: 3.6, os: ubuntu-20.04, tox: 'py36-linux'}
+          - {name: Linux, python: 3.7, os: ubuntu-20.04, tox: 'flake8,flake8-docs'}
           - {name: Linux, python: 3.7, os: ubuntu-20.04, tox: 'py37-linux'}
-          - {name: Linux, python: 3.8, os: ubuntu-20.04, tox: 'py38-linux'}
-          - {name: Windows, python: 3.6, os: windows-2019, tox: 'py36-win'}
+          - {name: Linux, python: 3.8, os: ubuntu-20.04, tox: 'py38-linux-cov'}
           - {name: Windows, python: 3.7, os: windows-2019, tox: 'py37-win'}
           - {name: Windows, python: 3.8, os: windows-2019, tox: 'py38-win'}
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes
 * [#3250](https://github.com/RaRe-Technologies/gensim/pull/3250): Make negative ns_exponent work correctly, by [@menshikh-iv](https://github.com/menshikh-iv)
 * [#3258](https://github.com/RaRe-Technologies/gensim/pull/3258): Adding another check to _check_corpus_sanity for compressed files, adding test, by [@dchaplinsky](https://github.com/dchaplinsky)
 * [#3274](https://github.com/RaRe-Technologies/gensim/pull/3274): Migrate setup.py from distutils to setuptools, by [@geojacobm6](https://github.com/geojacobm6)
+* [#3286](https://github.com/RaRe-Technologies/gensim/pull/3286): Fixes 'not enough arguments for format string' error, by [@gilbertfrancois](https://github.com/gilbertfrancois)
 
 ## 4.1.2, 2021-09-17
 

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -993,7 +993,8 @@ class Doc2Vec(Word2Vec):
             logger.warning(
                 "Highest int doctag (%i) larger than count of documents (%i). This means "
                 "at least %i excess, unused slots (%i bytes) will be allocated for vectors.",
-                max_rawint, corpus_count, ((max_rawint - corpus_count) * self.vector_size * 4))
+                max_rawint, corpus_count, max_rawint - corpus_count, 
+                ((max_rawint - corpus_count) * self.vector_size * 4))
         if max_rawint > -1:
             # adjust indexes/list to account for range of pure-int keyed doctags
             for key in doctags_list:

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -994,7 +994,8 @@ class Doc2Vec(Word2Vec):
                 "Highest int doctag (%i) larger than count of documents (%i). This means "
                 "at least %i excess, unused slots (%i bytes) will be allocated for vectors.",
                 max_rawint, corpus_count, max_rawint - corpus_count, 
-                ((max_rawint - corpus_count) * self.vector_size * 4))
+                (max_rawint - corpus_count) * self.vector_size * dtype(REAL).itemsize,
+            )
         if max_rawint > -1:
             # adjust indexes/list to account for range of pure-int keyed doctags
             for key in doctags_list:

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -993,7 +993,7 @@ class Doc2Vec(Word2Vec):
             logger.warning(
                 "Highest int doctag (%i) larger than count of documents (%i). This means "
                 "at least %i excess, unused slots (%i bytes) will be allocated for vectors.",
-                max_rawint, corpus_count, max_rawint - corpus_count, 
+                max_rawint, corpus_count, max_rawint - corpus_count,
                 (max_rawint - corpus_count) * self.vector_size * dtype(REAL).itemsize,
             )
         if max_rawint > -1:

--- a/tox.ini
+++ b/tox.ini
@@ -46,9 +46,10 @@ ignore_errors = True
 # Conditional factors https://tox.wiki/en/latest/config.html#factors
 #
 [pytest]
-addopts =
-    cov: -rfxEXs --durations=20 --showlocals --cov=gensim/ --cov-report=xml
-    !cov: -rfxEXs --durations=20 --showlocals
+addopts = -rfxEXs --durations=20 --showlocals
+
+[pytest-cov]
+addopts = -rfxEXs --durations=20 --showlocals --cov=gensim/ --cov-report=xml
 
 [testenv]
 recreate = True
@@ -76,7 +77,8 @@ commands =
     python --version
     pip --version
     python setup.py build_ext --inplace
-    pytest {posargs:gensim/test}
+    cov: pytest-cov {posargs:gensim/test}
+    !cov: pytest {posargs:gensim/test}
 
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -48,9 +48,6 @@ ignore_errors = True
 [pytest]
 addopts = -rfxEXs --durations=20 --showlocals
 
-[pytest-cov]
-addopts = -rfxEXs --durations=20 --showlocals --cov=gensim/ --cov-report=xml
-
 [testenv]
 recreate = True
 
@@ -77,7 +74,7 @@ commands =
     python --version
     pip --version
     python setup.py build_ext --inplace
-    cov: pytest-cov {posargs:gensim/test}
+    cov: pytest {posargs:gensim/test} --cov=gensim/ --cov-report=xml
     !cov: pytest {posargs:gensim/test}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = {py36,py37,py38, py39}-{win,linux}, flake8, docs, docs-upload, download-wheels, upload-wheels, test-pypi
+envlist = {py36,py37,py38, py39}-{win,linux}, py38-linux-cov, flake8, docs, docs-upload, download-wheels, upload-wheels, test-pypi
 skipsdist = True
 platform = linux: linux
            win: win64
@@ -42,9 +42,13 @@ exclude_lines =
 
 ignore_errors = True
 
+#
+# Conditional factors https://tox.wiki/en/latest/config.html#factors
+#
 [pytest]
-addopts = -rfxEXs --durations=20 --showlocals --cov=gensim/ --cov-report=xml
-
+addopts =
+    cov: -rfxEXs --durations=20 --showlocals --cov=gensim/ --cov-report=xml
+    !cov: -rfxEXs --durations=20 --showlocals
 
 [testenv]
 recreate = True


### PR DESCRIPTION
For Doc2Vec, when building the vocabulary and the `raw_int` and `corpus_count` are not the same, the log gives a warning. However, the log string expects 4 arguments, but only 3 are given, so the log produces an error, shown below. 

The fix was to give the difference of `raw_int` and `corpus_count` as the 3rd argument.


Part of the stack trace:
```
--- Logging error ---
Traceback (most recent call last):
  File "/home/ubuntu/.pyenv/versions/3.8.10/lib/python3.8/logging/__init__.py", line 1085, in emit
    msg = self.format(record)
  File "/home/ubuntu/.pyenv/versions/3.8.10/lib/python3.8/logging/__init__.py", line 929, in format
    return fmt.format(record)
  File "/home/ubuntu/.pyenv/versions/3.8.10/lib/python3.8/logging/__init__.py", line 668, in format
    record.message = record.getMessage()
  File "/home/ubuntu/.pyenv/versions/3.8.10/lib/python3.8/logging/__init__.py", line 373, in getMessage
    msg = msg % self.args
TypeError: not enough arguments for format string
Call stack:
  File "/home/ubuntu/.pyenv/versions/3.8.10/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
...

...
  File "/home/ubuntu/.cache/pypoetry/virtualenvs/gilbert-lab-aKPhFkG7-py3.8/lib/python3.8/site-packages/gensim/models/doc2vec.py", line 993, in _scan_vocab
    logger.warning(
Message: 'Highest int doctag (%i) larger than count of documents (%i). This means at least %i excess, unused slots (%i bytes) will be allocated for vectors.'
Arguments: (60108, 60082, 5200)

```