### PR TITLE
Window alignment options are added for Word2Vec Skip-gram

### DIFF
--- a/gensim/models/word2vec.py
+++ b/gensim/models/word2vec.py
@@ -244,7 +244,7 @@ class Word2Vec(utils.SaveLoad):
             max_vocab_size=None, sample=1e-3, seed=1, workers=3, min_alpha=0.0001,
             sg=0, hs=0, negative=5, ns_exponent=0.75, cbow_mean=1, hashfxn=hash, epochs=5, null_word=0,
             trim_rule=None, sorted_vocab=1, batch_words=MAX_WORDS_IN_BATCH, compute_loss=False, callbacks=(),
-            comment=None, max_final_vocab=None, shrink_windows=True,
+            comment=None, max_final_vocab=None, shrink_windows=True, window_alignment=0,
         ):
         """Train, use and evaluate neural networks described in https://code.google.com/p/word2vec/.
 
@@ -355,6 +355,12 @@ class Word2Vec(utils.SaveLoad):
             for each target word during training, to match the original word2vec algorithm's
             approximate weighting of context words by distance. Otherwise, the effective
             window size is always fixed to `window` words to either side.
+        window_alignment: int, optional
+            When window parameter is set to -1, only the left context of the current word is used for training.
+            For instance, if the `window` is set to 10, only the first 10 words on the left of the current
+            word will be used. On the other hand, when `window` is set to 1, only the right context of the current
+            word will be used. If window is set to 0, both the left and right context of the current word is used,
+            that is, if `window` is set to 5, 5 words are used from both the left and right contexts, totaling 10 words.
 
         Examples
         --------
@@ -388,6 +394,7 @@ class Word2Vec(utils.SaveLoad):
 
         self.window = int(window)
         self.shrink_windows = bool(shrink_windows)
+        self.window_alignment = int(window_alignment)
         self.random = np.random.RandomState(seed)
 
         self.hs = int(hs)
@@ -952,7 +959,7 @@ class Word2Vec(utils.SaveLoad):
         work, neu1 = inits
         tally = 0
         if self.sg:
-            tally += train_batch_sg(self, sentences, alpha, work, self.compute_loss)
+            tally += train_batch_sg(self, sentences, alpha, work, self.compute_loss, self.window_alignment)
         else:
             tally += train_batch_cbow(self, sentences, alpha, work, neu1, self.compute_loss)
         return tally, self._raw_word_count(sentences)

--- a/gensim/models/word2vec_inner.pxd
+++ b/gensim/models/word2vec_inner.pxd
@@ -50,7 +50,7 @@ cdef our_saxpy_ptr our_saxpy
 
 
 cdef struct Word2VecConfig:
-    int hs, negative, sample, compute_loss, size, window, cbow_mean, workers
+    int hs, negative, sample, compute_loss, size, window, cbow_mean, workers, window_alignment
     REAL_t running_training_loss, alpha
 
     REAL_t *syn0


### PR DESCRIPTION
In the original Skip-gram model, the context window includes both the left and right sides of the target word. However, for research purposes, academicians may need to use word embedding models that only consider words placed on one side of the target word in order to improve accuracy without enlarging the window size. For instance, in the paper "[Intrinsic and Extrinsic Evaluation of Word Embedding Models](https://www.cmpe.boun.edu.tr/~gungort/papers/Intrinsic%20and%20Extrinsic%20Evaluation%20of%20Word%20Embedding%20Models.pdf)" the researchers compared centered (default), left-aligned, and right-aligned window configurations for Turkish language. Need for this feature was also discussed in a StackOverflow post: https://stackoverflow.com/q/63101674/16530078

In this pull request, I attempted to introduce a new parameter to the Word2Vec class, making it easy to use left-right window alignments. 
To exemplify, it works like this: If `window_alignment` is set to 0, it takes `window` many words from both left and right (totaling to 2 * `window` many words). If `window_alignment` is -1 or 1, it takes `window` many words from either only left or right respectively. Of course, if `shrink_windows = True`, it may still effect the number of words being used in the training. 