### PR TITLE
fixed loss computation for sg, hs

### DIFF
--- a/gensim/models/word2vec_inner.pyx
+++ b/gensim/models/word2vec_inner.pyx
@@ -126,7 +126,7 @@ cdef void w2v_fast_sentence_sg_hs(
 
         if _compute_loss == 1:
             sgn = (-1)**word_code[b]  # ch function: 0-> 1, 1 -> -1
-            lprob = -1*sgn*f_dot
+            lprob = sgn*f_dot
             if lprob <= -MAX_EXP or lprob >= MAX_EXP:
                 continue
             lprob = LOG_TABLE[<int>((lprob + MAX_EXP) * (EXP_TABLE_SIZE / MAX_EXP / 2))]


### PR DESCRIPTION
I found an issue with loss computation for Word2Vec when using Skip-Gram (`sg=1`) with Hierarchical Softmax (`hs=1`).
While training different models and trying to understand their loss I have encountered the same problem that was described in this [Why does the loss of Word2Vec model trained by gensim at first increase for a few epochs and then decrease?](https://stackoverflow.com/questions/73891182/why-does-the-loss-of-word2vec-model-trained-by-gensim-at-first-increase-for-a-fe) SO question. I guess that if I try to assign this PR to an open issue that will be #2617.
I decided not to elaborate too much here because the author of the SO question has given all the information needed in order to understand and reproduce the results and I guess that @gojomo is very aware to the different details already. In addition I am actually changing only 3 characters in the code and they will only affect very specific and limited component of the code, which is the loss calculation when using Word2Vec Skip-Gram (`sg=1`) with Hierarchical Softmax (`hs=1`) and setting `compute_loss=True`.
In short, the loss appears to behave in a weird and unpredictable way (essentially spiking up somewhere in the beginning of the training and not converging for different vector sizes as expected) but the word vectors are improving over time according to different score metrics I have tested. I've plotted the loss relative to epoch for different vector sizes in order to show what I mean.

![image](https://user-images.githubusercontent.com/65530510/199091527-db465e39-878a-44b3-b094-9e42d7b4a2ca.png)

After some investigation of the code I have found that in the loss calculation there was a redundant `-1` on line 127 on `word2vec_inner.pyx` file:
https://github.com/RaRe-Technologies/gensim/blob/a435f24fe25e17f473e71af3468660512c2606cb/gensim/models/word2vec_inner.pyx#L127-L133
This `-1` does not align with the computation of the loss that was mentioned in [word2vec Parameter Learning Explained
](https://arxiv.org/abs/1411.2738).
After getting rid of this `-1` I was able to get the expected results from the loss under the exact same conditions when running the previous experiments with the problematic results.
 
![image](https://user-images.githubusercontent.com/65530510/199094023-487b4c97-645a-469c-9fa0-3758248bb0f0.png)
