### PR TITLE
Fix `KeyedVectors.add_vectors()` error when use most_similar

### DIFF
--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -614,6 +614,8 @@ class KeyedVectors(utils.SaveLoad):
             for attr, extra in extras:
                 self.expandos[attr][in_vocab_idxs] = extra[in_vocab_mask]
 
+        self.fill_norms()
+
     def __setitem__(self, keys, weights):
         """Add keys and theirs vectors in a manual way.
         If some key is already in the vocabulary, old vector is replaced with the new one.
@@ -705,7 +707,7 @@ class KeyedVectors(utils.SaveLoad):
         either recalculated or 'None', to trigger a full recalculation later on-request.
 
         """
-        if self.norms is None or force:
+        if self.norms is None or len(self) != len(self.norms) or force:
             self.norms = np.linalg.norm(self.vectors, axis=1)
 
     @property

--- a/gensim/test/test_keyedvectors.py
+++ b/gensim/test/test_keyedvectors.py
@@ -265,6 +265,11 @@ class TestKeyedVectors(unittest.TestCase):
         for ent, vector in zip(entities, vectors):
             self.assertTrue(np.allclose(kv[ent], vector))
 
+        # assert `len(kv)` == `len(kv.norms)` after `fill_norms()`
+        kv.fill_norms()
+        kv.add_vectors(["___not_present_in_keyed_vectors___"], [np.random.randn(self.vectors.vector_size)], replace=False)
+        self.assertEqual(len(kv), len(kv.norms))
+
     def test_add_type(self):
         kv = KeyedVectors(2)
         assert kv.vectors.dtype == REAL


### PR DESCRIPTION
Fixing one of the issues in https://github.com/RaRe-Technologies/gensim/issues/3224

If I call `most_similar()` before doing `add_vectors()`  and then call `most_similar()` again after doing `add_vectors()`, I get a `ValueError: operands could not be broadcast together with shapes`.
This error occurs because `len(vectors)` and `len(vectors.norms)` do not match.

```python
from gensim.models import Word2Vec
import numpy

model = Word2Vec(sentences=[
                            ["this", "is", "test1"],
                            ["that", "is", "test2"],
], vector_size=2, min_count=1)

print(model.wv.most_similar("test1", topn=1)) #=> [('test2', 0.9941185712814331)]

model.wv.add_vectors(["test3"], [numpy.array([0.5, 0.5])])

print(model.wv.most_similar("test1", topn=1)) #=> ValueError: operands could not be broadcast together with shapes (6,) (5,) 
```

To resolve this error, I have used fill_norms to match `len(vectors)` and `len(vectors.norms)`.
