### PR TITLE
Allow overriding the Cython version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -320,6 +320,9 @@ NUMPY_STR = 'numpy >= 1.17.0'
 #
 CYTHON_STR = 'Cython==0.29.28'
 
+# Allow overriding the Cython version requirement
+CYTHON_STR = os.environ.get('GENSIM_CYTHON_REQUIRES', CYTHON_STR)
+
 install_requires = [
     NUMPY_STR,
     'scipy >= 0.18.1',


### PR DESCRIPTION
Use an environment variable for this since it is often easier to set in a
build wrapper rather than trying to override command-line options in the
right layer of a multi-layer build wrapper and it also requires a lot less
code to do the override.

This will be useful for using alpha versions of Cython or old versions of
Cython provided by the distros or specific versions that fix certain bugs.
