### PR TITLE
fix: conversion of cosine distance to cosine similarity is incorrect

### DIFF
--- a/gensim/similarities/annoy.py
+++ b/gensim/similarities/annoy.py
@@ -185,4 +185,4 @@ class AnnoyIndexer():
         ids, distances = self.index.get_nns_by_vector(
             vector, num_neighbors, include_distances=True)
 
-        return [(self.labels[ids[i]], 1 - distances[i] / 2) for i in range(len(ids))]
+        return [(self.labels[ids[i]], 1 - distances[i] ** 2 / 2) for i in range(len(ids))]


### PR DESCRIPTION
Fixes #3440 