### PR TITLE
pin sphinx versions, add explicit gallery_top label

### DIFF
--- a/docs/src/auto_examples/index.rst
+++ b/docs/src/auto_examples/index.rst
@@ -1,23 +1,23 @@
 :orphan:
 
-
-
-.. _sphx_glr_auto_examples:
-
 Documentation
 =============
+
+.. _gallery_top:
 
 We welcome contributions to our documentation via GitHub pull requests, whether it's fixing a typo or authoring an entirely new tutorial or guide.
 If you're thinking about contributing documentation, please see :ref:`sphx_glr_auto_examples_howtos_run_doc.py`.
 
 
+
 .. raw:: html
 
-    <div class="sphx-glr-clear"></div>
+    <div class="sphx-glr-thumbnails">
 
 
+.. raw:: html
 
-.. _sphx_glr_auto_examples_core:
+    </div>
 
 Core Tutorials: New Users Start Here!
 -------------------------------------
@@ -29,24 +29,25 @@ Understanding this functionality is vital for using gensim effectively.
 
 .. raw:: html
 
+    <div class="sphx-glr-thumbnails">
+
+
+.. raw:: html
+
     <div class="sphx-glr-thumbcontainer" tooltip="This tutorial introduces Documents, Corpora, Vectors and Models: the basic concepts and terms n...">
 
 .. only:: html
 
- .. figure:: /auto_examples/core/images/thumb/sphx_glr_run_core_concepts_thumb.png
-     :alt: Core Concepts
+  .. image:: /auto_examples/core/images/thumb/sphx_glr_run_core_concepts_thumb.png
+    :alt: Core Concepts
 
-     :ref:`sphx_glr_auto_examples_core_run_core_concepts.py`
+  :ref:`sphx_glr_auto_examples_core_run_core_concepts.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">Core Concepts</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/core/run_core_concepts
 
 .. raw:: html
 
@@ -54,20 +55,16 @@ Understanding this functionality is vital for using gensim effectively.
 
 .. only:: html
 
- .. figure:: /auto_examples/core/images/thumb/sphx_glr_run_corpora_and_vector_spaces_thumb.png
-     :alt: Corpora and Vector Spaces
+  .. image:: /auto_examples/core/images/thumb/sphx_glr_run_corpora_and_vector_spaces_thumb.png
+    :alt: Corpora and Vector Spaces
 
-     :ref:`sphx_glr_auto_examples_core_run_corpora_and_vector_spaces.py`
+  :ref:`sphx_glr_auto_examples_core_run_corpora_and_vector_spaces.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">Corpora and Vector Spaces</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/core/run_corpora_and_vector_spaces
 
 .. raw:: html
 
@@ -75,20 +72,16 @@ Understanding this functionality is vital for using gensim effectively.
 
 .. only:: html
 
- .. figure:: /auto_examples/core/images/thumb/sphx_glr_run_topics_and_transformations_thumb.png
-     :alt: Topics and Transformations
+  .. image:: /auto_examples/core/images/thumb/sphx_glr_run_topics_and_transformations_thumb.png
+    :alt: Topics and Transformations
 
