### PR TITLE
Cancel in-progress GitHub Workflow jobs when there are updates

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,6 +8,11 @@
 #
 name: Rebuild documentation
 on: workflow_dispatch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     name: Rebuild documentation

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 0 * * sun,wed'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   linters:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -3,6 +3,10 @@ name: Linters
 on:
   workflow_call:
   
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   linters:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [ develop ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   linters:


### PR DESCRIPTION
Some jobs can take a while and leaving old jobs running is wasteful.

This is especially important for the documentation building jobs,
which can take a long time to complete.
