### PR TITLE
Giving missing credit in EnsembleLDA to Alex in docs

### DIFF
--- a/gensim/models/ensemblelda.py
+++ b/gensim/models/ensemblelda.py
@@ -91,7 +91,7 @@ different hyperparameters:
 Citation
 --------
 BRIGL, Tobias, 2019, Extracting Reliable Topics using Ensemble Latent Dirichlet Allocation [Bachelor Thesis].
-Technische Hochschule Ingolstadt. Munich: Data Reply GmbH. Available from:
+Technische Hochschule Ingolstadt. Munich: Data Reply GmbH. Supervised by Alex Loosley. Available from:
 https://www.sezanzeb.de/machine_learning/ensemble_LDA/
 
 """


### PR DESCRIPTION
Given that Alex also invested his time into the EnsembleLDA during the PR (https://github.com/RaRe-Technologies/gensim/pull/2980) and thesis supervision, I feel like his name should pop up in the docs https://radimrehurek.com/gensim/models/ensemblelda.html?highlight=ensemblelda#citation