-     :ref:`sphx_glr_auto_examples_core_run_topics_and_transformations.py`
+  :ref:`sphx_glr_auto_examples_core_run_topics_and_transformations.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">Topics and Transformations</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/core/run_topics_and_transformations
 
 .. raw:: html
 
@@ -96,27 +89,20 @@ Understanding this functionality is vital for using gensim effectively.
 
 .. only:: html
 
- .. figure:: /auto_examples/core/images/thumb/sphx_glr_run_similarity_queries_thumb.png
-     :alt: Similarity Queries
+  .. image:: /auto_examples/core/images/thumb/sphx_glr_run_similarity_queries_thumb.png
+    :alt: Similarity Queries
 
-     :ref:`sphx_glr_auto_examples_core_run_similarity_queries.py`
+  :ref:`sphx_glr_auto_examples_core_run_similarity_queries.py`
+
+.. raw:: html
+
+      <div class="sphx-glr-thumbnail-title">Similarity Queries</div>
+    </div>
+
 
 .. raw:: html
 
     </div>
-
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/core/run_similarity_queries
-.. raw:: html
-
-    <div class="sphx-glr-clear"></div>
-
-
-
-.. _sphx_glr_auto_examples_tutorials:
 
 Tutorials: Learning Oriented Lessons
 ------------------------------------
@@ -127,24 +113,25 @@ Learning-oriented lessons that introduce a particular gensim feature, e.g. a mod
 
 .. raw:: html
 
+    <div class="sphx-glr-thumbnails">
+
+
+.. raw:: html
+
     <div class="sphx-glr-thumbcontainer" tooltip="Introduces Gensim&#x27;s Word2Vec model and demonstrates its use on the `Lee Evaluation Corpus &lt;http...">
 
 .. only:: html
 
- .. figure:: /auto_examples/tutorials/images/thumb/sphx_glr_run_word2vec_thumb.png
-     :alt: Word2Vec Model
+  .. image:: /auto_examples/tutorials/images/thumb/sphx_glr_run_word2vec_thumb.png
+    :alt: Word2Vec Model
 
-     :ref:`sphx_glr_auto_examples_tutorials_run_word2vec.py`
+  :ref:`sphx_glr_auto_examples_tutorials_run_word2vec.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">Word2Vec Model</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/tutorials/run_word2vec
 
 .. raw:: html
 
@@ -152,20 +139,16 @@ Learning-oriented lessons that introduce a particular gensim feature, e.g. a mod
 
 .. only:: html
 
- .. figure:: /auto_examples/tutorials/images/thumb/sphx_glr_run_doc2vec_lee_thumb.png
-     :alt: Doc2Vec Model
+  .. image:: /auto_examples/tutorials/images/thumb/sphx_glr_run_doc2vec_lee_thumb.png
+    :alt: Doc2Vec Model
 
-     :ref:`sphx_glr_auto_examples_tutorials_run_doc2vec_lee.py`
+  :ref:`sphx_glr_auto_examples_tutorials_run_doc2vec_lee.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">Doc2Vec Model</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/tutorials/run_doc2vec_lee
 
 .. raw:: html
 
@@ -173,20 +156,16 @@ Learning-oriented lessons that introduce a particular gensim feature, e.g. a mod
 
 .. only:: html
 
- .. figure:: /auto_examples/tutorials/images/thumb/sphx_glr_run_ensemblelda_thumb.png
-     :alt: Ensemble LDA
+  .. image:: /auto_examples/tutorials/images/thumb/sphx_glr_run_ensemblelda_thumb.png
+    :alt: Ensemble LDA
 
-     :ref:`sphx_glr_auto_examples_tutorials_run_ensemblelda.py`
+  :ref:`sphx_glr_auto_examples_tutorials_run_ensemblelda.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">Ensemble LDA</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/tutorials/run_ensemblelda
 
 .. raw:: html
 
@@ -194,20 +173,16 @@ Learning-oriented lessons that introduce a particular gensim feature, e.g. a mod
 
 .. only:: html
 
- .. figure:: /auto_examples/tutorials/images/thumb/sphx_glr_run_fasttext_thumb.png
-     :alt: FastText Model
+  .. image:: /auto_examples/tutorials/images/thumb/sphx_glr_run_fasttext_thumb.png
+    :alt: FastText Model
 
-     :ref:`sphx_glr_auto_examples_tutorials_run_fasttext.py`
+  :ref:`sphx_glr_auto_examples_tutorials_run_fasttext.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">FastText Model</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/tutorials/run_fasttext
 
 .. raw:: html
 
@@ -215,20 +190,16 @@ Learning-oriented lessons that introduce a particular gensim feature, e.g. a mod
 
 .. only:: html
 
