### PR TITLE
GitHub Actions: Add Python3.14 and 3.14t to the testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,17 +26,17 @@ jobs:
     needs: [linters]
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - name: Setup Python ${{ matrix.python }}
+        uses: actions/setup-python@v6
         with:
           #
-          # We use Py3.8 here for historical reasons.
+          # We use Py3.9 here for historical reasons.
           #
           python-version: "3.9"
 
       - name: Update pip
-        run: python -m pip install -U pip setuptools
+        run: python -m pip install --upgrade pip setuptools
 
       - name: Install apt packages for LaTeX rendering
         run: |
@@ -45,7 +45,7 @@ jobs:
           sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install dvipng texlive-latex-base texlive-latex-extra texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended latexmk
           sudo apt-get -yq install build-essential
       - name: Install gensim and its dependencies
-        run: pip install -e .[docs]
+        run: pip install --editable .[docs]
 
       - name: Build documentation
         run: |
@@ -68,12 +68,16 @@ jobs:
           - {python: '3.11', os: ubuntu-24.04}
           - {python: '3.12', os: ubuntu-24.04}
           - {python: '3.13', os: ubuntu-24.04}
+          - {python: '3.14', os: ubuntu-24.04}
+          - {python: '3.14t', os: ubuntu-24.04}
 
           - {python: '3.9', os: windows-2025}
           - {python: '3.10', os: windows-2025}
           - {python: '3.11', os: windows-2025}
           - {python: '3.12', os: windows-2025}
           - {python: '3.13', os: windows-2025}
+          - {python: '3.14', os: windows-2025}
+          - {python: '3.14t', os: windows-2025}
 
     #
     # Don't run this job unless the linters have succeeded.
@@ -83,13 +87,13 @@ jobs:
     needs: [linters]
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - name: Setup Python ${{ matrix.python }}
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - name: Update pip
-        run: python -m pip install -U pip
+        run: python -m pip install --upgrade pip
 
       #
       # Work-around mysterious build problem
@@ -113,11 +117,11 @@ jobs:
 
       - name: Install gensim and its dependencies
         if: matrix.os != 'windows'
-        run: pip install -e .[test]
+        run: pip install --editable .[test]
 
       - name: Install gensim and its dependencies (Windows)
         if: matrix.os == 'windows'
-        run: pip install -e .[test-win]
+        run: pip install --editable .[test-win]
 
       - run: pip freeze
 


### PR DESCRIPTION
% `uvx --with=gensim python3.14 -c 'import gensim' ` # Fails.

* #3627
* #3628 

https://www.python.org/downloads/release/python-3140/

Pickle issues only on Linux, as discussed at:
* https://docs.python.org/3.14/whatsnew/3.14.html#porting-to-python-3-14
* https://docs.python.org/3.14/whatsnew/3.14.html#multiprocessing