### PR TITLE
Switch to Cython language level 3

### DIFF
--- a/gensim/_matutils.pyx
+++ b/gensim/_matutils.pyx
@@ -1,6 +1,7 @@
 #!/usr/bin/env cython
 # coding: utf-8
 # cython: embedsignature=True
+# cython: language_level=3
 
 from __future__ import division
 cimport cython

--- a/gensim/corpora/_mmreader.pyx
+++ b/gensim/corpora/_mmreader.pyx
@@ -1,5 +1,6 @@
 # Copyright (C) 2018 Radim Rehurek <radimrehurek@seznam.cz>
 # cython: embedsignature=True
+# cython: language_level=3
 
 """Reader for corpus in the Matrix Market format."""
 import logging

--- a/gensim/models/doc2vec_corpusfile.pyx
+++ b/gensim/models/doc2vec_corpusfile.pyx
@@ -1,4 +1,5 @@
 #!/usr/bin/env cython
+# cython: language_level=3
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True

--- a/gensim/models/doc2vec_inner.pxd
+++ b/gensim/models/doc2vec_inner.pxd
@@ -1,5 +1,6 @@
 #!/usr/bin/env cython
 # distutils: language = c++
+# cython: language_level=3
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True

--- a/gensim/models/doc2vec_inner.pxd
+++ b/gensim/models/doc2vec_inner.pxd
@@ -16,7 +16,7 @@
 import numpy as np
 cimport numpy as np
 
-from word2vec_inner cimport REAL_t
+from gensim.models.word2vec_inner cimport REAL_t
 
 DEF MAX_DOCUMENT_LEN = 10000
 

--- a/gensim/models/doc2vec_inner.pyx
+++ b/gensim/models/doc2vec_inner.pyx
@@ -1,4 +1,5 @@
 #!/usr/bin/env cython
+# cython: language_level=3
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True

--- a/gensim/models/doc2vec_inner.pyx
+++ b/gensim/models/doc2vec_inner.pyx
@@ -25,7 +25,7 @@ except ImportError:
     # in scipy > 0.15, fblas function has been removed
     import scipy.linalg.blas as fblas
 
-from word2vec_inner cimport bisect_left, random_int32, sscal, REAL_t, EXP_TABLE, our_dot, our_saxpy
+from gensim.models.word2vec_inner cimport bisect_left, random_int32, sscal, REAL_t, EXP_TABLE, our_dot, our_saxpy
 
 DEF MAX_DOCUMENT_LEN = 10000
 

--- a/gensim/models/fasttext_corpusfile.pyx
+++ b/gensim/models/fasttext_corpusfile.pyx
@@ -1,5 +1,6 @@
 #!/usr/bin/env cython
 # distutils: language = c++
+# cython: language_level=3
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True

--- a/gensim/models/fasttext_inner.pxd
+++ b/gensim/models/fasttext_inner.pxd
@@ -1,4 +1,5 @@
 #!/usr/bin/env cython
+# cython: language_level=3
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True

--- a/gensim/models/fasttext_inner.pxd
+++ b/gensim/models/fasttext_inner.pxd
@@ -14,7 +14,7 @@
 import numpy as np
 cimport numpy as np
 
-from word2vec_inner cimport REAL_t
+from gensim.models.word2vec_inner cimport REAL_t
 
 
 DEF MAX_SENTENCE_LEN = 10000

--- a/gensim/models/fasttext_inner.pyx
+++ b/gensim/models/fasttext_inner.pyx
@@ -1,4 +1,5 @@
 #!/usr/bin/env cython
+# cython: language_level=3
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True

--- a/gensim/models/fasttext_inner.pyx
+++ b/gensim/models/fasttext_inner.pyx
@@ -56,7 +56,7 @@ from libc.string cimport memset
 #
 # The versions are as chosen in word2vec_inner.pyx, and aliased to `our_` functions
 
-from word2vec_inner cimport bisect_left, random_int32, scopy, sscal, \
+from gensim.models.word2vec_inner cimport bisect_left, random_int32, scopy, sscal, \
      REAL_t, our_dot, our_saxpy
 
 DEF MAX_SENTENCE_LEN = 10000

--- a/gensim/models/nmf_pgd.pyx
+++ b/gensim/models/nmf_pgd.pyx
@@ -1,5 +1,6 @@
 # Author: Timofey Yefimov
 
+# cython: language_level=3
 # cython: cdivision=True
 # cython: boundscheck=False
 # cython: wraparound=False