- .. figure:: /auto_examples/tutorials/images/thumb/sphx_glr_run_annoy_thumb.png
-     :alt: Fast Similarity Queries with Annoy and Word2Vec
+  .. image:: /auto_examples/tutorials/images/thumb/sphx_glr_run_annoy_thumb.png
+    :alt: Fast Similarity Queries with Annoy and Word2Vec
 
-     :ref:`sphx_glr_auto_examples_tutorials_run_annoy.py`
+  :ref:`sphx_glr_auto_examples_tutorials_run_annoy.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">Fast Similarity Queries with Annoy and Word2Vec</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/tutorials/run_annoy
 
 .. raw:: html
 
@@ -236,20 +207,16 @@ Learning-oriented lessons that introduce a particular gensim feature, e.g. a mod
 
 .. only:: html
 
- .. figure:: /auto_examples/tutorials/images/thumb/sphx_glr_run_lda_thumb.png
-     :alt: LDA Model
+  .. image:: /auto_examples/tutorials/images/thumb/sphx_glr_run_lda_thumb.png
+    :alt: LDA Model
 
-     :ref:`sphx_glr_auto_examples_tutorials_run_lda.py`
+  :ref:`sphx_glr_auto_examples_tutorials_run_lda.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">LDA Model</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/tutorials/run_lda
 
 .. raw:: html
 
@@ -257,20 +224,16 @@ Learning-oriented lessons that introduce a particular gensim feature, e.g. a mod
 
 .. only:: html
 
- .. figure:: /auto_examples/tutorials/images/thumb/sphx_glr_run_wmd_thumb.png
-     :alt: Word Mover's Distance
+  .. image:: /auto_examples/tutorials/images/thumb/sphx_glr_run_wmd_thumb.png
+    :alt: Word Mover's Distance
 
-     :ref:`sphx_glr_auto_examples_tutorials_run_wmd.py`
+  :ref:`sphx_glr_auto_examples_tutorials_run_wmd.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">Word Mover's Distance</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/tutorials/run_wmd
 
 .. raw:: html
 
@@ -278,27 +241,20 @@ Learning-oriented lessons that introduce a particular gensim feature, e.g. a mod
 
 .. only:: html
 
- .. figure:: /auto_examples/tutorials/images/thumb/sphx_glr_run_scm_thumb.png
-     :alt: Soft Cosine Measure
+  .. image:: /auto_examples/tutorials/images/thumb/sphx_glr_run_scm_thumb.png
+    :alt: Soft Cosine Measure
 
-     :ref:`sphx_glr_auto_examples_tutorials_run_scm.py`
+  :ref:`sphx_glr_auto_examples_tutorials_run_scm.py`
+
+.. raw:: html
+
+      <div class="sphx-glr-thumbnail-title">Soft Cosine Measure</div>
+    </div>
+
 
 .. raw:: html
 
     </div>
-
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/tutorials/run_scm
-.. raw:: html
-
-    <div class="sphx-glr-clear"></div>
-
-
-
-.. _sphx_glr_auto_examples_howtos:
 
 How-to Guides: Solve a Problem
 ------------------------------
@@ -309,24 +265,25 @@ These **goal-oriented guides** demonstrate how to **solve a specific problem** u
 
 .. raw:: html
 
+    <div class="sphx-glr-thumbnails">
+
+
+.. raw:: html
+
     <div class="sphx-glr-thumbcontainer" tooltip="Demonstrates simple and quick access to common corpora and pretrained models.">
 
 .. only:: html
 
- .. figure:: /auto_examples/howtos/images/thumb/sphx_glr_run_downloader_api_thumb.png
-     :alt: How to download pre-trained models and corpora
+  .. image:: /auto_examples/howtos/images/thumb/sphx_glr_run_downloader_api_thumb.png
+    :alt: How to download pre-trained models and corpora
 
-     :ref:`sphx_glr_auto_examples_howtos_run_downloader_api.py`
+  :ref:`sphx_glr_auto_examples_howtos_run_downloader_api.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">How to download pre-trained models and corpora</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/howtos/run_downloader_api
 
 .. raw:: html
 
