### PR TITLE
remove unused dependency, handle ImportError

### DIFF
--- a/gensim/models/flsamodel.py
+++ b/gensim/models/flsamodel.py
@@ -5,15 +5,17 @@ Created on Thu Oct 27 11:04:27 2022
 @author: 20200016
 """
 
-import math
 from collections import Counter
-import warnings
-import pickle
 import itertools
+import math
+import pickle
+import sys
+import warnings
+
 import numpy as np
 from scipy.sparse.linalg import svds
 from scipy.sparse import dok_matrix
-from pyfume import Clustering
+
 import gensim.corpora as corpora
 from gensim.models.coherencemodel import CoherenceModel
 from gensim.models import Word2Vec
@@ -699,6 +701,19 @@ class FlsaModel():
         -------
             numpy.array : float
         """
+
+        try:
+            from pyfume import Clustering
+        except ImportError:
+            msg = (
+                "FlsaModel requires pyfume; install manually via "
+                "`pip install pyfume` or otherwise"
+            )
+            print('-' * len(msg), file=sys.stderr)
+            print(msg, file=sys.stderr)
+            print('-' * len(msg), file=sys.stderr)
+            raise
+
         clusterer = Clustering.Clusterer(
             nr_clus=number_of_clusters,
             data=data,

--- a/setup.py
+++ b/setup.py
@@ -344,7 +344,6 @@ install_requires = [
     NUMPY_STR,
     'scipy >= 1.7.0',
     'smart_open >= 1.8.1',
-    'FuzzyTM >= 0.4.0'
 ]
 
 setup_requires = [NUMPY_STR]


### PR DESCRIPTION
1. Get rid of FuzzyTM import (it's completely unnecessary)
2. Delay import of pyfume until it's actually used, and then provide instructions for installing it

I also got rid of the flsamodel extra from setup.py, because it's not necessary to introduce another level of indirection here.

Bandaid hot-fix PR until #3437 is properly resolved.