### PR TITLE
Using efficient np.linalg.multi_dot 

### DIFF
--- a/gensim/test/svd_error.py
+++ b/gensim/test/svd_error.py
@@ -62,7 +62,7 @@ def rmse(diff):
 
 
 def print_error(name, aat, u, s, ideal_nf, ideal_n2):
-    err = -np.dot(u, np.dot(np.diag(s), u.T))
+    err = -np.linalg.multi_dot([u, np.diag(s), u.T])
     err += aat
     nf, n2 = np.linalg.norm(err), norm2(err)
     print(


### PR DESCRIPTION
It is more succinct and effective to refactor code to use `np.linalg.multi_dot` rather than numerous `np.dot` routines.
What do you think about this change that has practical value?