@@ -334,20 +291,16 @@ These **goal-oriented guides** demonstrate how to **solve a specific problem** u
 
 .. only:: html
 
- .. figure:: /auto_examples/howtos/images/thumb/sphx_glr_run_doc_thumb.png
-     :alt: How to Author Gensim Documentation
+  .. image:: /auto_examples/howtos/images/thumb/sphx_glr_run_doc_thumb.png
+    :alt: How to Author Gensim Documentation
 
-     :ref:`sphx_glr_auto_examples_howtos_run_doc.py`
+  :ref:`sphx_glr_auto_examples_howtos_run_doc.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">How to Author Gensim Documentation</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/howtos/run_doc
 
 .. raw:: html
 
@@ -355,20 +308,16 @@ These **goal-oriented guides** demonstrate how to **solve a specific problem** u
 
 .. only:: html
 
- .. figure:: /auto_examples/howtos/images/thumb/sphx_glr_run_doc2vec_imdb_thumb.png
-     :alt: How to reproduce the doc2vec 'Paragraph Vector' paper
+  .. image:: /auto_examples/howtos/images/thumb/sphx_glr_run_doc2vec_imdb_thumb.png
+    :alt: How to reproduce the doc2vec 'Paragraph Vector' paper
 
-     :ref:`sphx_glr_auto_examples_howtos_run_doc2vec_imdb.py`
+  :ref:`sphx_glr_auto_examples_howtos_run_doc2vec_imdb.py`
 
 .. raw:: html
 
+      <div class="sphx-glr-thumbnail-title">How to reproduce the doc2vec 'Paragraph Vector' paper</div>
     </div>
 
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/howtos/run_doc2vec_imdb
 
 .. raw:: html
 
@@ -376,27 +325,20 @@ These **goal-oriented guides** demonstrate how to **solve a specific problem** u
 
 .. only:: html
 
- .. figure:: /auto_examples/howtos/images/thumb/sphx_glr_run_compare_lda_thumb.png
-     :alt: How to Compare LDA Models
+  .. image:: /auto_examples/howtos/images/thumb/sphx_glr_run_compare_lda_thumb.png
+    :alt: How to Compare LDA Models
 
-     :ref:`sphx_glr_auto_examples_howtos_run_compare_lda.py`
+  :ref:`sphx_glr_auto_examples_howtos_run_compare_lda.py`
+
+.. raw:: html
+
+      <div class="sphx-glr-thumbnail-title">How to Compare LDA Models</div>
+    </div>
+
 
 .. raw:: html
 
     </div>
-
-
-.. toctree::
-   :hidden:
-
-   /auto_examples/howtos/run_compare_lda
-.. raw:: html
-
-    <div class="sphx-glr-clear"></div>
-
-
-
-.. _sphx_glr_auto_examples_other:
 
 Other Resources
 ---------------
@@ -433,27 +375,38 @@ Blog posts, tutorial videos, hackathons and other useful Gensim resources, from 
    - ? `Deep Inverse Regression with Yelp Reviews <https://github.com/RaRe-Technologies/gensim/blob/develop/docs/notebooks/deepir.ipynb>`__ (Document Classification using Bayesian Inversion and several word2vec models, one for each class)
 
 
+
 .. raw:: html
 
-    <div class="sphx-glr-clear"></div>
+    <div class="sphx-glr-thumbnails">
 
 
+.. raw:: html
 
-.. only :: html
-
- .. container:: sphx-glr-footer
-    :class: sphx-glr-footer-gallery
+    </div>
 
 
-  .. container:: sphx-glr-download sphx-glr-download-python
+.. toctree::
+   :hidden:
+   :includehidden:
 
