### PR TITLE
Update Python module MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,6 @@ recursive-include gensim/test/test_data *
 include README.md
 include CHANGELOG.md
 include COPYING
-include COPYING.LESSER
-include ez_setup.py
 
 include gensim/models/voidptr.h
 include gensim/models/stdint_wrapper.h
@@ -16,7 +14,7 @@ include gensim/models/word2vec_corpusfile.cpp
 include gensim/models/word2vec_corpusfile.pyx
 include gensim/models/word2vec_corpusfile.pxd
 
-include gensim/models/doc2vec_inner.c
+include gensim/models/doc2vec_inner.cpp
 include gensim/models/doc2vec_inner.pyx
 include gensim/models/doc2vec_inner.pxd
 include gensim/models/doc2vec_corpusfile.cpp


### PR DESCRIPTION
Drop COPYING.LESSER as it was moved to COPYING in 2016.

Drop ez_setup.py as it was removed in 2018.

Switch doc2vec_inner.c to doc2vec_inner.cpp,
as it has always been using language=c++.

Suggested-by: setup.py build
Fixes: commit beb04ea1f8f9c438b0a40aa4cbbd955ea065f84f
Fixes: commit 2891861d77f9eff2dc703214c099240ef227b7da
Fixes: commit 1aa11bbaa7beba9b3068cb2e2d04a500ebd31f30