### PR TITLE
Ignore Cython generated C code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,5 +88,6 @@ gensim/models/fasttext_inner.c
 gensim/models/nmf_pgd.c
 gensim/models/word2vec_corpusfile.cpp
 gensim/models/word2vec_inner.c
+gensim/similarities/fastss.c
 
 .ipynb_checkpoints


### PR DESCRIPTION
The fastss code was forgotten when it was Cythonized and when updating the gitignores.
