### PR TITLE
Add tox environments to setup.cfg, fix napoleon import

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -27,7 +27,7 @@ html_theme = 'sphinx_rtd_theme'
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
     'sphinx.ext.imgmath',
     'sphinxcontrib.programoutput',
     'sphinx_gallery.gen_gallery',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[tox:tox]
+envlist = compile,docs
+
 [wheelhouse_uploader]
 artifact_indexes=
     #

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[tox:tox]
-envlist = compile,docs
-
 [wheelhouse_uploader]
 artifact_indexes=
     #


### PR DESCRIPTION
- `tox -e compile,docs` fails with `ERROR: tox config file (either pyproject.toml, tox.ini, setup.cfg) not found` otherwise on my machine. `tox -e ALL` can be used now
- fixed napoleon import `Could not import extension sphinxcontrib.napoleon (exception: cannot import name 'Callable' from 'collections' (/usr/lib/python3.10/collections/__init__.py))` https://github.com/sphinx-doc/sphinx/issues/10378#issuecomment-1107455569

Python 3.10.6, 5.15.65-1-MANJARO