### PR TITLE
Sanity check for `hs` and `negative` in Word2Vec

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -286,11 +286,11 @@ class Word2Vec(utils.SaveLoad):
             Training algorithm: 1 for skip-gram; otherwise CBOW.
         hs : {0, 1}, optional
             If 1, hierarchical softmax will be used for model training.
-            If 0, and `negative` is non-zero, negative sampling will be used.
+            If 0, hierarchical softmax will not be used for model training.
         negative : int, optional
             If > 0, negative sampling will be used, the int for negative specifies how many "noise words"
             should be drawn (usually between 5-20).
-            If set to 0, no negative sampling is used.
+            If 0, negative sampling will not be used.
         ns_exponent : float, optional
             The exponent used to shape the negative sampling distribution. A value of 1.0 samples exactly in proportion
             to the frequencies, 0.0 samples all words equally, while a negative value samples low-frequency words more
@@ -1536,6 +1536,17 @@ class Word2Vec(utils.SaveLoad):
             If the combination of input parameters is inconsistent.
 
         """
+        if (not self.hs) and (not self.negative):
+            raise ValueError(
+                "You must set either 'hs' or 'negative' to be positive for proper training. "
+                "When both 'hs=0' and 'negative=0', there will be no training."
+            )
+        if self.hs and self.negative:
+            logger.warning(
+                "Both hierarchical softmax and negative sampling are activated. "
+                "This is probably a mistake. You should set either 'hs=0' "
+                "or 'negative=0' to disable one of them. "
+            )
         if self.alpha > self.min_alpha_yet_reached:
             logger.warning("Effective 'alpha' higher than previous training cycles")
 

--- a/gensim/test/test_word2vec.py
+++ b/gensim/test/test_word2vec.py
@@ -888,7 +888,7 @@ class TestWord2VecModel(unittest.TestCase):
         self.assertRaises(RuntimeError, binary_model_with_neg.predict_output_word, ['system', 'human'])
 
         # negative sampling scheme not used
-        model_without_neg = word2vec.Word2Vec(sentences, min_count=1, negative=0)
+        model_without_neg = word2vec.Word2Vec(sentences, min_count=1, hs=1, negative=0)
         self.assertRaises(RuntimeError, model_without_neg.predict_output_word, ['system', 'human'])
 
         # passing indices instead of words in context
@@ -1031,6 +1031,19 @@ class TestWord2VecModel(unittest.TestCase):
             if epoch == 5:
                 model.alpha += 0.05
         warning = "Effective 'alpha' higher than previous training cycles"
+        self.assertTrue(warning in str(loglines))
+
+    @log_capture()
+    def test_train_hs_and_neg(self, loglines):
+        """
+        Test if ValueError is raised when both hs=0 and negative=0
+        Test if warning is raised if both hs and negative are activated
+        """
+        with self.assertRaises(ValueError):
+            word2vec.Word2Vec(sentences, min_count=1, hs=0, negative=0)
+
+        word2vec.Word2Vec(sentences, min_count=1, hs=1, negative=5)
+        warning = "Both hierarchical softmax and negative sampling are activated."
         self.assertTrue(warning in str(loglines))
 
     def test_train_with_explicit_param(self):


### PR DESCRIPTION
Fixes #1983

Changes:

- Raise `ValueError` when both `hs=0` and `negative=0`
- Raise warning when `hs` and `negative` are nonzero
- Add test for the above
- Update description about `hs` and `negative` to avoid confusion

@gojomo Please let me know if you want any changes. Cheers!