--- a/gensim/models/word2vec_corpusfile.pxd
+++ b/gensim/models/word2vec_corpusfile.pxd
@@ -1,4 +1,5 @@
 # distutils: language = c++
+# cython: language_level=3
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True

--- a/gensim/models/word2vec_corpusfile.pyx
+++ b/gensim/models/word2vec_corpusfile.pyx
@@ -1,5 +1,6 @@
 #!/usr/bin/env cython
 # distutils: language = c++
+# cython: language_level=3
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True

--- a/gensim/models/word2vec_inner.pxd
+++ b/gensim/models/word2vec_inner.pxd
@@ -1,3 +1,4 @@
+# cython: language_level=3
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True

--- a/gensim/models/word2vec_inner.pyx
+++ b/gensim/models/word2vec_inner.pyx
@@ -1,4 +1,5 @@
 #!/usr/bin/env cython
+# cython: language_level=3
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True

--- a/gensim/models/word2vec_inner.pyx
+++ b/gensim/models/word2vec_inner.pyx
@@ -20,12 +20,7 @@ from libc.math cimport exp
 from libc.math cimport log
 from libc.string cimport memset
 
-# scipy <= 0.15
-try:
-    from scipy.linalg.blas import fblas
-except ImportError:
-    # in scipy > 0.15, fblas function has been removed
-    import scipy.linalg.blas as fblas
+import scipy.linalg.blas as fblas
 
 REAL = np.float32
 

--- a/setup.py
+++ b/setup.py
@@ -15,25 +15,26 @@ import os
 import platform
 import shutil
 import sys
+from collections import OrderedDict
 
 from setuptools import Extension, find_packages, setup, distutils
 from setuptools.command.build_ext import build_ext
 
-c_extensions = {
-    'gensim.models.word2vec_inner': 'gensim/models/word2vec_inner.c',
-    'gensim.corpora._mmreader': 'gensim/corpora/_mmreader.c',
-    'gensim.models.fasttext_inner': 'gensim/models/fasttext_inner.c',
-    'gensim._matutils': 'gensim/_matutils.c',
-    'gensim.models.nmf_pgd': 'gensim/models/nmf_pgd.c',
-    'gensim.similarities.fastss': 'gensim/similarities/fastss.c',
-}
+c_extensions = OrderedDict([
+    ('gensim.models.word2vec_inner', 'gensim/models/word2vec_inner.c'),
+    ('gensim.corpora._mmreader', 'gensim/corpora/_mmreader.c'),
+    ('gensim.models.fasttext_inner', 'gensim/models/fasttext_inner.c'),
+    ('gensim._matutils', 'gensim/_matutils.c'),
+    ('gensim.models.nmf_pgd', 'gensim/models/nmf_pgd.c'),
+    ('gensim.similarities.fastss', 'gensim/similarities/fastss.c'),
+])
 
-cpp_extensions = {
-    'gensim.models.doc2vec_inner': 'gensim/models/doc2vec_inner.cpp',
-    'gensim.models.word2vec_corpusfile': 'gensim/models/word2vec_corpusfile.cpp',
-    'gensim.models.fasttext_corpusfile': 'gensim/models/fasttext_corpusfile.cpp',
-    'gensim.models.doc2vec_corpusfile': 'gensim/models/doc2vec_corpusfile.cpp',
-}
+cpp_extensions = OrderedDict([
+    ('gensim.models.doc2vec_inner', 'gensim/models/doc2vec_inner.cpp'),
+    ('gensim.models.word2vec_corpusfile', 'gensim/models/word2vec_corpusfile.cpp'),
+    ('gensim.models.fasttext_corpusfile', 'gensim/models/fasttext_corpusfile.cpp'),
+    ('gensim.models.doc2vec_corpusfile', 'gensim/models/doc2vec_corpusfile.cpp'),
+])
 
 
 def need_cython():
@@ -111,8 +112,8 @@ class CustomBuildExt(build_ext):
 
         if need_cython():
             import Cython.Build
-            Cython.Build.cythonize(list(make_c_ext(use_cython=True)))
-            Cython.Build.cythonize(list(make_cpp_ext(use_cython=True)))
+            Cython.Build.cythonize(list(make_c_ext(use_cython=True)), language_level=3)
+            Cython.Build.cythonize(list(make_cpp_ext(use_cython=True)), language_level=3)
 
 
 class CleanExt(distutils.cmd.Command):


### PR DESCRIPTION
Python 2 is not supported by gensim, so
switching to language level 3 should be fine.

Silences a warning from Cython:

FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release!