-    :download:`Download all examples in Python source code: auto_examples_python.zip </auto_examples/auto_examples_python.zip>`
+   /auto_examples/core/index.rst
+   /auto_examples/tutorials/index.rst
+   /auto_examples/howtos/index.rst
+   /auto_examples/other/index.rst
 
 
+.. only:: html
 
-  .. container:: sphx-glr-download sphx-glr-download-jupyter
+  .. container:: sphx-glr-footer sphx-glr-footer-gallery
 
-    :download:`Download all examples in Jupyter notebooks: auto_examples_jupyter.zip </auto_examples/auto_examples_jupyter.zip>`
+    .. container:: sphx-glr-download sphx-glr-download-python
+
+      :download:`Download all examples in Python source code: auto_examples_python.zip </auto_examples/auto_examples_python.zip>`
+
+    .. container:: sphx-glr-download sphx-glr-download-jupyter
+
+      :download:`Download all examples in Jupyter notebooks: auto_examples_jupyter.zip </auto_examples/auto_examples_jupyter.zip>`
 
 
 .. only:: html

--- a/docs/src/gallery/README.txt
+++ b/docs/src/gallery/README.txt
@@ -1,5 +1,7 @@
 Documentation
 =============
 
+.. _gallery_top:
+
 We welcome contributions to our documentation via GitHub pull requests, whether it's fixing a typo or authoring an entirely new tutorial or guide.
 If you're thinking about contributing documentation, please see :ref:`sphx_glr_auto_examples_howtos_run_doc.py`.

--- a/docs/src/support.rst
+++ b/docs/src/support.rst
@@ -11,7 +11,7 @@ Open source support
 
 The main communication channel is the free `Gensim mailing list <https://groups.google.com/group/gensim>`_.
 
-This is the preferred way to ask for help, report problems and share insights with the community. Newbie questions are perfectly fine, as long as you've read the :ref:`tutorials <sphx_glr_auto_examples>` and `FAQ <https://github.com/RaRe-Technologies/gensim/wiki/Recipes-&-FAQ>`_.
+This is the preferred way to ask for help, report problems and share insights with the community. Newbie questions are perfectly fine, as long as you've read the :ref:`tutorials <gallery_top>` and `FAQ <https://github.com/RaRe-Technologies/gensim/wiki/Recipes-&-FAQ>`_.
 
 FAQ and some useful snippets of code are maintained on GitHub: https://github.com/RARE-Technologies/gensim/wiki/Recipes-&-FAQ.
 

--- a/gensim/models/doc2vec.py
+++ b/gensim/models/doc2vec.py
@@ -1137,7 +1137,8 @@ class TaggedBrownCorpus:
 
 class TaggedLineDocument:
     def __init__(self, source):
-        """Iterate over a file that contains documents: one line = :class:`~gensim.models.doc2vec.TaggedDocument` object.
+        """Iterate over a file that contains documents:
+        one line = :class:`~gensim.models.doc2vec.TaggedDocument` object.
 
         Words are expected to be already preprocessed and separated by whitespace. Document tags are constructed
         automatically from the document line number (each document gets a unique integer tag).

--- a/gensim/models/keyedvectors.py
+++ b/gensim/models/keyedvectors.py
@@ -517,7 +517,7 @@ class KeyedVectors(utils.SaveLoad):
             elif not ignore_missing:
                 raise KeyError(f"Key '{key}' not present in vocabulary")
 
-        if(total_weight > 0):
+        if total_weight > 0:
             mean = mean / total_weight
         if post_normalize:
             mean = matutils.unitvec(mean).astype(REAL)
