### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -348,6 +348,9 @@ setup(
     author_email='me@radimrehurek.com',
 
     url='http://radimrehurek.com/gensim',
+    project_urls={
+        'Source': 'https://github.com/RaRe-Technologies/gensim',
+    },
     download_url='http://pypi.python.org/pypi/gensim',
 
     license='LGPL-2.1-only',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.