### PR TITLE
Fix inconsistent documentation for LdaSeqModel #3474

### DIFF
--- a/gensim/models/ldaseqmodel.py
+++ b/gensim/models/ldaseqmodel.py
@@ -22,7 +22,7 @@ TODO: The next steps to take this forward would be:
 Examples
 --------
 
-Set up a model using have 30 documents, with 5 in the first time-slice, 10 in the second, and 15 in the third
+Set up a model using 9 documents, with 2 in the first time-slice, 4 in the second, and 3 in the third
 
 .. sourcecode:: pycon
 


### PR DESCRIPTION
As mentioned in #3474, there is an inconsistency in a code example and the description text above it. Currently on the documentation it reads:

![image](https://github.com/RaRe-Technologies/gensim/assets/54182533/c3403118-e30c-44d7-9951-b55b02ba6900)

with this pull request, this will be changed to:

![image](https://github.com/RaRe-Technologies/gensim/assets/54182533/18371ab2-f915-4ffb-a187-c3b8882ad2b9)


fixes #3474