### PR TITLE
Path Coherence Model to correctly handle empty documents

### DIFF
--- a/gensim/test/test_coherencemodel.py
+++ b/gensim/test/test_coherencemodel.py
@@ -305,6 +305,12 @@ class TestCoherenceModel(unittest.TestCase):
         self.assertAlmostEqual(np.mean(coherence_topics2), coherence2, 4)
         self.assertAlmostEqual(coherence1, coherence2, places=4)
 
+    def testEmptyList(self):
+        """Test if CoherenceModel works with document without tokens"""
+        texts = self.texts + [[]]
+        cm = CoherenceModel(model=self.ldamodel, texts=texts, coherence="c_v", processes=1)
+        cm.get_coherence()
+
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)

--- a/gensim/topic_coherence/text_analysis.py
+++ b/gensim/topic_coherence/text_analysis.py
@@ -293,7 +293,8 @@ class WindowedTextsAnalyzer(UsesDictionary):
             relevant_texts, window_size, ignore_below_size=False, include_doc_num=True)
 
         for doc_num, virtual_document in windows:
-            self.analyze_text(virtual_document, doc_num)
+            if len(virtual_document) > 0:
+                self.analyze_text(virtual_document, doc_num)
             self.num_docs += 1
         return self
 


### PR DESCRIPTION
Fixes https://github.com/RaRe-Technologies/gensim/issues/3368
Before https://github.com/RaRe-Technologies/gensim/pull/3197 empty documents were skipped, after changes coherence fails if any document without tokens is in the list.

Fixing to also work when documents without tokens are in the list.