@@ -1252,7 +1252,7 @@ class KeyedVectors(utils.SaveLoad):
             Similarities between `ws1` and `ws2`.
 
         """
-        if not(len(ws1) and len(ws2)):
+        if not (len(ws1) and len(ws2)):
             raise ZeroDivisionError('At least one of the passed list is empty.')
         mean1 = self.get_mean_vector(ws1, pre_normalize=False)
         mean2 = self.get_mean_vector(ws2, pre_normalize=False)

--- a/gensim/models/ldamodel.py
+++ b/gensim/models/ldamodel.py
@@ -314,7 +314,8 @@ class LdaState(utils.SaveLoad):
 
 
 class LdaModel(interfaces.TransformationABC, basemodel.BaseTopicModel):
-    """Train and use Online Latent Dirichlet Allocation model as presented in `'Online Learning for LDA' by Hoffman et al.`_
+    """Train and use Online Latent Dirichlet Allocation model as presented in
+    `'Online Learning for LDA' by Hoffman et al.`_
 
     Examples
     -------

--- a/gensim/models/ldaseqmodel.py
+++ b/gensim/models/ldaseqmodel.py
@@ -4,7 +4,8 @@
 # Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
 # Based on Copyright (C) 2016 Radim Rehurek <radimrehurek@seznam.cz>
 
-"""Lda Sequence model, inspired by `David M. Blei, John D. Lafferty: "Dynamic Topic Models"
+"""Lda Sequence model, inspired by
+`David M. Blei, John D. Lafferty: "Dynamic Topic Models"
 <https://mimno.infosci.cornell.edu/info6150/readings/dynamic_topic_models.pdf>`_.
 The original C/C++ implementation can be found on `blei-lab/dtm <https://github.com/blei-lab/dtm>`_.
 

--- a/gensim/models/ldaseqmodel.py
+++ b/gensim/models/ldaseqmodel.py
@@ -745,7 +745,8 @@ class sslm(utils.SaveLoad):
         return self.zeta
 
     def compute_post_variance(self, word, chain_variance):
-        r"""Get the variance, based on the `Variational Kalman Filtering approach for Approximate Inference (section 3.1)
+        r"""Get the variance, based on the
+        `Variational Kalman Filtering approach for Approximate Inference (section 3.1)
         <https://mimno.infosci.cornell.edu/info6150/readings/dynamic_topic_models.pdf>`_.
 
         This function accepts the word to compute variance for, along with the associated sslm class object,

--- a/gensim/test/test_ldamodel.py
+++ b/gensim/test/test_ldamodel.py
@@ -33,7 +33,7 @@ corpus = [dictionary.doc2bow(text) for text in common_texts]
 def test_random_state():
     testcases = [np.random.seed(0), None, np.random.RandomState(0), 0]
     for testcase in testcases:
-        assert(isinstance(utils.get_random_state(testcase), np.random.RandomState))
+        assert isinstance(utils.get_random_state(testcase), np.random.RandomState)
 
 
 class TestLdaModel(unittest.TestCase, basetmtests.TestBaseTopicModel):

--- a/setup.py
+++ b/setup.py
@@ -297,11 +297,17 @@ win_testenv = core_testenv[:]
 #   https://packaging.python.org/discussions/install-requires-vs-requirements/
 #
 
+#
+# We pin the Sphinx-related packages to specific versions here because we want
+# our documentation builds to be reproducible.  Different versions of Sphinx
+# can generate slightly different output, and because we keep some of the output
+# under version control, we want to keep these differences to a minimum.
+#
 docs_testenv = core_testenv + distributed_env + visdom_req + [
-    'sphinx',
-    'sphinx-gallery',
-    'sphinxcontrib.programoutput',
-    'sphinxcontrib-napoleon',
+    'sphinx==5.1.1',
+    'sphinx-gallery==0.11.1',
+    'sphinxcontrib.programoutput==0.17',
+    'sphinxcontrib-napoleon==0.7',
     'matplotlib',  # expected by sphinx-gallery
     'memory_profiler',
     'annoy',


### PR DESCRIPTION
Previously, Sphinx was adding a label to the top of the gallery automatically, but now it's gone, for some mysterious reason.

This PR also includes a bunch of flake8 fixes.  I'm not sure why these weren't picked up earlier.