### PR TITLE
Disable the Gensim 3=>4 warning in docs

### DIFF
--- a/docs/src/sphinx_rtd_theme/notification.html
+++ b/docs/src/sphinx_rtd_theme/notification.html
@@ -1,8 +1,3 @@
-<!-- <div class="notification">
-  You're viewing documentation for the latest Gensim 4. For old Gensim 3.8.3, please visit the old <a id="notification" 
-href="https://radimrehurek.com/gensim_3.8.3">Gensim 3.8.3 documentation</a> and <a href="https://github.com/RaRe-Technologies/gensim/wiki/Migrating-from-Gensim-3.x-to-4">Migration Guide</a>.
-  <script>
-    notification.href += location.pathname.replace(/^\/gensim/, "");
-  </script>
+<div class="notification">
+  Gensim relies on your donations for sustenance. If you like Gensim, please <a href="https://github.com/sponsors/piskvorky">consider donating</a>.
 </div>
--->

--- a/docs/src/sphinx_rtd_theme/notification.html
+++ b/docs/src/sphinx_rtd_theme/notification.html
@@ -1,6 +1,8 @@
-<div class="notification">
-  You're viewing documentation for Gensim 4.0.0. For Gensim 3.8.3, please visit the old <a id="notification" href="https://radimrehurek.com/gensim_3.8.3">Gensim 3.8.3 documentation</a> and <a href="https://github.com/RaRe-Technologies/gensim/wiki/Migrating-from-Gensim-3.x-to-4">Migration Guide</a>.
+<!-- <div class="notification">
+  You're viewing documentation for the latest Gensim 4. For old Gensim 3.8.3, please visit the old <a id="notification" 
+href="https://radimrehurek.com/gensim_3.8.3">Gensim 3.8.3 documentation</a> and <a href="https://github.com/RaRe-Technologies/gensim/wiki/Migrating-from-Gensim-3.x-to-4">Migration Guide</a>.
   <script>
     notification.href += location.pathname.replace(/^\/gensim/, "");
   </script>
 </div>
+-->


### PR DESCRIPTION
IMO no longer needed, Gensim 4 has been out for more than a year:

<img width="1725" alt="Screen Shot 2022-05-05 at 18 48 53" src="https://user-images.githubusercontent.com/610412/166972989-77053c61-ab01-434d-bbc3-8109e5acb6a6.png">
