### PR TITLE
gensim/test/test_coherencemodel.py: Make testProcesses match implementation

### DIFF
--- a/gensim/test/test_coherencemodel.py
+++ b/gensim/test/test_coherencemodel.py
@@ -148,7 +148,7 @@ class TestCoherenceModel(unittest.TestCase):
             topics=self.topics1, corpus=self.corpus, dictionary=self.dictionary, coherence='u_mass'
         )
 
-        model, used_cpus = get_model(), mp.cpu_count() - 1
+        model, used_cpus = get_model(),  max(1, mp.cpu_count() - 1)
         self.assertEqual(model.processes, used_cpus)
         for p in range(-2, 1):
             self.assertEqual(get_model(processes=p).processes, used_cpus)


### PR DESCRIPTION
Fixes this error when building on a single-CPU system:
```

=================================== FAILURES =================================== _______________________ TestCoherenceModel.testProcesses _______________________

self = <gensim.test.test_coherencemodel.TestCoherenceModel testMethod=testProcesses>

    def testProcesses(self):
        get_model = partial(CoherenceModel,
            topics=self.topics1, corpus=self.corpus, dictionary=self.dictionary, coherence='u_mass'
        )

        model, used_cpus = get_model(), mp.cpu_count() - 1
>       self.assertEqual(model.processes, used_cpus)
E       AssertionError: 1 != 0

gensim/test/test_coherencemodel.py:152: AssertionError ------------------------------ Captured log call ------------------------------- WARNING  gensim.models.ldamodel:ldamodel.py:959 too few updates, training might not converge; consid er increasing the number of passes or iterations to improve accuracy
```